### PR TITLE
feat(telemetry): convert to opt-in consent model

### DIFF
--- a/cli/cmd/syllago/main.go
+++ b/cli/cmd/syllago/main.go
@@ -26,6 +26,7 @@ import (
 	zone "github.com/lrstanley/bubblezone"
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // Set at build time via -ldflags.
@@ -84,9 +85,27 @@ func init() {
 		verbose, _ := cmd.Flags().GetBool("verbose")
 		output.Verbose = verbose
 
-		// Initialize telemetry after output flags are set so the first-run
-		// notice (if any) respects --no-color via lipgloss profile above.
 		telemetry.Init()
+
+		// Telemetry is opt-in. If the user has not yet recorded a consent
+		// decision, show the disclosure and prompt before any work runs.
+		// Skip prompting in contexts where it would be inappropriate:
+		//   - the TUI takes responsibility for its own consent modal
+		//     (running `syllago` with no args lands here, then NewApp
+		//     handles consent).
+		//   - telemetry subcommands (`telemetry on/off/status/reset`) are
+		//     themselves the consent surface; prompting on top of them
+		//     would be circular and confusing.
+		//   - --json or --quiet imply non-interactive scripting.
+		//   - non-TTY stdin/stderr cannot prompt usefully; leave disabled.
+		if telemetry.NeedsConsent() && shouldPromptConsent(cmd, quiet) {
+			enabled, err := telemetry.PromptCLIConsent(os.Stderr, os.Stdin)
+			if err == nil {
+				if rcErr := telemetry.RecordConsent(enabled); rcErr == nil && enabled {
+					telemetry.Init() // pick up the new consent state
+				}
+			}
+		}
 
 		return nil
 	}
@@ -206,6 +225,53 @@ func main() {
 		printExecuteError(err)
 		os.Exit(output.ExitError)
 	}
+}
+
+// isInteractiveStdinStderrFn reports whether both stdin and stderr are
+// connected to a terminal. Indirected through a function variable so tests
+// can simulate a real TTY without spawning a pty.
+var isInteractiveStdinStderrFn = func() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+// shouldPromptConsent reports whether the current invocation is an
+// appropriate place to ask the user for telemetry consent. The CLI must
+// never silently background a prompt or interrupt scripted output, so we
+// suppress prompting in any context that doesn't have a real human at the
+// terminal.
+//
+// The TUI is excluded here because it shows its own integrated modal — see
+// cli/internal/tui/telemetry_consent.go. The telemetry subcommands are
+// excluded because they are themselves the consent surface.
+func shouldPromptConsent(cmd *cobra.Command, quiet bool) bool {
+	if cmd == nil {
+		return false
+	}
+	// Root command with no args runs the TUI, which has its own consent modal.
+	if cmd == rootCmd {
+		return false
+	}
+	// Skip any telemetry subcommand (on/off/status/reset).
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Name() == "telemetry" {
+			return false
+		}
+	}
+	// Skip purely-informational commands.
+	switch cmd.Name() {
+	case "version", "help":
+		return false
+	}
+	// Scripted output paths.
+	if output.JSON || quiet {
+		return false
+	}
+	// Need an interactive terminal on both ends — the user has to read the
+	// disclosure on stderr and type a y/N answer on stdin.
+	if !isInteractiveStdinStderrFn() {
+		return false
+	}
+	return true
 }
 
 // printExecuteError prints err to the error writer unless it's a SilentError

--- a/cli/cmd/syllago/should_prompt_consent_test.go
+++ b/cli/cmd/syllago/should_prompt_consent_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+)
+
+// TestShouldPromptConsent_Branches covers every branch of shouldPromptConsent
+// against a synthetic command tree. The function gates a user-visible prompt,
+// so a regression in any branch either spams the prompt during scripting or
+// silently skips it for real users — both bad outcomes that won't surface in
+// any other test.
+//
+// The TTY check is indirected through isInteractiveStdinStderrFn so we can
+// drive both arms of that branch without spawning a pty.
+func TestShouldPromptConsent_Branches(t *testing.T) {
+	// Build a command tree mirroring the real one in shape but isolated
+	// from the global rootCmd: root → install (leaf), root → telemetry →
+	// {on, off, status, reset}, root → version, root → help.
+	root := &cobra.Command{Use: "syllago-test"}
+	install := &cobra.Command{Use: "install"}
+	versionLeaf := &cobra.Command{Use: "version"}
+	helpLeaf := &cobra.Command{Use: "help"}
+	tel := &cobra.Command{Use: "telemetry"}
+	telOn := &cobra.Command{Use: "on"}
+	telStatus := &cobra.Command{Use: "status"}
+	tel.AddCommand(telOn, telStatus)
+	root.AddCommand(install, versionLeaf, helpLeaf, tel)
+
+	// Override the TTY check for the duration of this test. Default to
+	// "interactive" so each subtest can opt out by setting it to false.
+	origTTY := isInteractiveStdinStderrFn
+	t.Cleanup(func() { isInteractiveStdinStderrFn = origTTY })
+
+	// output.JSON is a package global; restore after each subtest.
+	origJSON := output.JSON
+	t.Cleanup(func() { output.JSON = origJSON })
+
+	tests := []struct {
+		name        string
+		cmd         *cobra.Command
+		quiet       bool
+		jsonOutput  bool
+		interactive bool
+		// special: when set, treat cmd as the live rootCmd. This is the
+		// only branch that needs the real package-level rootCmd identity.
+		useRealRoot bool
+		want        bool
+	}{
+		{
+			name: "nil_command_returns_false",
+			cmd:  nil,
+			want: false,
+		},
+		{
+			name:        "real_root_command_skips_prompt_TUI_handles_it",
+			useRealRoot: true,
+			interactive: true,
+			want:        false,
+		},
+		{
+			name:        "telemetry_parent_skips_prompt",
+			cmd:         tel,
+			interactive: true,
+			want:        false,
+		},
+		{
+			name:        "telemetry_on_subcommand_skips_prompt",
+			cmd:         telOn,
+			interactive: true,
+			want:        false,
+		},
+		{
+			name:        "telemetry_status_subcommand_skips_prompt",
+			cmd:         telStatus,
+			interactive: true,
+			want:        false,
+		},
+		{
+			name:        "version_skips_prompt",
+			cmd:         versionLeaf,
+			interactive: true,
+			want:        false,
+		},
+		{
+			name:        "help_skips_prompt",
+			cmd:         helpLeaf,
+			interactive: true,
+			want:        false,
+		},
+		{
+			name:        "json_output_skips_prompt",
+			cmd:         install,
+			jsonOutput:  true,
+			interactive: true,
+			want:        false,
+		},
+		{
+			name:        "quiet_flag_skips_prompt",
+			cmd:         install,
+			quiet:       true,
+			interactive: true,
+			want:        false,
+		},
+		{
+			name:        "non_interactive_skips_prompt",
+			cmd:         install,
+			interactive: false,
+			want:        false,
+		},
+		{
+			name: "interactive_normal_command_prompts",
+			// All gates clear: regular leaf command, not in scripted
+			// mode, with a TTY on both ends. This is the one branch that
+			// returns true.
+			cmd:         install,
+			interactive: true,
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interactive := tt.interactive
+			isInteractiveStdinStderrFn = func() bool { return interactive }
+			output.JSON = tt.jsonOutput
+
+			cmd := tt.cmd
+			if tt.useRealRoot {
+				cmd = rootCmd
+			}
+
+			got := shouldPromptConsent(cmd, tt.quiet)
+			if got != tt.want {
+				t.Errorf("shouldPromptConsent(%v, quiet=%v, json=%v, interactive=%v) = %v, want %v",
+					cmdName(cmd), tt.quiet, tt.jsonOutput, interactive, got, tt.want)
+			}
+		})
+	}
+}
+
+func cmdName(c *cobra.Command) string {
+	if c == nil {
+		return "<nil>"
+	}
+	return c.CommandPath()
+}

--- a/cli/cmd/syllago/telemetry_cmd.go
+++ b/cli/cmd/syllago/telemetry_cmd.go
@@ -32,39 +32,57 @@ func runTelemetryStatus(cmd *cobra.Command, args []string) error {
 
 	if output.JSON {
 		type statusOut struct {
-			Enabled     bool   `json:"enabled"`
-			AnonymousID string `json:"anonymousId"`
-			Endpoint    string `json:"endpoint,omitempty"`
+			Enabled         bool   `json:"enabled"`
+			ConsentRecorded bool   `json:"consentRecorded"`
+			AnonymousID     string `json:"anonymousId"`
+			Endpoint        string `json:"endpoint,omitempty"`
 		}
 		endpoint := cfg.Endpoint
 		if endpoint == "" {
 			endpoint = "https://us.i.posthog.com/capture/"
 		}
 		data, _ := json.MarshalIndent(statusOut{
-			Enabled:     cfg.Enabled,
-			AnonymousID: cfg.AnonymousID,
-			Endpoint:    endpoint,
+			Enabled:         cfg.Enabled,
+			ConsentRecorded: cfg.ConsentRecorded,
+			AnonymousID:     cfg.AnonymousID,
+			Endpoint:        endpoint,
 		}, "", "  ")
 		fmt.Fprintln(output.Writer, string(data))
 		return nil
 	}
 
-	state := "disabled"
-	if cfg.Enabled {
-		state = "enabled"
+	state := "disabled (opt-in)"
+	switch {
+	case cfg.Enabled && cfg.ConsentRecorded:
+		state = "enabled (you opted in)"
+	case !cfg.Enabled && cfg.ConsentRecorded:
+		state = "disabled (you opted out)"
+	case !cfg.ConsentRecorded:
+		state = "disabled (awaiting your decision)"
 	}
 	fmt.Fprintf(output.Writer, "Telemetry: %s\n", state)
-	fmt.Fprintf(output.Writer, "Anonymous ID: %s\n\n", cfg.AnonymousID)
-	fmt.Fprintf(output.Writer, "Events tracked:\n")
-	fmt.Fprintf(output.Writer, "  command_executed    Command name, provider, content type, count,\n")
-	fmt.Fprintf(output.Writer, "                      success, dry-run, version, OS, architecture\n")
-	fmt.Fprintf(output.Writer, "  tui_session_started TUI session completed (no interaction details)\n\n")
-	fmt.Fprintf(output.Writer, "Never tracked:\n")
-	fmt.Fprintf(output.Writer, "  File contents, paths, usernames, hostnames, registry URLs,\n")
-	fmt.Fprintf(output.Writer, "  hook commands, MCP configs, or any content you manage.\n\n")
+	id := cfg.AnonymousID
+	if id == "" {
+		id = "(not yet generated)"
+	}
+	fmt.Fprintf(output.Writer, "Anonymous ID: %s\n\n", id)
+	fmt.Fprintf(output.Writer, "Telemetry is opt-in. Nothing is sent unless you have explicitly\n")
+	fmt.Fprintf(output.Writer, "agreed via the consent prompt or `syllago telemetry on`.\n\n")
+	fmt.Fprintf(output.Writer, "What we collect (only with your consent):\n")
+	for _, item := range telemetry.CollectedItems() {
+		fmt.Fprintf(output.Writer, "  - %s\n", item)
+	}
+	fmt.Fprintln(output.Writer)
+	fmt.Fprintf(output.Writer, "What we never collect:\n")
+	for _, item := range telemetry.NeverItems() {
+		fmt.Fprintf(output.Writer, "  - %s\n", item)
+	}
+	fmt.Fprintln(output.Writer)
+	fmt.Fprintf(output.Writer, "Enable:   syllago telemetry on\n")
 	fmt.Fprintf(output.Writer, "Disable:  syllago telemetry off\n")
 	fmt.Fprintf(output.Writer, "Reset ID: syllago telemetry reset\n")
-	fmt.Fprintf(output.Writer, "Docs:     https://syllago.dev/telemetry\n")
+	fmt.Fprintf(output.Writer, "Docs:     %s\n", telemetry.DocsURL)
+	fmt.Fprintf(output.Writer, "Code:     %s\n", telemetry.CodeURL)
 	return nil
 }
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/tidwall/sjson v1.2.5
 	github.com/yuin/goldmark v1.8.2
 	golang.org/x/net v0.53.0
+	golang.org/x/term v0.42.0
 	golang.org/x/text v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -118,7 +119,6 @@ require (
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/term v0.42.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260316180232-0b37fe3546d5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260316180232-0b37fe3546d5 // indirect
 	google.golang.org/grpc v1.79.3 // indirect

--- a/cli/internal/telemetry/config.go
+++ b/cli/internal/telemetry/config.go
@@ -19,12 +19,23 @@ const (
 )
 
 // Config is the user-level telemetry config stored at ~/.syllago/telemetry.json.
+//
+// Telemetry is opt-in. Events fire only when both Enabled=true AND
+// ConsentRecorded=true. ConsentRecorded is only ever set as the result of an
+// explicit user action (the consent modal, or `syllago telemetry on/off`).
 type Config struct {
-	Enabled     bool      `json:"enabled"`
-	AnonymousID string    `json:"anonymousId"`
-	NoticeSeen  bool      `json:"noticeSeen"`
-	Endpoint    string    `json:"endpoint,omitempty"`
-	CreatedAt   time.Time `json:"createdAt"`
+	Enabled     bool   `json:"enabled"`
+	AnonymousID string `json:"anonymousId"`
+	// ConsentRecorded is true once the user has made an explicit choice
+	// (yes or no). When false, no events fire and the consent modal will
+	// appear on the next interactive launch.
+	ConsentRecorded bool `json:"consentRecorded"`
+	// NoticeSeen is the legacy flag from the opt-out era. Retained for
+	// migration compatibility — see migrateConfig in telemetry.go. Not used
+	// for new gating logic.
+	NoticeSeen bool      `json:"noticeSeen,omitempty"`
+	Endpoint   string    `json:"endpoint,omitempty"`
+	CreatedAt  time.Time `json:"createdAt"`
 }
 
 // SysConfig is the system-level config at /etc/syllago/telemetry.json.
@@ -134,16 +145,19 @@ func checkWritable(dir string) error {
 	return nil
 }
 
-// newConfig creates a default config with a fresh pseudonymous ID and the current time.
+// newConfig creates a default config with a fresh pseudonymous ID and the
+// current time. Defaults to Enabled=false and ConsentRecorded=false: nothing
+// is sent until the user explicitly opts in via the consent modal or
+// `syllago telemetry on`.
 func newConfig() (*Config, error) {
 	id, err := generateID()
 	if err != nil {
 		return nil, err
 	}
 	return &Config{
-		Enabled:     true,
-		AnonymousID: id,
-		NoticeSeen:  false,
-		CreatedAt:   time.Now().UTC(),
+		Enabled:         false,
+		AnonymousID:     id,
+		ConsentRecorded: false,
+		CreatedAt:       time.Now().UTC(),
 	}, nil
 }

--- a/cli/internal/telemetry/config_test.go
+++ b/cli/internal/telemetry/config_test.go
@@ -23,7 +23,7 @@ func TestLoadUserConfig_Valid(t *testing.T) {
 	overrideHome(t, home)
 	dir := filepath.Join(home, ".syllago")
 	os.MkdirAll(dir, 0755)
-	body := `{"enabled":true,"anonymousId":"syl_aabbccdd1122","noticeSeen":true,"createdAt":"2026-04-02T00:00:00Z"}`
+	body := `{"enabled":true,"anonymousId":"syl_aabbccdd1122","consentRecorded":true,"createdAt":"2026-04-02T00:00:00Z"}`
 	os.WriteFile(filepath.Join(dir, "telemetry.json"), []byte(body), 0644)
 
 	cfg, err := loadUserConfig()
@@ -36,8 +36,8 @@ func TestLoadUserConfig_Valid(t *testing.T) {
 	if cfg.AnonymousID != "syl_aabbccdd1122" {
 		t.Errorf("unexpected ID: %s", cfg.AnonymousID)
 	}
-	if !cfg.NoticeSeen {
-		t.Error("expected noticeSeen true")
+	if !cfg.ConsentRecorded {
+		t.Error("expected consentRecorded true")
 	}
 }
 
@@ -59,10 +59,10 @@ func TestSaveUserConfig_Roundtrip(t *testing.T) {
 	overrideHome(t, home)
 
 	want := &Config{
-		Enabled:     true,
-		AnonymousID: "syl_aabbccdd1122",
-		NoticeSeen:  false,
-		CreatedAt:   time.Now().UTC().Truncate(time.Second),
+		Enabled:         true,
+		AnonymousID:     "syl_aabbccdd1122",
+		ConsentRecorded: true,
+		CreatedAt:       time.Now().UTC().Truncate(time.Second),
 	}
 	if err := saveUserConfig(want); err != nil {
 		t.Fatalf("save failed: %v", err)
@@ -95,11 +95,12 @@ func TestNewConfig_DefaultsAndID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !cfg.Enabled {
-		t.Error("expected enabled true by default")
+	// Opt-in default: nothing fires until the user explicitly opts in.
+	if cfg.Enabled {
+		t.Error("expected enabled false by default (telemetry is opt-in)")
 	}
-	if cfg.NoticeSeen {
-		t.Error("expected noticeSeen false by default")
+	if cfg.ConsentRecorded {
+		t.Error("expected consentRecorded false by default")
 	}
 	if len(cfg.AnonymousID) == 0 {
 		t.Error("expected non-empty anonymous ID")

--- a/cli/internal/telemetry/disclosure.go
+++ b/cli/internal/telemetry/disclosure.go
@@ -1,0 +1,45 @@
+package telemetry
+
+// Disclosure URLs surfaced in the consent UI. Centralized here so the CLI
+// prompt and TUI modal cannot drift apart.
+const (
+	DocsURL = "https://syllago.dev/telemetry"
+	CodeURL = "https://github.com/OpenScribbler/syllago/tree/main/cli/internal/telemetry"
+)
+
+// MaintainerAppeal is the human paragraph the consent UI leads with. It is
+// the only place in the codebase where syllago asks for something from the
+// user — keep it honest and brief.
+const MaintainerAppeal = "syllago is built and maintained by one person, in their free time. " +
+	"Anonymous usage data is the only signal I have for what to fix and what " +
+	"to build next. If you opt in, I am so grateful. It directly shapes " +
+	"the project."
+
+// CollectedItems returns the list of things telemetry sends, when enabled.
+// One bullet per item, plain text — both renderers wrap them in their own
+// styling. Order matches the disclosure flow: command context first, then
+// system metadata, then the rotatable identifier.
+func CollectedItems() []string {
+	return []string{
+		"Command name (install, convert, list, …)",
+		"Provider slug (claude-code, cursor, …)",
+		"Content type (rules, hooks, skills, …)",
+		"Counts (number of items in a command)",
+		"Boolean flags (--dry-run, success/failure)",
+		"syllago version",
+		"Operating system + CPU architecture (e.g. linux/amd64)",
+		"A random anonymous ID, rotatable via `syllago telemetry reset`",
+	}
+}
+
+// NeverItems returns the categories of data that are never collected. This
+// list intentionally repeats what the docs say — the consent UI must stand
+// on its own without requiring the user to follow a link.
+func NeverItems() []string {
+	return []string{
+		"File contents, file paths, content names",
+		"Usernames, hostnames, IP addresses, emails",
+		"Registry URLs, hook commands, MCP configs",
+		"Keystrokes or TUI navigation",
+	}
+}

--- a/cli/internal/telemetry/prompt.go
+++ b/cli/internal/telemetry/prompt.go
@@ -1,0 +1,114 @@
+package telemetry
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ErrNoTTY is returned by PromptCLIConsent when the input or output stream is
+// not interactive. Callers must treat this as "no consent recorded yet" and
+// leave telemetry disabled. The user can opt in later via the TUI or by
+// running `syllago telemetry on` from an interactive shell.
+var ErrNoTTY = errors.New("telemetry: cannot prompt for consent on a non-interactive stream")
+
+// PromptCLIConsent renders the disclosure block to out, reads a Yes/No
+// answer from in, and returns the user's choice. It does NOT persist the
+// choice — call RecordConsent(choice) afterward.
+//
+// Defaults to "No" on empty input, malformed input, or EOF: if the user is
+// not paying attention, we err on the side of not collecting.
+//
+// The caller is responsible for deciding when prompting is appropriate
+// (interactive stdin, not in --json/--quiet mode, not running a telemetry
+// subcommand). See cli/cmd/syllago/main.go.
+func PromptCLIConsent(out io.Writer, in io.Reader) (bool, error) {
+	if out == nil || in == nil {
+		return false, ErrNoTTY
+	}
+	fmt.Fprint(out, RenderDisclosure())
+	fmt.Fprint(out, "\nEnable anonymous usage data? [y/N]: ")
+
+	reader := bufio.NewReader(in)
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, fmt.Errorf("reading consent answer: %w", err)
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	switch answer {
+	case "y", "yes":
+		fmt.Fprintln(out, "\nThank you. Telemetry is now enabled. Run `syllago telemetry off` any time to disable.")
+		return true, nil
+	default:
+		fmt.Fprintln(out, "\nGot it — telemetry stays off. You can opt in later with `syllago telemetry on`.")
+		return false, nil
+	}
+}
+
+// RenderDisclosure returns the plain-text consent block printed by
+// PromptCLIConsent. Exposed as a separate function so the same content can be
+// reproduced by `syllago telemetry status` or any other CLI surface that
+// wants to remind the user what is and is not collected.
+func RenderDisclosure() string {
+	var b strings.Builder
+	const bar = "──────────────────────────────────────────────────────────────────────"
+	b.WriteString("\n")
+	b.WriteString(bar + "\n")
+	b.WriteString("  syllago needs your help\n")
+	b.WriteString(bar + "\n\n")
+	b.WriteString("  ")
+	b.WriteString(wrap(MaintainerAppeal, 66, "  "))
+	b.WriteString("\n\n")
+
+	b.WriteString("  What gets collected (only if you opt in):\n")
+	for _, item := range CollectedItems() {
+		b.WriteString("    • ")
+		b.WriteString(item)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n  Never collected:\n")
+	for _, item := range NeverItems() {
+		b.WriteString("    • ")
+		b.WriteString(item)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n  Read the docs: ")
+	b.WriteString(DocsURL)
+	b.WriteString("\n  Read the code: ")
+	b.WriteString(CodeURL)
+	b.WriteString("\n\n  Change this any time:\n")
+	b.WriteString("    syllago telemetry on    — enable\n")
+	b.WriteString("    syllago telemetry off   — disable\n")
+	b.WriteString("    syllago telemetry reset — rotate anonymous ID\n")
+	b.WriteString(bar + "\n")
+	return b.String()
+}
+
+// wrap word-wraps s to width columns, prefixing every continuation line with
+// indent. Used so the maintainer appeal reads as a paragraph regardless of
+// the user's terminal width.
+func wrap(s string, width int, indent string) string {
+	if width <= 0 {
+		return s
+	}
+	words := strings.Fields(s)
+	if len(words) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	line := words[0]
+	for _, w := range words[1:] {
+		if len(line)+1+len(w) > width {
+			b.WriteString(line)
+			b.WriteString("\n")
+			b.WriteString(indent)
+			line = w
+			continue
+		}
+		line += " " + w
+	}
+	b.WriteString(line)
+	return b.String()
+}

--- a/cli/internal/telemetry/prompt_test.go
+++ b/cli/internal/telemetry/prompt_test.go
@@ -1,0 +1,274 @@
+package telemetry
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestPromptCLIConsent_Answers covers every input shape the consent prompt
+// must classify correctly. The function defaults to "No" on anything except
+// an explicit y/yes (any case, surrounded by whitespace) — locked in here so
+// a future refactor can't widen the truthy set unintentionally and start
+// recording consent for users who typed garbage.
+func TestPromptCLIConsent_Answers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    bool
+		wantErr bool
+	}{
+		// --- Yes branch ---
+		{"y_lowercase", "y\n", true, false},
+		{"Y_uppercase", "Y\n", true, false},
+		{"yes_lowercase", "yes\n", true, false},
+		{"yes_mixed_case", "Yes\n", true, false},
+		{"YES_uppercase", "YES\n", true, false},
+		{"y_with_leading_whitespace", "  y\n", true, false},
+		{"y_with_trailing_whitespace", "y   \n", true, false},
+		{"yes_no_trailing_newline", "yes", true, false},
+
+		// --- No branch (default) ---
+		{"n_lowercase", "n\n", false, false},
+		{"N_uppercase", "N\n", false, false},
+		{"no_lowercase", "no\n", false, false},
+		{"empty_line_defaults_to_no", "\n", false, false},
+		{"immediate_eof_defaults_to_no", "", false, false},
+		{"whitespace_only", "   \n", false, false},
+
+		// --- Anything-but-y/yes lands in the No branch. The cases below
+		// are deliberate: a partial-match like "yeah" must not opt in,
+		// because the user clearly typed a word and wasn't shown one of
+		// the documented answers. Defaulting these to No protects against
+		// false-positive consent from a typo or alternate-language reply.
+		{"garbage_text_defaults_to_no", "maybe\n", false, false},
+		{"yeah_does_not_match", "yeah\n", false, false},
+		{"yep_does_not_match", "yep\n", false, false},
+		{"y_with_extra_chars", "y!\n", false, false},
+		{"numeric_answer", "1\n", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			got, err := PromptCLIConsent(&out, strings.NewReader(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("PromptCLIConsent err=%v, wantErr=%v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("PromptCLIConsent(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPromptCLIConsent_NilStreams pins that a nil writer or reader is
+// rejected up front rather than panicking. A caller that hits this branch
+// has lost stdin or stderr — the only safe response is "no consent" without
+// blocking.
+func TestPromptCLIConsent_NilStreams(t *testing.T) {
+	t.Parallel()
+
+	got, err := PromptCLIConsent(nil, strings.NewReader("y\n"))
+	if got || !errors.Is(err, ErrNoTTY) {
+		t.Errorf("nil writer: got=%v err=%v, want false + ErrNoTTY", got, err)
+	}
+
+	got, err = PromptCLIConsent(&bytes.Buffer{}, nil)
+	if got || !errors.Is(err, ErrNoTTY) {
+		t.Errorf("nil reader: got=%v err=%v, want false + ErrNoTTY", got, err)
+	}
+}
+
+// errReader returns a non-EOF error on the first read. Used to verify the
+// prompt surfaces unexpected I/O failures instead of silently treating them
+// as "no consent" — a silent default would mask broken terminals.
+type errReader struct{ err error }
+
+func (r errReader) Read(_ []byte) (int, error) { return 0, r.err }
+
+func TestPromptCLIConsent_ReadError(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	wantErr := errors.New("simulated stdin failure")
+	got, err := PromptCLIConsent(&out, errReader{err: wantErr})
+	if got {
+		t.Errorf("expected false on read error, got true")
+	}
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Errorf("expected wrapped %v, got %v", wantErr, err)
+	}
+}
+
+// TestPromptCLIConsent_OutputContainsDisclosure pins the user-visible text
+// that must appear before the y/N prompt. If a future refactor accidentally
+// drops the disclosure (or the prompt text), this test fails — not a CI
+// regression we'd notice from green-bar tests otherwise.
+func TestPromptCLIConsent_OutputContainsDisclosure(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	if _, err := PromptCLIConsent(&out, strings.NewReader("n\n")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+
+	mustContain := []string{
+		"syllago needs your help",                  // title from RenderDisclosure
+		"What gets collected (only if you opt in)", // collected-list heading
+		"Never collected",                          // never-list heading
+		DocsURL,                                    // docs link
+		CodeURL,                                    // code link
+		"Enable anonymous usage data? [y/N]:",      // the actual prompt line
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+// TestPromptCLIConsent_ConfirmationMessages pins the exact wording shown to
+// the user after they answer. The "thank you" line on Yes is part of the
+// trust contract; the "stays off" line on No must reassure the user their
+// choice was recorded.
+func TestPromptCLIConsent_ConfirmationMessages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("yes_shows_thank_you", func(t *testing.T) {
+		t.Parallel()
+		var out bytes.Buffer
+		got, _ := PromptCLIConsent(&out, strings.NewReader("y\n"))
+		if !got {
+			t.Fatal("expected true for 'y'")
+		}
+		if !strings.Contains(out.String(), "Thank you") {
+			t.Errorf("yes confirmation must include 'Thank you'; got:\n%s", out.String())
+		}
+		if !strings.Contains(out.String(), "telemetry off") {
+			t.Errorf("yes confirmation must mention how to disable later; got:\n%s", out.String())
+		}
+	})
+
+	t.Run("no_shows_stays_off", func(t *testing.T) {
+		t.Parallel()
+		var out bytes.Buffer
+		got, _ := PromptCLIConsent(&out, strings.NewReader("n\n"))
+		if got {
+			t.Fatal("expected false for 'n'")
+		}
+		if !strings.Contains(out.String(), "telemetry stays off") {
+			t.Errorf("no confirmation must contain 'telemetry stays off'; got:\n%s", out.String())
+		}
+		if !strings.Contains(out.String(), "telemetry on") {
+			t.Errorf("no confirmation must show how to opt in later; got:\n%s", out.String())
+		}
+	})
+}
+
+// TestRenderDisclosure_StableFormat pins the structure that both the prompt
+// and `syllago telemetry status` rely on: paragraph appeal, two enumerated
+// lists, both URLs, and the change-anytime guidance. This is the only
+// canonical disclosure surface for the CLI.
+func TestRenderDisclosure_StableFormat(t *testing.T) {
+	t.Parallel()
+	got := RenderDisclosure()
+
+	mustContain := []string{
+		"syllago needs your help",
+		"What gets collected (only if you opt in):",
+		"Never collected:",
+		"Read the docs: " + DocsURL,
+		"Read the code: " + CodeURL,
+		"syllago telemetry on",
+		"syllago telemetry off",
+		"syllago telemetry reset",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(got, want) {
+			t.Errorf("RenderDisclosure missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+
+	// Every CollectedItems / NeverItems entry must appear verbatim — this
+	// is what makes the disclosure stand on its own without forcing the
+	// user to follow a link.
+	for _, item := range CollectedItems() {
+		if !strings.Contains(got, item) {
+			t.Errorf("RenderDisclosure missing collected item %q", item)
+		}
+	}
+	for _, item := range NeverItems() {
+		if !strings.Contains(got, item) {
+			t.Errorf("RenderDisclosure missing never-item %q", item)
+		}
+	}
+}
+
+// TestWrap_BehavesAsParagraph pins the small wrap helper used to render the
+// MaintainerAppeal paragraph. Long words that exceed width must move to the
+// next line rather than truncate; an empty input must not produce output
+// that breaks the surrounding box layout.
+func TestWrap_BehavesAsParagraph(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		in     string
+		width  int
+		indent string
+		want   []string // each line, in order
+	}{
+		{
+			name:   "fits_in_one_line",
+			in:     "short text",
+			width:  20,
+			indent: "  ",
+			want:   []string{"short text"},
+		},
+		{
+			name: "wraps_on_word_boundary",
+			// "one two" fits (7 chars). Adding "three" would push it to 13,
+			// so a break is inserted; "three four" fits exactly at 10, then
+			// "five" forces another break.
+			in:     "one two three four five",
+			width:  10,
+			indent: "  ",
+			want:   []string{"one two", "  three four", "  five"},
+		},
+		{
+			name:   "empty_input",
+			in:     "",
+			width:  10,
+			indent: "  ",
+			want:   []string{""},
+		},
+		{
+			name:   "zero_width_returns_input",
+			in:     "anything",
+			width:  0,
+			indent: "  ",
+			want:   []string{"anything"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := wrap(tt.in, tt.width, tt.indent)
+			gotLines := strings.Split(got, "\n")
+			if len(gotLines) != len(tt.want) {
+				t.Fatalf("line count mismatch: got %d, want %d\n  got: %q\n  want: %q", len(gotLines), len(tt.want), gotLines, tt.want)
+			}
+			for i := range tt.want {
+				if gotLines[i] != tt.want[i] {
+					t.Errorf("line %d: got %q, want %q", i, gotLines[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// Compile-time check that errReader implements io.Reader.
+var _ io.Reader = errReader{}

--- a/cli/internal/telemetry/telemetry.go
+++ b/cli/internal/telemetry/telemetry.go
@@ -48,8 +48,11 @@ func SetVersion(v string) {
 	sysBuildVersion = v
 }
 
-// NoticeWriter is where the first-run notice is written. Defaults to os.Stderr.
-// Override in tests to capture notice output.
+// NoticeWriter is retained for back-compat with tests and command-line code
+// that may still write status messages to stderr. The opt-out-era first-run
+// notice is no longer printed; consent is collected via the consent modal
+// (CLI prompt + TUI overlay). See cli/internal/telemetry/prompt.go and
+// cli/internal/tui/telemetry_consent.go.
 var NoticeWriter io.Writer = os.Stderr
 
 // enrichedProps stores command-specific properties set via Enrich().
@@ -92,14 +95,19 @@ func ResetEnrichment() {
 // Init initializes the telemetry subsystem. Must be called once per process,
 // early in the command lifecycle (PersistentPreRun).
 //
+// Telemetry is opt-in: events fire only when the user has explicitly recorded
+// consent (Config.ConsentRecorded == true) AND chosen to enable
+// (Config.Enabled == true). Init never prompts; the consent modal is invoked
+// separately by the CLI (cmd/syllago) and TUI (internal/tui).
+//
 // Order of operations:
 //  1. If apiKey is empty (dev build), return immediately.
 //  2. If DO_NOT_TRACK is truthy, return immediately.
 //  3. If /etc/syllago/telemetry.json has enabled:false, return immediately.
 //  4. Attempt to load user config. If unreadable/unwritable, disable for session.
-//  5. If config missing, create with defaults (enabled:true, new ID, noticeSeen:false).
-//  6. If noticeSeen:false, print first-run notice to NoticeWriter, set noticeSeen:true.
-//  7. If enabled:false, return without initializing HTTP client.
+//  5. If config missing, create with safe defaults (Enabled=false, ConsentRecorded=false).
+//  6. Migrate legacy opt-out-era configs in memory and on disk.
+//  7. If user has not recorded consent OR has disabled telemetry, return without firing.
 //  8. Initialize HTTP client.
 func Init() {
 	state.mu.Lock()
@@ -142,23 +150,25 @@ func Init() {
 		created = true
 	}
 
-	// Step 6 — first-run notice.
-	if !cfg.NoticeSeen {
-		fmt.Fprint(NoticeWriter, firstRunNotice)
-		cfg.NoticeSeen = true
-		if err := saveUserConfig(cfg); err != nil {
-			state.disabled = true
-			return
-		}
-	} else if created {
+	// Step 6 — migrate legacy opt-out-era configs (only when loaded from disk).
+	// Anyone who installed before the opt-in switch has Enabled=true with no
+	// recorded consent; force them off until they explicitly re-opt-in. Users
+	// who had previously run `syllago telemetry off` are preserved as opted-out
+	// without re-prompt. Fresh configs are left as-is so the consent modal
+	// appears on first interactive launch.
+	migrated := false
+	if !created {
+		migrated = migrateConfig(cfg)
+	}
+	if created || migrated {
 		if err := saveUserConfig(cfg); err != nil {
 			state.disabled = true
 			return
 		}
 	}
 
-	// Step 7 — check enabled flag.
-	if !cfg.Enabled {
+	// Step 7 — must have explicit consent AND be enabled.
+	if !cfg.ConsentRecorded || !cfg.Enabled {
 		state.disabled = true
 		return
 	}
@@ -171,6 +181,92 @@ func Init() {
 		state.endpoint = defaultEndpoint
 	}
 	state.client = &http.Client{Timeout: 2 * time.Second}
+}
+
+// migrateConfig rewrites legacy opt-out-era configs in place. Returns true if
+// the config changed and needs to be saved. Designed to run only against
+// configs loaded from disk — fresh configs created by newConfig() should not
+// be passed in, since their (Enabled=false, ConsentRecorded=false) state is
+// the same shape as a legacy explicit-off without the NoticeSeen marker.
+//
+// Migration rules:
+//
+//   - Already has ConsentRecorded=true: nothing to do.
+//   - Has Enabled=true with no recorded consent: force Enabled=false and
+//     clear NoticeSeen. The consent modal will run on the next interactive
+//     launch and let the user make a real, informed choice.
+//   - Has NoticeSeen=true with Enabled=false: user previously ran
+//     `syllago telemetry off`. Preserve the opted-out state and mark
+//     consent as recorded so we don't re-prompt them. Clear NoticeSeen
+//     so migration is idempotent across loads.
+//
+// NoticeSeen is cleared in both branches so a second migration pass (e.g.
+// from NeedsConsent reloading the persisted post-migration config) does
+// not re-fire the explicit-off branch.
+func migrateConfig(cfg *Config) bool {
+	if cfg.ConsentRecorded {
+		return false
+	}
+	if cfg.Enabled {
+		cfg.Enabled = false
+		cfg.NoticeSeen = false
+		return true
+	}
+	if cfg.NoticeSeen {
+		cfg.ConsentRecorded = true
+		cfg.NoticeSeen = false
+		return true
+	}
+	return false
+}
+
+// NeedsConsent reports whether the user has not yet recorded an explicit
+// consent decision. Callers (CLI prompt, TUI modal) use this to decide
+// whether to show the consent UI before any work runs.
+//
+// Returns false in any condition where the consent modal should not appear:
+// dev builds (no API key), DO_NOT_TRACK set, system-level disable, missing
+// home dir, or unreadable config.
+func NeedsConsent() bool {
+	if apiKey == "" {
+		return false
+	}
+	if isDNTSet() {
+		return false
+	}
+	if sc, err := loadSysConfig(); err == nil && sc != nil && !sc.Enabled {
+		return false
+	}
+	cfg, err := loadUserConfig()
+	if err != nil {
+		return false
+	}
+	if cfg == nil {
+		return true
+	}
+	// Apply migration so callers see post-migration state.
+	migrateConfig(cfg)
+	return !cfg.ConsentRecorded
+}
+
+// RecordConsent persists the user's explicit choice. Sets both Enabled and
+// ConsentRecorded so that future runs respect the decision and never re-prompt.
+// Call this from the consent UI (CLI prompt or TUI modal) once the user has
+// answered Yes or No.
+func RecordConsent(enabled bool) error {
+	cfg, err := loadUserConfig()
+	if err != nil {
+		return fmt.Errorf("loading telemetry config: %w", err)
+	}
+	if cfg == nil {
+		cfg, err = newConfig()
+		if err != nil {
+			return err
+		}
+	}
+	cfg.Enabled = enabled
+	cfg.ConsentRecorded = true
+	return saveUserConfig(cfg)
 }
 
 // Track fires an event to PostHog asynchronously. Returns immediately — the POST
@@ -245,21 +341,6 @@ func sendEvent(client *http.Client, endpoint string, payload postHogPayload) {
 	_, _ = io.Copy(io.Discard, resp.Body)
 }
 
-// firstRunNotice is the exact first-run notice text printed to stderr.
-const firstRunNotice = `
-syllago collects anonymous usage data (commands run, provider
-types, error codes) to help prioritize development. No file
-contents, paths, or identifying information is collected.
-
-To opt out, run any of the following:
-
-  syllago telemetry off       Turn off telemetry
-  export DO_NOT_TRACK=1       Disable via environment variable
-
-Learn more: https://syllago.dev/telemetry
-
-`
-
 // Reset generates a new anonymous ID, saves it, and returns the new ID.
 func Reset() (string, error) {
 	cfg, err := loadUserConfig()
@@ -283,7 +364,10 @@ func Reset() (string, error) {
 	return newID, nil
 }
 
-// SetEnabled sets the enabled flag in the user config and saves it.
+// SetEnabled sets the enabled flag in the user config and saves it. Running
+// `syllago telemetry on` or `syllago telemetry off` is itself an explicit
+// consent decision, so we also mark ConsentRecorded=true to suppress any
+// future consent prompt.
 func SetEnabled(enabled bool) error {
 	cfg, err := loadUserConfig()
 	if err != nil {
@@ -296,6 +380,7 @@ func SetEnabled(enabled bool) error {
 		}
 	}
 	cfg.Enabled = enabled
+	cfg.ConsentRecorded = true
 	return saveUserConfig(cfg)
 }
 

--- a/cli/internal/telemetry/telemetry_test.go
+++ b/cli/internal/telemetry/telemetry_test.go
@@ -70,7 +70,7 @@ func TestInit_UnreadableConfig_DisabledForSession(t *testing.T) {
 	}
 }
 
-func TestInit_FirstRun_NoticeWritten(t *testing.T) {
+func TestInit_FirstRun_DisabledNoNotice(t *testing.T) {
 	origKey := apiKey
 	apiKey = "phc_test"
 	t.Cleanup(func() { apiKey = origKey; resetState() })
@@ -82,29 +82,253 @@ func TestInit_FirstRun_NoticeWritten(t *testing.T) {
 	t.Cleanup(func() { NoticeWriter = os.Stderr })
 
 	Init()
-	if !strings.Contains(notice.String(), "To opt out") {
-		t.Errorf("first-run notice not written; got: %q", notice.String())
+
+	// Opt-in: a fresh install must not auto-enable telemetry and must not
+	// print any inline notice. The consent UI (CLI prompt + TUI modal) is
+	// responsible for any disclosure.
+	if !state.disabled {
+		t.Error("expected telemetry disabled on first run when consent has not been recorded")
+	}
+	if notice.Len() != 0 {
+		t.Errorf("Init must not write any inline notice on first run; got: %q", notice.String())
+	}
+	if !NeedsConsent() {
+		t.Error("NeedsConsent should report true on first run")
 	}
 }
 
-func TestInit_NoticeWrittenOnce(t *testing.T) {
+func TestInit_LegacyOptOut_PreservedNoPrompt(t *testing.T) {
+	// Users who previously ran `syllago telemetry off` end up with
+	// Enabled=false and ConsentRecorded=false (legacy schema). Migration
+	// must preserve the opted-out state without re-prompting them.
 	origKey := apiKey
 	apiKey = "phc_test"
 	t.Cleanup(func() { apiKey = origKey; resetState() })
 	home := t.TempDir()
 	overrideHome(t, home)
 
-	var notice strings.Builder
-	NoticeWriter = &notice
-	t.Cleanup(func() { NoticeWriter = os.Stderr })
+	dir := filepath.Join(home, ".syllago")
+	os.MkdirAll(dir, 0755)
+	body := `{"enabled":false,"anonymousId":"syl_legacyoff","noticeSeen":true,"createdAt":"2026-04-02T00:00:00Z"}`
+	os.WriteFile(filepath.Join(dir, "telemetry.json"), []byte(body), 0644)
 
 	Init()
-	resetState()
-	Init() // second call
 
-	count := strings.Count(notice.String(), "To opt out")
-	if count != 1 {
-		t.Errorf("expected notice exactly once, got %d occurrences", count)
+	if !state.disabled {
+		t.Error("legacy opted-out user must remain disabled")
+	}
+	cfg, _ := loadUserConfig()
+	if cfg == nil || !cfg.ConsentRecorded {
+		t.Error("legacy opted-out user should have ConsentRecorded=true after migration")
+	}
+	if cfg != nil && cfg.Enabled {
+		t.Error("legacy opted-out user must remain Enabled=false after migration")
+	}
+	if NeedsConsent() {
+		t.Error("legacy opted-out user must not be re-prompted")
+	}
+}
+
+func TestInit_LegacySilentOptIn_ForcedOff(t *testing.T) {
+	// Users on the previous opt-out scheme had Enabled=true with no real
+	// recorded consent. Migration must force them off and leave consent
+	// unrecorded so the modal appears on the next interactive launch.
+	origKey := apiKey
+	apiKey = "phc_test"
+	t.Cleanup(func() { apiKey = origKey; resetState() })
+	home := t.TempDir()
+	overrideHome(t, home)
+
+	dir := filepath.Join(home, ".syllago")
+	os.MkdirAll(dir, 0755)
+	body := `{"enabled":true,"anonymousId":"syl_legacyon","noticeSeen":true,"createdAt":"2026-04-02T00:00:00Z"}`
+	os.WriteFile(filepath.Join(dir, "telemetry.json"), []byte(body), 0644)
+
+	Init()
+
+	if !state.disabled {
+		t.Error("legacy opt-out-era user must be force-disabled until they re-opt-in")
+	}
+	cfg, _ := loadUserConfig()
+	if cfg == nil {
+		t.Fatal("config should still exist after migration")
+	}
+	if cfg.Enabled {
+		t.Error("Enabled must be forced to false during migration")
+	}
+	if cfg.ConsentRecorded {
+		t.Error("ConsentRecorded must remain false so the modal re-prompts")
+	}
+	if !NeedsConsent() {
+		t.Error("NeedsConsent must be true so the consent modal appears")
+	}
+}
+
+// TestMigrateConfig_TableDriven exercises every documented migration branch
+// directly against the migrateConfig function, without going through Init().
+// This is the regression layer for the "ambiguity after migration" bug fixed
+// alongside the opt-in switchover: the silent-opt-in case (Enabled=true,
+// NoticeSeen=true) and the explicit-off case (Enabled=false, NoticeSeen=true)
+// share the same shape post-migration if NoticeSeen isn't cleared, which let
+// a second migration call mis-classify them.
+func TestMigrateConfig_TableDriven(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		in         Config
+		wantChange bool
+		wantOut    Config
+	}{
+		{
+			name: "fresh_install_untouched",
+			// newConfig() shape: ConsentRecorded=false, Enabled=false,
+			// NoticeSeen=false. Must NOT migrate — the consent modal will
+			// appear naturally on next launch.
+			in:         Config{Enabled: false, ConsentRecorded: false, NoticeSeen: false},
+			wantChange: false,
+			wantOut:    Config{Enabled: false, ConsentRecorded: false, NoticeSeen: false},
+		},
+		{
+			name: "already_consented_yes",
+			// Modern config with explicit yes — never re-touched.
+			in:         Config{Enabled: true, ConsentRecorded: true, NoticeSeen: false},
+			wantChange: false,
+			wantOut:    Config{Enabled: true, ConsentRecorded: true, NoticeSeen: false},
+		},
+		{
+			name: "already_consented_no",
+			// Modern config with explicit no — never re-touched.
+			in:         Config{Enabled: false, ConsentRecorded: true, NoticeSeen: false},
+			wantChange: false,
+			wantOut:    Config{Enabled: false, ConsentRecorded: true, NoticeSeen: false},
+		},
+		{
+			name: "legacy_silent_opt_in_forced_off",
+			// Opt-out era default: Enabled=true, NoticeSeen=true, no consent.
+			// Force off and clear NoticeSeen so a second migration pass is
+			// a no-op. ConsentRecorded stays false → consent modal shows.
+			in:         Config{Enabled: true, ConsentRecorded: false, NoticeSeen: true},
+			wantChange: true,
+			wantOut:    Config{Enabled: false, ConsentRecorded: false, NoticeSeen: false},
+		},
+		{
+			name: "legacy_explicit_opt_out_preserved",
+			// User previously ran `syllago telemetry off`: Enabled=false,
+			// NoticeSeen=true, no consent. Preserve the off state, mark
+			// consent recorded so they aren't re-prompted, clear NoticeSeen.
+			in:         Config{Enabled: false, ConsentRecorded: false, NoticeSeen: true},
+			wantChange: true,
+			wantOut:    Config{Enabled: false, ConsentRecorded: true, NoticeSeen: false},
+		},
+		{
+			name: "legacy_silent_opt_in_with_id_preserved",
+			// Anonymous ID and timestamp are out-of-scope for migration —
+			// only the three flags should change. Verifies migrate doesn't
+			// stomp unrelated fields.
+			in: Config{
+				Enabled: true, ConsentRecorded: false, NoticeSeen: true,
+				AnonymousID: "syl_legacyABC", Endpoint: "https://custom/",
+			},
+			wantChange: true,
+			wantOut: Config{
+				Enabled: false, ConsentRecorded: false, NoticeSeen: false,
+				AnonymousID: "syl_legacyABC", Endpoint: "https://custom/",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := tt.in
+			gotChange := migrateConfig(&cfg)
+			if gotChange != tt.wantChange {
+				t.Errorf("migrateConfig changed=%v, want %v", gotChange, tt.wantChange)
+			}
+			if cfg.Enabled != tt.wantOut.Enabled {
+				t.Errorf("Enabled=%v, want %v", cfg.Enabled, tt.wantOut.Enabled)
+			}
+			if cfg.ConsentRecorded != tt.wantOut.ConsentRecorded {
+				t.Errorf("ConsentRecorded=%v, want %v", cfg.ConsentRecorded, tt.wantOut.ConsentRecorded)
+			}
+			if cfg.NoticeSeen != tt.wantOut.NoticeSeen {
+				t.Errorf("NoticeSeen=%v, want %v", cfg.NoticeSeen, tt.wantOut.NoticeSeen)
+			}
+			if cfg.AnonymousID != tt.wantOut.AnonymousID {
+				t.Errorf("AnonymousID=%q, want %q", cfg.AnonymousID, tt.wantOut.AnonymousID)
+			}
+			if cfg.Endpoint != tt.wantOut.Endpoint {
+				t.Errorf("Endpoint=%q, want %q", cfg.Endpoint, tt.wantOut.Endpoint)
+			}
+		})
+	}
+}
+
+// TestMigrateConfig_Idempotent is the regression test for the bug fixed
+// during the opt-in conversion: running migrateConfig twice must produce the
+// same result as running it once. The original implementation flipped
+// silent-opt-in (Enabled=true, NoticeSeen=true) to (Enabled=false,
+// NoticeSeen=true) — but that output shape matched the legacy explicit-off
+// case, so a second call would silently flip ConsentRecorded to true and
+// suppress the consent modal that the migration was supposed to trigger.
+func TestMigrateConfig_Idempotent(t *testing.T) {
+	t.Parallel()
+	startStates := []struct {
+		name string
+		cfg  Config
+	}{
+		{"fresh_install", Config{}},
+		{"legacy_silent_opt_in", Config{Enabled: true, NoticeSeen: true}},
+		{"legacy_explicit_off", Config{Enabled: false, NoticeSeen: true}},
+		{"already_consented_yes", Config{Enabled: true, ConsentRecorded: true}},
+		{"already_consented_no", Config{Enabled: false, ConsentRecorded: true}},
+	}
+	for _, s := range startStates {
+		t.Run(s.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := s.cfg
+			migrateConfig(&cfg)
+			afterFirst := cfg
+
+			changed := migrateConfig(&cfg)
+			if changed {
+				t.Errorf("second migrateConfig call must be a no-op, but reported changed=true")
+			}
+			if cfg != afterFirst {
+				t.Errorf("second call mutated config:\n  after first:  %+v\n  after second: %+v", afterFirst, cfg)
+			}
+		})
+	}
+}
+
+func TestRecordConsent_Yes(t *testing.T) {
+	home := t.TempDir()
+	overrideHome(t, home)
+
+	if err := RecordConsent(true); err != nil {
+		t.Fatalf("RecordConsent(true): %v", err)
+	}
+	cfg, _ := loadUserConfig()
+	if cfg == nil || !cfg.Enabled || !cfg.ConsentRecorded {
+		t.Errorf("expected enabled=true, consentRecorded=true; got %+v", cfg)
+	}
+	if NeedsConsent() {
+		t.Error("NeedsConsent must be false after RecordConsent")
+	}
+}
+
+func TestRecordConsent_No(t *testing.T) {
+	home := t.TempDir()
+	overrideHome(t, home)
+
+	if err := RecordConsent(false); err != nil {
+		t.Fatalf("RecordConsent(false): %v", err)
+	}
+	cfg, _ := loadUserConfig()
+	if cfg == nil || cfg.Enabled || !cfg.ConsentRecorded {
+		t.Errorf("expected enabled=false, consentRecorded=true; got %+v", cfg)
+	}
+	if NeedsConsent() {
+		t.Error("a recorded No is still a recorded decision")
 	}
 }
 
@@ -128,9 +352,10 @@ func TestTrack_SendsEvent(t *testing.T) {
 	home := t.TempDir()
 	overrideHome(t, home)
 
-	var notice strings.Builder
-	NoticeWriter = &notice
-	t.Cleanup(func() { NoticeWriter = os.Stderr })
+	// Simulate explicit user opt-in so Init activates the HTTP path.
+	if err := RecordConsent(true); err != nil {
+		t.Fatalf("RecordConsent: %v", err)
+	}
 
 	Init()
 	// Override endpoint to the test server after Init().
@@ -194,9 +419,9 @@ func TestTrack_Offline_SilentDrop(t *testing.T) {
 	home := t.TempDir()
 	overrideHome(t, home)
 
-	var notice strings.Builder
-	NoticeWriter = &notice
-	t.Cleanup(func() { NoticeWriter = os.Stderr })
+	if err := RecordConsent(true); err != nil {
+		t.Fatalf("RecordConsent: %v", err)
+	}
 
 	Init()
 	// Point at a guaranteed-unreachable address.
@@ -279,10 +504,6 @@ func TestInit_UnwritableConfigDir_DisabledForSession(t *testing.T) {
 	os.Chmod(dir, 0555) // read-only
 	t.Cleanup(func() { os.Chmod(dir, 0755) })
 
-	var notice strings.Builder
-	NoticeWriter = &notice
-	t.Cleanup(func() { NoticeWriter = os.Stderr })
-
 	Init()
 	if !state.disabled {
 		t.Error("expected disabled when config dir is not writable")
@@ -322,10 +543,10 @@ func TestStatus_MissingConfig(t *testing.T) {
 	}
 }
 
-// TestEndToEnd_FullLifecycle exercises the complete telemetry lifecycle as a
-// user would experience it: fresh install → first-run notice → events sent →
-// second run (no notice) → off → on → reset. Uses httptest to verify events
-// actually arrive at the ingest endpoint with correct payloads.
+// TestEndToEnd_FullLifecycle exercises the complete opt-in telemetry
+// lifecycle: fresh install (disabled, awaiting consent) → user opts in →
+// events sent → second run (still on, no prompt) → off → on → reset.
+// Uses httptest to verify events arrive with the correct payloads.
 func TestEndToEnd_FullLifecycle(t *testing.T) {
 	// --- Setup: capture HTTP events ---
 	var received []postHogPayload
@@ -361,34 +582,46 @@ func TestEndToEnd_FullLifecycle(t *testing.T) {
 	home := t.TempDir()
 	overrideHome(t, home)
 
-	var notice strings.Builder
-	NoticeWriter = &notice
-	t.Cleanup(func() { NoticeWriter = os.Stderr })
-
-	// --- Phase 1: First run (fresh install) ---
+	// --- Phase 1: First run (fresh install) — must stay disabled until consent ---
 	Init()
+	if !state.disabled {
+		t.Fatal("fresh install must leave telemetry disabled until the user opts in")
+	}
+	if !NeedsConsent() {
+		t.Error("NeedsConsent must report true on first run")
+	}
 
-	// Config file should exist now.
+	// Track on a fresh install must be a no-op even with the test server up.
+	state.mu.Lock()
+	state.endpoint = srv.URL
+	state.mu.Unlock()
+	Track("should_not_send_pre_consent", nil)
+	Shutdown()
+	mu.Lock()
+	if len(received) != 0 {
+		t.Errorf("no events should fire pre-consent; got %d", len(received))
+	}
+	mu.Unlock()
+
+	// --- Phase 2: User opts in via the consent UI ---
+	if err := RecordConsent(true); err != nil {
+		t.Fatalf("RecordConsent(true): %v", err)
+	}
 	cfgPath := filepath.Join(home, ".syllago", "telemetry.json")
 	if _, err := os.Stat(cfgPath); err != nil {
 		t.Fatalf("config file not created: %v", err)
 	}
 
-	// First-run notice should have been written.
-	if !strings.Contains(notice.String(), "To opt out") {
-		t.Errorf("first-run notice missing; got: %q", notice.String())
-	}
-
-	// State should be active with a valid anonymous ID.
+	resetState()
+	Init()
 	if state.disabled {
-		t.Fatal("telemetry should be enabled after first Init()")
+		t.Fatal("telemetry should be enabled after RecordConsent(true)")
 	}
 	if !isValidID(state.anonymousID) {
-		t.Errorf("invalid anonymous ID after Init(): %s", state.anonymousID)
+		t.Errorf("invalid anonymous ID: %s", state.anonymousID)
 	}
 	firstID := state.anonymousID
 
-	// Override endpoint to our test server.
 	state.mu.Lock()
 	state.endpoint = srv.URL
 	state.mu.Unlock()
@@ -446,16 +679,14 @@ func TestEndToEnd_FullLifecycle(t *testing.T) {
 	}
 	mu.Unlock()
 
-	// --- Phase 3: Second run (no notice) ---
+	// --- Phase 3: Second run — consent already recorded, no re-prompt ---
 	resetState()
-	notice.Reset()
-
 	Init()
-	if notice.Len() > 0 {
-		t.Errorf("notice should not appear on second run; got: %q", notice.String())
-	}
 	if state.disabled {
-		t.Error("telemetry should still be enabled on second run")
+		t.Error("telemetry should still be enabled on second run after a recorded yes")
+	}
+	if NeedsConsent() {
+		t.Error("NeedsConsent must return false once consent has been recorded")
 	}
 	Shutdown()
 
@@ -564,6 +795,13 @@ func setupEnrichTestServer(t *testing.T) (*[]postHogPayload, *sync.Mutex) {
 	var notice strings.Builder
 	NoticeWriter = &notice
 	t.Cleanup(func() { NoticeWriter = os.Stderr })
+
+	// Simulate explicit user opt-in so Init activates the HTTP path. Under
+	// the new opt-in semantics, Init leaves state.disabled=true unless the
+	// config has both Enabled=true and ConsentRecorded=true.
+	if err := RecordConsent(true); err != nil {
+		t.Fatalf("RecordConsent: %v", err)
+	}
 
 	Init()
 	state.mu.Lock()

--- a/cli/internal/tui/app.go
+++ b/cli/internal/tui/app.go
@@ -75,19 +75,20 @@ type App struct {
 	projectRoot     string
 
 	// Sub-models
-	topBar         topBarModel
-	library        libraryModel  // Library tab: table + drill-in
-	explorer       explorerModel // Content/Loadout tabs: items list + preview
-	gallery        galleryModel  // Loadouts/Registries tabs: card grid + contents sidebar
-	helpBar        helpBarModel
-	modal          editModal           // reusable edit overlay (name + description)
-	confirm        confirmModal        // reusable confirm overlay (uninstall + simple confirms)
-	remove         removeModal         // multi-step remove overlay (library item removal)
-	help           helpOverlay         // keyboard shortcut reference (? key)
-	toast          toastModel          // bottom-right notification overlay
-	registryAdd    registryAddModal    // registry add overlay
-	tofu           tofuModal           // MOAT trust-on-first-use approval overlay
-	trustInspector trustInspectorModel // reusable trust inspector (library + registries)
+	topBar           topBarModel
+	library          libraryModel  // Library tab: table + drill-in
+	explorer         explorerModel // Content/Loadout tabs: items list + preview
+	gallery          galleryModel  // Loadouts/Registries tabs: card grid + contents sidebar
+	helpBar          helpBarModel
+	modal            editModal             // reusable edit overlay (name + description)
+	confirm          confirmModal          // reusable confirm overlay (uninstall + simple confirms)
+	remove           removeModal           // multi-step remove overlay (library item removal)
+	help             helpOverlay           // keyboard shortcut reference (? key)
+	toast            toastModel            // bottom-right notification overlay
+	registryAdd      registryAddModal      // registry add overlay
+	tofu             tofuModal             // MOAT trust-on-first-use approval overlay
+	trustInspector   trustInspectorModel   // reusable trust inspector (library + registries)
+	telemetryConsent telemetryConsentModal // first-run opt-in disclosure
 
 	// Config group sub-models
 	configSettings settingsModel
@@ -135,7 +136,6 @@ type App struct {
 	galleryDrillIn       bool   // true when viewing card contents as a library
 	galleryDrillCard     string // name of the card we drilled into (for breadcrumbs)
 	registryOpInProgress bool   // true during async registry operation (add/sync/remove)
-	telemetryNotice      bool   // true if first-run telemetry notice should be shown as toast
 
 	// D16 rule-append verification state — populated by rescanCatalog and
 	// consumed by library (Installed column is binary from MatchSet) and
@@ -155,44 +155,40 @@ func NewApp(cat *catalog.Catalog, providers []provider.Provider, version string,
 		cat = &catalog.Catalog{}
 	}
 
-	// Check if first-run telemetry notice should display as a TUI toast.
-	// PersistentPreRun already called telemetry.Init() which sets noticeSeen=true
-	// on the CLI path, so this will only be true if noticeSeen was already false
-	// before Init() ran (i.e., first-ever launch).
-	showTelemetryNotice := false
-	telemetryCfg := telemetry.Status()
-	if !telemetryCfg.NoticeSeen && telemetryCfg.Enabled {
-		showTelemetryNotice = true
+	// Telemetry is opt-in; if the user has not yet recorded a consent
+	// decision the modal opens before any other UI is reachable.
+	consent := newTelemetryConsentModal()
+	if telemetry.NeedsConsent() {
+		consent.Open()
 	}
 
 	a := App{
-		catalog:         cat,
-		providers:       providers,
-		version:         version,
-		autoUpdate:      autoUpdate,
-		isReleaseBuild:  isReleaseBuild,
-		registrySources: registrySources,
-		cfg:             cfg,
-		contentRoot:     contentRoot,
-		projectRoot:     projectRoot,
-		topBar:          newTopBar(),
-		library:         newLibraryModel(cat.Items, providers, projectRoot),
-		explorer:        newExplorerModel(nil, false, providers, projectRoot),
-		gallery:         newGalleryModel(),
-		helpBar:         newHelpBar(version),
-		modal:           newEditModal(),
-		confirm:         newConfirmModal(),
-		remove:          newRemoveModal(),
-		help:            newHelpOverlay(),
-		toast:           newToastModel(),
-		registryAdd:     newRegistryAddModal(),
-		tofu:            newTOFUModal(),
-		trustInspector:  newTrustInspectorModel(),
+		catalog:          cat,
+		providers:        providers,
+		version:          version,
+		autoUpdate:       autoUpdate,
+		isReleaseBuild:   isReleaseBuild,
+		registrySources:  registrySources,
+		cfg:              cfg,
+		contentRoot:      contentRoot,
+		projectRoot:      projectRoot,
+		topBar:           newTopBar(),
+		library:          newLibraryModel(cat.Items, providers, projectRoot),
+		explorer:         newExplorerModel(nil, false, providers, projectRoot),
+		gallery:          newGalleryModel(),
+		helpBar:          newHelpBar(version),
+		modal:            newEditModal(),
+		confirm:          newConfirmModal(),
+		remove:           newRemoveModal(),
+		help:             newHelpOverlay(),
+		toast:            newToastModel(),
+		registryAdd:      newRegistryAddModal(),
+		tofu:             newTOFUModal(),
+		trustInspector:   newTrustInspectorModel(),
+		telemetryConsent: consent,
 
 		moatSession: moat.NewSession(),
 		moatMinTier: moat.TrustTierUnsigned,
-
-		telemetryNotice: showTelemetryNotice,
 	}
 
 	// Extract registry names for settings display
@@ -207,14 +203,8 @@ func NewApp(cat *catalog.Catalog, providers []provider.Provider, version string,
 	return a
 }
 
-// telemetryNoticeMsg triggers the first-run telemetry toast in Update().
-type telemetryNoticeMsg struct{}
-
 // Init implements tea.Model.
 func (a App) Init() tea.Cmd {
-	if a.telemetryNotice {
-		return func() tea.Msg { return telemetryNoticeMsg{} }
-	}
 	return nil
 }
 

--- a/cli/internal/tui/app_test.go
+++ b/cli/internal/tui/app_test.go
@@ -2163,26 +2163,11 @@ func TestApp_AddWizardWindowResize(t *testing.T) {
 
 // --- Coverage boost: pure helpers + Init ---
 
-func TestApp_Init_NoTelemetryNotice_ReturnsNil(t *testing.T) {
+func TestApp_Init_ReturnsNil(t *testing.T) {
 	t.Parallel()
 	app := testApp(t)
-	app.telemetryNotice = false
 	if cmd := app.Init(); cmd != nil {
-		t.Errorf("expected nil cmd when telemetryNotice=false, got %v", cmd)
-	}
-}
-
-func TestApp_Init_WithTelemetryNotice_ReturnsCmd(t *testing.T) {
-	t.Parallel()
-	app := testApp(t)
-	app.telemetryNotice = true
-	cmd := app.Init()
-	if cmd == nil {
-		t.Fatal("expected non-nil cmd when telemetryNotice=true")
-	}
-	msg := cmd()
-	if _, ok := msg.(telemetryNoticeMsg); !ok {
-		t.Errorf("expected telemetryNoticeMsg, got %T", msg)
+		t.Errorf("expected nil cmd from App.Init, got %v", cmd)
 	}
 }
 

--- a/cli/internal/tui/app_update.go
+++ b/cli/internal/tui/app_update.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/metadata"
+	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
 )
 
 // Update implements tea.Model.
@@ -35,6 +36,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.tofu.width = msg.Width
 		a.tofu.height = ch
 		a.trustInspector.SetSize(msg.Width, ch)
+		a.telemetryConsent.SetSize(msg.Width, ch)
 		a.configSettings.SetSize(msg.Width, ch)
 		a.configSystem.SetSize(msg.Width, ch)
 		a.configSandbox.SetSize(msg.Width, ch)
@@ -61,6 +63,15 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case tea.MouseMsg:
+		// First-run telemetry consent modal blocks all interaction until
+		// the user records a choice. It must precede every other routing
+		// path so consent cannot be skipped by clicking outside or
+		// triggering a wizard hotkey.
+		if a.telemetryConsent.Active() {
+			var cmd tea.Cmd
+			a.telemetryConsent, cmd = a.telemetryConsent.Update(msg)
+			return a, cmd
+		}
 		// Wizard mode: topbar [?] button and help overlay still work
 		if a.wizardMode != wizardNone {
 			if a.help.active {
@@ -121,6 +132,16 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.routeMouse(msg)
 
 	case tea.KeyMsg:
+		// First-run telemetry consent modal blocks every other key path
+		// (except ctrl+c) until the user records a choice.
+		if a.telemetryConsent.Active() {
+			if msg.Type == tea.KeyCtrlC {
+				return a, tea.Quit
+			}
+			var cmd tea.Cmd
+			a.telemetryConsent, cmd = a.telemetryConsent.Update(msg)
+			return a, cmd
+		}
 		// Toast dismissal takes priority over modals — Esc dismisses toast first.
 		if a.toast.visible && msg.Type == tea.KeyEsc {
 			cmd := a.toast.Dismiss()
@@ -377,12 +398,24 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a.routeKey(msg)
 		}
 
-	case telemetryNoticeMsg:
-		const noticeText = "Syllago collects anonymous usage data to help prioritize\n" +
-			"development. No file contents or identifying info is collected.\n" +
-			"Run \"syllago telemetry off\" to disable.\n" +
-			"syllago.dev/telemetry"
-		cmd := a.toast.Push(noticeText, toastWarning)
+	case telemetryConsentDoneMsg:
+		// Persist the user's explicit choice. RecordConsent is best-effort
+		// — if it fails (read-only home, etc.) we still close the modal and
+		// surface a toast rather than blocking the TUI.
+		if err := telemetry.RecordConsent(msg.Enabled); err != nil {
+			cmd := a.toast.Push("Telemetry choice could not be saved: "+err.Error(), toastError)
+			return a, cmd
+		}
+		var label string
+		var level toastLevel
+		if msg.Enabled {
+			label = "Telemetry enabled. Thank you. Disable any time with `syllago telemetry off`."
+			level = toastSuccess
+		} else {
+			label = "Telemetry stays off. Opt in any time with `syllago telemetry on`."
+			level = toastSuccess
+		}
+		cmd := a.toast.Push(label, level)
 		return a, cmd
 
 	case toastTickMsg:

--- a/cli/internal/tui/app_view.go
+++ b/cli/internal/tui/app_view.go
@@ -43,6 +43,13 @@ func (a App) View() string {
 	if a.help.active {
 		content = overlayModal(content, a.help.View(), a.width, a.contentHeight())
 	}
+	// Consent modal overlays all other modals/wizards on first run. It is
+	// placed last (just before the toast layer) so nothing visually leaks
+	// through; Update routes input to it before any other component, so
+	// what the user sees and what they can interact with stay in sync.
+	if a.telemetryConsent.Active() {
+		content = overlayModal(content, a.telemetryConsent.View(), a.width, a.contentHeight())
+	}
 	if a.toast.visible {
 		content = overlayToast(content, a.toast.View(), a.width, a.contentHeight())
 	}

--- a/cli/internal/tui/telemetry_consent.go
+++ b/cli/internal/tui/telemetry_consent.go
@@ -1,0 +1,188 @@
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	zone "github.com/lrstanley/bubblezone"
+
+	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
+)
+
+// telemetryConsentDoneMsg is emitted when the user dismisses the modal.
+// Enabled reflects the user's choice. App.Update handles persistence and
+// transitions back to the normal landing screen.
+type telemetryConsentDoneMsg struct {
+	Enabled bool
+}
+
+// telemetryConsentModal is a full-screen blocking modal shown the first
+// time the TUI launches without a recorded telemetry consent decision.
+//
+// It is intentionally larger than other TUI modals: this is a one-time
+// disclosure with content that must be fully readable in place — the user
+// should never have to follow a link to know what they are consenting to.
+type telemetryConsentModal struct {
+	active   bool
+	focusIdx int // 0 = "No, thanks", 1 = "Yes, share usage data"
+
+	width  int
+	height int
+}
+
+func newTelemetryConsentModal() telemetryConsentModal {
+	return telemetryConsentModal{focusIdx: 0}
+}
+
+// Active reports whether the modal should consume input.
+func (m telemetryConsentModal) Active() bool { return m.active }
+
+// Open activates the modal with default focus on the safe choice.
+func (m *telemetryConsentModal) Open() {
+	m.active = true
+	m.focusIdx = 0
+}
+
+// Close deactivates the modal.
+func (m *telemetryConsentModal) Close() {
+	m.active = false
+}
+
+// SetSize lets the parent control modal width/height. The modal renders
+// at the given width but caps internally to keep readable line lengths.
+func (m *telemetryConsentModal) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+}
+
+// Update handles keyboard + mouse while active. Returns a
+// telemetryConsentDoneMsg when the user makes a choice; the App handles
+// persistence (telemetry.RecordConsent) so this component stays presentation-only.
+func (m telemetryConsentModal) Update(msg tea.Msg) (telemetryConsentModal, tea.Cmd) {
+	if !m.active {
+		return m, nil
+	}
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "tab", "right", "l":
+			m.focusIdx = 1
+		case "shift+tab", "left", "h":
+			m.focusIdx = 0
+		case "y", "Y":
+			return m.choose(true)
+		case "n", "N", "esc":
+			return m.choose(false)
+		case "enter":
+			return m.choose(m.focusIdx == 1)
+		}
+	case tea.MouseMsg:
+		if msg.Action != tea.MouseActionPress || msg.Button != tea.MouseButtonLeft {
+			return m, nil
+		}
+		if zone.Get("consent-no").InBounds(msg) {
+			return m.choose(false)
+		}
+		if zone.Get("consent-yes").InBounds(msg) {
+			return m.choose(true)
+		}
+	}
+	return m, nil
+}
+
+func (m telemetryConsentModal) choose(enabled bool) (telemetryConsentModal, tea.Cmd) {
+	m.active = false
+	return m, func() tea.Msg { return telemetryConsentDoneMsg{Enabled: enabled} }
+}
+
+// View renders the consent modal. Designed to dominate the screen until the
+// user makes a choice — there is no useful TUI state behind it on first run.
+func (m telemetryConsentModal) View() string {
+	if !m.active {
+		return ""
+	}
+
+	innerW := 70
+	if m.width > 0 && m.width-4 < innerW {
+		innerW = m.width - 4
+	}
+	if innerW < 40 {
+		innerW = 40
+	}
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(primaryColor)
+	emphasisStyle := lipgloss.NewStyle().Bold(true).Foreground(warningColor)
+	bulletStyle := lipgloss.NewStyle().Foreground(primaryText)
+	linkStyle := lipgloss.NewStyle().Foreground(accentColor).Underline(true)
+	mutedStyle := lipgloss.NewStyle().Foreground(mutedColor)
+
+	var lines []string
+	lines = append(lines, titleStyle.Render("syllago needs your help"))
+	lines = append(lines, "")
+
+	for _, line := range wrapPlain(telemetry.MaintainerAppeal, innerW) {
+		lines = append(lines, line)
+	}
+	lines = append(lines, "")
+	lines = append(lines, emphasisStyle.Render("Telemetry is OFF by default. Nothing is sent unless you choose Yes."))
+	lines = append(lines, "")
+
+	lines = append(lines, titleStyle.Render("What gets collected (only if you opt in):"))
+	for _, item := range telemetry.CollectedItems() {
+		lines = append(lines, bulletStyle.Render("  • "+item))
+	}
+	lines = append(lines, "")
+
+	lines = append(lines, titleStyle.Render("Never collected:"))
+	for _, item := range telemetry.NeverItems() {
+		lines = append(lines, bulletStyle.Render("  • "+item))
+	}
+	lines = append(lines, "")
+
+	lines = append(lines, mutedStyle.Render("Read the docs: ")+linkStyle.Render(telemetry.DocsURL))
+	lines = append(lines, mutedStyle.Render("Read the code: ")+linkStyle.Render(telemetry.CodeURL))
+	lines = append(lines, "")
+	lines = append(lines, mutedStyle.Render("Change this any time:  syllago telemetry on  /  off  /  reset"))
+	lines = append(lines, "")
+
+	lines = append(lines, renderModalButtons(m.focusIdx, innerW, "", nil,
+		buttonDef{label: "No, thanks", zoneID: "consent-no", focusAt: 0},
+		buttonDef{label: "Yes, share usage data", zoneID: "consent-yes", focusAt: 1},
+	))
+
+	body := strings.Join(lines, "\n")
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(accentColor).
+		Padding(1, 2).
+		Width(innerW + 4).
+		Render(body)
+
+	return zone.Mark("consent-modal", box)
+}
+
+// wrapPlain word-wraps s to width columns. Mirrors telemetry.RenderDisclosure
+// wrapping but produces a []string for line-based rendering inside the modal.
+func wrapPlain(s string, width int) []string {
+	if width <= 0 {
+		return []string{s}
+	}
+	words := strings.Fields(s)
+	if len(words) == 0 {
+		return []string{""}
+	}
+	var out []string
+	line := words[0]
+	for _, w := range words[1:] {
+		if len(line)+1+len(w) > width {
+			out = append(out, line)
+			line = w
+			continue
+		}
+		line += " " + w
+	}
+	out = append(out, line)
+	return out
+}

--- a/cli/internal/tui/telemetry_consent.go
+++ b/cli/internal/tui/telemetry_consent.go
@@ -121,9 +121,7 @@ func (m telemetryConsentModal) View() string {
 	lines = append(lines, titleStyle.Render("syllago needs your help"))
 	lines = append(lines, "")
 
-	for _, line := range wrapPlain(telemetry.MaintainerAppeal, innerW) {
-		lines = append(lines, line)
-	}
+	lines = append(lines, wrapPlain(telemetry.MaintainerAppeal, innerW)...)
 	lines = append(lines, "")
 	lines = append(lines, emphasisStyle.Render("Telemetry is OFF by default. Nothing is sent unless you choose Yes."))
 	lines = append(lines, "")

--- a/cli/internal/tui/telemetry_consent_test.go
+++ b/cli/internal/tui/telemetry_consent_test.go
@@ -1,0 +1,430 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	zone "github.com/lrstanley/bubblezone"
+
+	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
+)
+
+// Tests for the first-run telemetry consent modal. The modal is the only
+// place a TUI user sees telemetry information before any data could be sent,
+// so its content, focus model, and dismissal paths are all part of the
+// privacy contract — not just visual polish.
+//
+// The tests below exercise the modal model directly (not through App) so a
+// regression in App routing doesn't mask a regression in the modal itself.
+// Mouse tests must run sequentially because bubblezone uses a singleton
+// scanner — see .claude/rules/tui-testing.md.
+
+// --- Lifecycle ---
+
+func TestConsentModal_OpenSetsActiveAndSafeFocus(t *testing.T) {
+	t.Parallel()
+	m := newTelemetryConsentModal()
+	if m.Active() {
+		t.Fatal("modal must start inactive")
+	}
+	m.Open()
+	if !m.Active() {
+		t.Fatal("Open must activate the modal")
+	}
+	if m.focusIdx != 0 {
+		t.Errorf("focusIdx after Open = %d, want 0 (the safe 'No' button)", m.focusIdx)
+	}
+}
+
+func TestConsentModal_CloseDeactivates(t *testing.T) {
+	t.Parallel()
+	m := newTelemetryConsentModal()
+	m.Open()
+	m.Close()
+	if m.Active() {
+		t.Error("Close must deactivate the modal")
+	}
+}
+
+func TestConsentModal_UpdateIgnoredWhenInactive(t *testing.T) {
+	t.Parallel()
+	m := newTelemetryConsentModal()
+	// Modal not opened. All input must be ignored — no command, no state change.
+	got, cmd := m.Update(keyRune('y'))
+	if cmd != nil {
+		t.Errorf("inactive modal must not return a command, got %T", cmd())
+	}
+	if got.Active() {
+		t.Error("inactive modal must remain inactive after Update")
+	}
+}
+
+func TestConsentModal_ViewEmptyWhenInactive(t *testing.T) {
+	t.Parallel()
+	m := newTelemetryConsentModal()
+	if got := m.View(); got != "" {
+		t.Errorf("inactive View must return empty string, got %q", got)
+	}
+}
+
+// --- Keyboard ---
+
+// TestConsentModal_KeyAnswers covers the keyboard answer paths. Each row
+// pins a specific key behavior in the privacy contract: y/Y opts in, n/N
+// opts out, Esc opts out (the default-safe dismissal), Enter respects the
+// current focus. Tab/arrow keys move focus without recording an answer.
+func TestConsentModal_KeyAnswers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		startFocus     int
+		key            tea.KeyMsg
+		wantClosed     bool
+		wantCmd        bool // expect a tea.Cmd that emits telemetryConsentDoneMsg
+		wantEnabled    bool
+		wantFocusAfter int // only checked when wantClosed=false
+	}{
+		{name: "y_lowercase_opts_in", startFocus: 0, key: keyRune('y'), wantClosed: true, wantCmd: true, wantEnabled: true},
+		{name: "Y_uppercase_opts_in", startFocus: 0, key: keyRune('Y'), wantClosed: true, wantCmd: true, wantEnabled: true},
+		{name: "n_lowercase_opts_out", startFocus: 0, key: keyRune('n'), wantClosed: true, wantCmd: true, wantEnabled: false},
+		{name: "N_uppercase_opts_out", startFocus: 0, key: keyRune('N'), wantClosed: true, wantCmd: true, wantEnabled: false},
+		{name: "esc_opts_out", startFocus: 1, key: keyPress(tea.KeyEsc), wantClosed: true, wantCmd: true, wantEnabled: false},
+		{name: "enter_on_no_focus_opts_out", startFocus: 0, key: keyPress(tea.KeyEnter), wantClosed: true, wantCmd: true, wantEnabled: false},
+		{name: "enter_on_yes_focus_opts_in", startFocus: 1, key: keyPress(tea.KeyEnter), wantClosed: true, wantCmd: true, wantEnabled: true},
+		// Focus movement keys must NOT emit a done message.
+		{name: "tab_moves_focus_to_yes", startFocus: 0, key: keyTab, wantClosed: false, wantFocusAfter: 1},
+		{name: "shift_tab_moves_focus_to_no", startFocus: 1, key: keyShiftTab, wantClosed: false, wantFocusAfter: 0},
+		{name: "right_arrow_moves_focus_to_yes", startFocus: 0, key: keyPress(tea.KeyRight), wantClosed: false, wantFocusAfter: 1},
+		{name: "left_arrow_moves_focus_to_no", startFocus: 1, key: keyPress(tea.KeyLeft), wantClosed: false, wantFocusAfter: 0},
+		{name: "h_vim_moves_focus_to_no", startFocus: 1, key: keyRune('h'), wantClosed: false, wantFocusAfter: 0},
+		{name: "l_vim_moves_focus_to_yes", startFocus: 0, key: keyRune('l'), wantClosed: false, wantFocusAfter: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := newTelemetryConsentModal()
+			m.Open()
+			m.focusIdx = tt.startFocus
+
+			got, cmd := m.Update(tt.key)
+
+			if tt.wantClosed {
+				if got.Active() {
+					t.Errorf("modal must be inactive after a final answer key")
+				}
+				if !tt.wantCmd {
+					if cmd != nil {
+						t.Errorf("expected nil command, got non-nil")
+					}
+					return
+				}
+				if cmd == nil {
+					t.Fatal("expected a command emitting telemetryConsentDoneMsg, got nil")
+				}
+				msg, ok := cmd().(telemetryConsentDoneMsg)
+				if !ok {
+					t.Fatalf("command emitted %T, want telemetryConsentDoneMsg", cmd())
+				}
+				if msg.Enabled != tt.wantEnabled {
+					t.Errorf("Enabled=%v, want %v", msg.Enabled, tt.wantEnabled)
+				}
+				return
+			}
+
+			if !got.Active() {
+				t.Error("focus-movement key must NOT close the modal")
+			}
+			if cmd != nil {
+				t.Errorf("focus-movement key must not emit a command, got %T", cmd())
+			}
+			if got.focusIdx != tt.wantFocusAfter {
+				t.Errorf("focusIdx=%d, want %d", got.focusIdx, tt.wantFocusAfter)
+			}
+		})
+	}
+}
+
+// TestConsentModal_UnboundKeyDoesNothing pins that random keystrokes don't
+// accidentally dismiss the modal or change focus. Without this, a stray
+// keypress while the user reads the disclosure could record a decision they
+// didn't intend.
+func TestConsentModal_UnboundKeyDoesNothing(t *testing.T) {
+	t.Parallel()
+	m := newTelemetryConsentModal()
+	m.Open()
+	m.focusIdx = 0
+
+	got, cmd := m.Update(keyRune('z'))
+	if cmd != nil {
+		t.Errorf("unbound key emitted a command: %T", cmd())
+	}
+	if !got.Active() {
+		t.Error("unbound key must not close the modal")
+	}
+	if got.focusIdx != 0 {
+		t.Errorf("unbound key changed focus from 0 to %d", got.focusIdx)
+	}
+}
+
+// --- View content ---
+
+// TestConsentModal_ViewContainsRequiredDisclosure pins every load-bearing
+// piece of text in the modal: the appeal paragraph, the OFF-by-default
+// emphasis, both enumerated lists in full, both URLs, and the action hint.
+// If any of these go missing the user's consent is no longer fully informed
+// — this test catches that before the modal regresses.
+func TestConsentModal_ViewContainsRequiredDisclosure(t *testing.T) {
+	t.Parallel()
+	m := newTelemetryConsentModal()
+	m.Open()
+	m.SetSize(120, 40)
+
+	view := m.View()
+
+	// Direct substring checks for content that fits on a single line.
+	mustContain := []string{
+		"syllago needs your help",
+		"OFF by default",
+		"What gets collected (only if you opt in):",
+		"Never collected:",
+		telemetry.DocsURL,
+		"syllago telemetry on",
+		"No, thanks",
+		"Yes, share usage data",
+	}
+	for _, want := range mustContain {
+		assertContains(t, view, want)
+	}
+
+	// CodeURL exceeds the modal's 70-char inner width, so it wraps onto two
+	// lines with leading whitespace. Normalize the view (strip borders, fold
+	// whitespace) before checking for the URL — the text must be present, even
+	// if rendering breaks it across lines.
+	flat := flattenView(view)
+	if !strings.Contains(flat, telemetry.CodeURL) {
+		t.Errorf("normalized view missing CodeURL %q", telemetry.CodeURL)
+	}
+
+	// Every collected/never item must appear verbatim. Wrapping never
+	// applies inside the bullet list (each item is one line by design),
+	// so this is a strict substring match.
+	for _, item := range telemetry.CollectedItems() {
+		assertContains(t, view, item)
+	}
+	for _, item := range telemetry.NeverItems() {
+		assertContains(t, view, item)
+	}
+}
+
+// TestConsentModal_ViewIncludesAppealParagraph pins that the maintainer
+// appeal is rendered (possibly wrapped). We collapse all whitespace and
+// check for a distinctive substring so wrapping mode doesn't cause flakes.
+func TestConsentModal_ViewIncludesAppealParagraph(t *testing.T) {
+	t.Parallel()
+	m := newTelemetryConsentModal()
+	m.Open()
+	m.SetSize(120, 40)
+
+	stripped := normalizeWhitespace(m.View())
+	// Pull a high-signal phrase out of the middle of MaintainerAppeal so
+	// the test doesn't break every time the appeal is reworded — but does
+	// break if the paragraph drops out entirely.
+	if !strings.Contains(stripped, "one person") {
+		t.Errorf("modal view missing maintainer appeal text; got:\n%s", stripped)
+	}
+	if !strings.Contains(stripped, "OFF by default") {
+		t.Errorf("modal view missing OFF-by-default emphasis")
+	}
+}
+
+// normalizeWhitespace collapses runs of whitespace (including line breaks
+// from word-wrap) so substring checks survive layout changes. ANSI is
+// stripped via assertContains in callers; here we just normalize.
+func normalizeWhitespace(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+	return strings.TrimSpace(s)
+}
+
+// --- Mouse ---
+
+// TestConsentModal_MouseClickNo pins zone "consent-no". The "No, thanks"
+// button is the safe default — if its click handler regresses, users who
+// reach for the mouse instead of the keyboard would be unable to opt out
+// without dismissing via Esc.
+func TestConsentModal_MouseClickNo(t *testing.T) {
+	// Sequential — bubblezone v1.0.0 uses a singleton scanner; concurrent
+	// Scan calls clobber the global zone map. See .claude/rules/tui-testing.md.
+	m := newTelemetryConsentModal()
+	m.Open()
+	m.SetSize(120, 40)
+
+	scanZones(m.View())
+	z := zone.Get("consent-no")
+	if z.IsZero() {
+		t.Skip("zone consent-no not registered (bubblezone rendering issue)")
+	}
+
+	got, cmd := m.Update(mouseClick(z.StartX, z.StartY))
+
+	if got.Active() {
+		t.Error("modal must close after No click")
+	}
+	if cmd == nil {
+		t.Fatal("No click must emit a command")
+	}
+	msg, ok := cmd().(telemetryConsentDoneMsg)
+	if !ok {
+		t.Fatalf("command emitted %T, want telemetryConsentDoneMsg", cmd())
+	}
+	if msg.Enabled {
+		t.Error("No click must emit Enabled=false")
+	}
+}
+
+// TestConsentModal_MouseClickYes pins zone "consent-yes". The opt-in path
+// must require a deliberate click — never a click anywhere on the modal —
+// so this test is the lower bound on what counts as consent.
+func TestConsentModal_MouseClickYes(t *testing.T) {
+	m := newTelemetryConsentModal()
+	m.Open()
+	m.SetSize(120, 40)
+
+	scanZones(m.View())
+	z := zone.Get("consent-yes")
+	if z.IsZero() {
+		t.Skip("zone consent-yes not registered (bubblezone rendering issue)")
+	}
+
+	got, cmd := m.Update(mouseClick(z.StartX, z.StartY))
+
+	if got.Active() {
+		t.Error("modal must close after Yes click")
+	}
+	if cmd == nil {
+		t.Fatal("Yes click must emit a command")
+	}
+	msg, ok := cmd().(telemetryConsentDoneMsg)
+	if !ok {
+		t.Fatalf("command emitted %T, want telemetryConsentDoneMsg", cmd())
+	}
+	if !msg.Enabled {
+		t.Error("Yes click must emit Enabled=true")
+	}
+}
+
+// TestConsentModal_MouseClickElsewhereDoesNothing pins that a click on the
+// modal body (not on a button) does not record a decision. A naive
+// implementation that closes on any click inside the modal-zone would let
+// users opt in by accident.
+func TestConsentModal_MouseClickElsewhereDoesNothing(t *testing.T) {
+	m := newTelemetryConsentModal()
+	m.Open()
+	m.SetSize(120, 40)
+
+	scanZones(m.View())
+	// Click at (0,0) — outside any button zone but still within the modal.
+	got, cmd := m.Update(mouseClick(0, 0))
+
+	if !got.Active() {
+		t.Error("body click must not close the modal")
+	}
+	if cmd != nil {
+		t.Errorf("body click must not emit a command, got %T", cmd())
+	}
+}
+
+// TestConsentModal_MouseRightClickIgnored pins that the modal only reacts
+// to left-button presses. A right-click context-menu attempt must not
+// trigger an answer.
+func TestConsentModal_MouseRightClickIgnored(t *testing.T) {
+	m := newTelemetryConsentModal()
+	m.Open()
+	m.SetSize(120, 40)
+
+	scanZones(m.View())
+	z := zone.Get("consent-yes")
+	if z.IsZero() {
+		t.Skip("zone consent-yes not registered")
+	}
+
+	rightClick := tea.MouseMsg{X: z.StartX, Y: z.StartY, Action: tea.MouseActionPress, Button: tea.MouseButtonRight}
+	got, cmd := m.Update(rightClick)
+
+	if !got.Active() {
+		t.Error("right-click must not close the modal")
+	}
+	if cmd != nil {
+		t.Errorf("right-click must not emit a command, got %T", cmd())
+	}
+}
+
+// --- App-level integration ---
+
+// TestApp_ConsentDoneMsg_PersistsAndToasts pins the App's reaction to
+// telemetryConsentDoneMsg: it must call telemetry.RecordConsent with the
+// user's choice and surface a toast confirming the result. Without this,
+// even a working modal would drop the user's answer on the floor.
+func TestApp_ConsentDoneMsg_PersistsAndToasts(t *testing.T) {
+	// Sequential because telemetry.UserHomeDirFn is a global override.
+	tmp := t.TempDir()
+	orig := telemetry.UserHomeDirFn
+	telemetry.UserHomeDirFn = func() (string, error) { return tmp, nil }
+	t.Cleanup(func() { telemetry.UserHomeDirFn = orig })
+
+	app := testApp(t)
+
+	// Yes branch.
+	m, _ := app.Update(telemetryConsentDoneMsg{Enabled: true})
+	a := m.(App)
+	if !a.toast.visible {
+		t.Fatal("Yes path must surface a toast")
+	}
+	cur := a.toast.Current()
+	if cur == nil {
+		t.Fatal("Yes path must produce a current toast")
+	}
+	if !strings.Contains(cur.message, "Telemetry enabled") {
+		t.Errorf("Yes toast text=%q, want substring 'Telemetry enabled'", cur.message)
+	}
+	cfg := telemetry.Status()
+	if !cfg.Enabled || !cfg.ConsentRecorded {
+		t.Errorf("after Yes msg: Enabled=%v ConsentRecorded=%v, want both true", cfg.Enabled, cfg.ConsentRecorded)
+	}
+
+	// No branch — fresh App so the queued Yes toast doesn't shadow the
+	// new one (toastModel.Current() returns the head of the FIFO queue).
+	app2 := testApp(t)
+	m2, _ := app2.Update(telemetryConsentDoneMsg{Enabled: false})
+	a2 := m2.(App)
+	cur2 := a2.toast.Current()
+	if cur2 == nil {
+		t.Fatal("No path must produce a current toast")
+	}
+	if !strings.Contains(cur2.message, "stays off") {
+		t.Errorf("No toast text=%q, want substring 'stays off'", cur2.message)
+	}
+	cfg = telemetry.Status()
+	if cfg.Enabled {
+		t.Error("after No msg: Enabled must be false")
+	}
+	if !cfg.ConsentRecorded {
+		t.Error("after No msg: ConsentRecorded must remain true")
+	}
+}
+
+// flattenView returns the visible text of a rendered modal view collapsed to
+// a single line: ANSI/box-drawing borders stripped and runs of whitespace
+// folded to a single space. Used when assertions span content that the modal
+// wraps across multiple lines (e.g., a URL longer than innerW).
+func flattenView(view string) string {
+	cleaned := view
+	for _, r := range []string{"│", "╭", "╮", "╰", "╯", "─"} {
+		cleaned = strings.ReplaceAll(cleaned, r, " ")
+	}
+	cleaned = strings.ReplaceAll(cleaned, "\n", " ")
+	return strings.Join(strings.Fields(cleaned), "")
+}


### PR DESCRIPTION
## Summary

Telemetry was previously opt-out: enabled by default with a one-time notice. This PR flips the contract — nothing is sent until the user makes an explicit Yes/No choice through one of two surfaces:

- **CLI prompt** — fires once on first interactive non-JSON, non-quiet, non-skip-listed command. y/Y/yes (any case, with whitespace) opt in; anything else opts out.
- **TUI consent modal** — full-screen blocking overlay on App startup, keyboard + mouse parity, focus defaults to "No, thanks" so accidental Enter never opts in.

A new `ConsentRecorded` config flag gates all telemetry emission, separate from `Enabled` so a future reset can re-prompt cleanly. Legacy configs are migrated in place: previously-enabled installs are forced off and required to re-opt-in; explicit-off choices are preserved as a recorded No so existing scripted disables don't trigger a prompt.

The PostHog ldflag continues to act as the build-time toggle — dev builds with no key skip the consent flow because there's no destination to consent to.

## What's tested

- `migrateConfig` table-driven (6 cases) + idempotency across 5 starting states (regression for the bug where re-running migration on a freshly-migrated config flipped `ConsentRecorded` to true)
- `PromptCLIConsent` parser covers 18 input shapes, nil-stream rejection, read-error wrapping, disclosure substring pinning, confirmation-message wording
- `shouldPromptConsent` 11-branch table hits every gate (nil command, real rootCmd, telemetry parents, version, help, JSON, quiet, non-interactive)
- TUI consent modal: lifecycle, 13-key keyboard table, unbound-key safety, view-content pinning, three sequential mouse-zone tests, App-level `telemetryConsentDoneMsg` integration

## Test plan

- [ ] `make build && make test` from `cli/` — full suite green
- [ ] Build with stub PostHog key, delete `~/.syllago/telemetry.json`, run `syllago` — TUI modal overlays on startup
- [ ] Same setup, run `syllago list` — CLI y/N prompt fires on stderr
- [ ] Confirm `syllago telemetry status` reflects the recorded choice in both human and `--json` output
- [ ] Re-run after answering — no re-prompt
- [ ] Pre-existing legacy config (`enabled: true, noticeSeen: true`) is migrated to forced-off + needs-consent

🤖 Generated with [Claude Code](https://claude.com/claude-code)