### PR TITLE
fix(capmon): derive per-content-type seeder specs and add drift gate

### DIFF
--- a/cli/cmd/syllago/capmon_cmd.go
+++ b/cli/cmd/syllago/capmon_cmd.go
@@ -78,6 +78,15 @@ var capmonVerifyCmd = &cobra.Command{
 				continue
 			}
 			path := filepath.Join(dir, e.Name())
+			// Skip per-content-type seeder specs (e.g. amp-skills.yaml). Those use
+			// `provider:` at the top level instead of `slug:` and have no
+			// schema_version field. They are an internal capmon artifact, not a
+			// canonical capability YAML, so schema validation does not apply.
+			// Mirrors the Slug=="" pattern in internal/capmon/generate.go.
+			caps, err := capyaml.LoadCapabilityYAML(path)
+			if err == nil && caps.Slug == "" {
+				continue
+			}
 			if err := capyaml.ValidateAgainstSchema(path, migrationWindow); err != nil {
 				return fmt.Errorf("validate %s: %w", e.Name(), err)
 			}

--- a/cli/cmd/syllago/capmon_cmd_test.go
+++ b/cli/cmd/syllago/capmon_cmd_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/OpenScribbler/syllago/cli/internal/capmon"
@@ -15,6 +17,54 @@ func TestCapmonVerify_EmptyDir(t *testing.T) {
 	err := capmonVerifyCmd.RunE(capmonVerifyCmd, []string{})
 	if err != nil {
 		t.Errorf("verify on empty dir: %v", err)
+	}
+}
+
+// TestCapmonVerify_SkipsSeederSpecs is a regression test for the bug where
+// `syllago capmon verify` failed on per-content-type seeder specs in
+// docs/provider-capabilities/. Seeder specs use `provider:` not `slug:` and
+// have no `schema_version` field, so the schema validator rejects them.
+// Verify must skip them (mirrors the Slug=="" pattern in
+// internal/capmon/generate.go).
+func TestCapmonVerify_SkipsSeederSpecs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Valid canonical capability YAML — has slug + schema_version.
+	canonicalYAML := `schema_version: "1"
+slug: test-provider
+display_name: Test Provider
+last_verified: "2026-04-28"
+content_types:
+  hooks:
+    supported: true
+`
+	if err := os.WriteFile(filepath.Join(dir, "test-provider.yaml"), []byte(canonicalYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seeder spec — has provider + content_type but no slug or schema_version.
+	seederSpec := `provider: test-provider
+content_type: skills
+format: ""
+proposed_mappings:
+  - canonical_key: display_name
+    supported: true
+    mechanism: "yaml key: name"
+    source_field: ""
+    source_value: ""
+    confidence: confirmed
+`
+	if err := os.WriteFile(filepath.Join(dir, "test-provider-skills.yaml"), []byte(seederSpec), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := capmonCapabilitiesDirOverride
+	capmonCapabilitiesDirOverride = dir
+	t.Cleanup(func() { capmonCapabilitiesDirOverride = orig })
+
+	err := capmonVerifyCmd.RunE(capmonVerifyCmd, []string{})
+	if err != nil {
+		t.Errorf("verify on dir with seeder spec should succeed (skipping seeder), got: %v", err)
 	}
 }
 

--- a/cli/cmd/syllago/capmon_derive_cmd.go
+++ b/cli/cmd/syllago/capmon_derive_cmd.go
@@ -50,17 +50,18 @@ Content types with status=unsupported are omitted from output.`,
 			return fmt.Errorf("load format doc: %w", err)
 		}
 
-		spec, err := capmon.DeriveSeederSpec(doc, canonicalKeys)
+		specs, err := capmon.DeriveSeederSpecs(doc, canonicalKeys)
 		if err != nil {
 			return err
 		}
 
-		outPath := capmon.SeederSpecPath(outputDir, provider, spec.ContentType)
-		if err := capmon.WriteSeederSpec(spec, outPath); err != nil {
-			return fmt.Errorf("write seeder spec: %w", err)
+		for _, spec := range specs {
+			outPath := capmon.SeederSpecPath(outputDir, provider, spec.ContentType)
+			if err := capmon.WriteSeederSpec(spec, outPath); err != nil {
+				return fmt.Errorf("write seeder spec for %q: %w", spec.ContentType, err)
+			}
+			fmt.Printf("✓ Derived seeder spec for %q (%s) → %s\n", provider, spec.ContentType, outPath)
 		}
-
-		fmt.Printf("✓ Derived seeder spec for %q → %s\n", provider, outPath)
 		return nil
 	},
 }

--- a/cli/internal/capmon/derive.go
+++ b/cli/internal/capmon/derive.go
@@ -9,43 +9,51 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// DeriveSeederSpec produces a SeederSpec from a FormatDoc deterministically.
-// Identical inputs always produce identical outputs (no timestamps, no UUIDs).
-// Content types with status "unsupported" are skipped.
-// Returns an error if any canonical_mappings key is not in canonical-keys.yaml.
-func DeriveSeederSpec(doc *FormatDoc, canonicalKeysPath string) (*SeederSpec, error) {
+// DeriveSeederSpecs produces one SeederSpec per supported content_type from a
+// FormatDoc, deterministically. Identical inputs always produce identical
+// outputs (no timestamps, no UUIDs). Content types with status "unsupported"
+// are skipped entirely (no spec emitted). Returns an error if any
+// canonical_mappings key is not in canonical-keys.yaml.
+//
+// The returned slice is sorted by ContentType so callers can rely on stable
+// ordering when writing per-content-type files to disk.
+func DeriveSeederSpecs(doc *FormatDoc, canonicalKeysPath string) ([]*SeederSpec, error) {
 	canonicalKeys, err := loadCanonicalKeys(canonicalKeysPath)
 	if err != nil {
-		return nil, fmt.Errorf("derive seeder spec: %w", err)
+		return nil, fmt.Errorf("derive seeder specs: %w", err)
 	}
 
-	spec := &SeederSpec{
-		Provider:    doc.Provider,
-		ContentType: "skills",
+	contentTypes := make([]string, 0, len(doc.ContentTypes))
+	for ct := range doc.ContentTypes {
+		contentTypes = append(contentTypes, ct)
 	}
+	sort.Strings(contentTypes)
 
-	// Collect all proposed mappings across content types, skipping unsupported ones.
-	// Sort canonical keys for determinism.
-	for ct, ctDoc := range doc.ContentTypes {
+	var specs []*SeederSpec
+	for _, ct := range contentTypes {
+		ctDoc := doc.ContentTypes[ct]
 		if ctDoc.Status == "unsupported" {
 			continue
 		}
 
 		validKeys := canonicalKeys[ct]
 
-		// Sort canonical mapping keys for deterministic output.
 		keys := make([]string, 0, len(ctDoc.CanonicalMappings))
 		for k := range ctDoc.CanonicalMappings {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
 
+		spec := &SeederSpec{
+			Provider:    doc.Provider,
+			ContentType: ct,
+		}
+
 		for _, key := range keys {
 			mapping := ctDoc.CanonicalMappings[key]
 
-			// Unknown key — hard error.
 			if validKeys != nil && !validKeys[key] {
-				return nil, fmt.Errorf("derive seeder spec for %q: canonical_mappings key %q not in canonical-keys.yaml", doc.Provider, key)
+				return nil, fmt.Errorf("derive seeder specs for %q: canonical_mappings key %q not in canonical-keys.yaml for content_type %q", doc.Provider, key, ct)
 			}
 
 			spec.ProposedMappings = append(spec.ProposedMappings, ProposedMapping{
@@ -55,9 +63,11 @@ func DeriveSeederSpec(doc *FormatDoc, canonicalKeysPath string) (*SeederSpec, er
 				Confidence:   mapping.Confidence,
 			})
 		}
+
+		specs = append(specs, spec)
 	}
 
-	return spec, nil
+	return specs, nil
 }
 
 // WriteSeederSpec writes a SeederSpec to the given path using an atomic

--- a/cli/internal/capmon/derive_test.go
+++ b/cli/internal/capmon/derive_test.go
@@ -32,6 +32,59 @@ func makeTestFormatDoc(provider string) *FormatDoc {
 	}
 }
 
+func makeMultiCTFormatDoc(provider string) *FormatDoc {
+	return &FormatDoc{
+		Provider:         provider,
+		LastFetchedAt:    "2026-04-11T00:00:00Z",
+		GenerationMethod: "human-edited",
+		ContentTypes: map[string]ContentTypeFormatDoc{
+			"skills": {
+				Status: "supported",
+				CanonicalMappings: map[string]CanonicalMapping{
+					"display_name": {
+						Supported:  true,
+						Mechanism:  "yaml key: name",
+						Confidence: "confirmed",
+					},
+				},
+			},
+			"rules": {
+				Status: "supported",
+				CanonicalMappings: map[string]CanonicalMapping{
+					"description": {
+						Supported:  true,
+						Mechanism:  "frontmatter description",
+						Confidence: "confirmed",
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeMultiCTCanonicalKeysFile(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	content := `content_types:
+  skills:
+    display_name:
+      description: "Display name"
+      type: string
+    project_scope:
+      description: "Project scope"
+      type: bool
+  rules:
+    description:
+      description: "Description"
+      type: string
+`
+	path := filepath.Join(dir, "canonical-keys.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 func makeTestCanonicalKeysFile(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -54,25 +107,25 @@ func makeTestCanonicalKeysFile(t *testing.T) string {
 	return path
 }
 
-func TestDeriveSeederSpec_Deterministic(t *testing.T) {
+func TestDeriveSeederSpecs_Deterministic(t *testing.T) {
 	t.Parallel()
 	doc := makeTestFormatDoc("amp")
 	canonicalKeysPath := makeTestCanonicalKeysFile(t)
 
-	spec1, err := DeriveSeederSpec(doc, canonicalKeysPath)
+	specs1, err := DeriveSeederSpecs(doc, canonicalKeysPath)
 	if err != nil {
 		t.Fatalf("first derive: %v", err)
 	}
-	spec2, err := DeriveSeederSpec(doc, canonicalKeysPath)
+	specs2, err := DeriveSeederSpecs(doc, canonicalKeysPath)
 	if err != nil {
 		t.Fatalf("second derive: %v", err)
 	}
-	if !reflect.DeepEqual(spec1, spec2) {
-		t.Error("DeriveSeederSpec is not deterministic: two calls with same input produced different output")
+	if !reflect.DeepEqual(specs1, specs2) {
+		t.Error("DeriveSeederSpecs is not deterministic: two calls with same input produced different output")
 	}
 }
 
-func TestDeriveSeederSpec_UnknownKey(t *testing.T) {
+func TestDeriveSeederSpecs_UnknownKey(t *testing.T) {
 	t.Parallel()
 	doc := &FormatDoc{
 		Provider:         "test",
@@ -93,13 +146,13 @@ func TestDeriveSeederSpec_UnknownKey(t *testing.T) {
 	}
 	canonicalKeysPath := makeTestCanonicalKeysFile(t)
 
-	_, err := DeriveSeederSpec(doc, canonicalKeysPath)
+	_, err := DeriveSeederSpecs(doc, canonicalKeysPath)
 	if err == nil {
 		t.Fatal("expected error for unknown canonical key")
 	}
 }
 
-func TestDeriveSeederSpec_UnsupportedSkipped(t *testing.T) {
+func TestDeriveSeederSpecs_UnsupportedSkipped(t *testing.T) {
 	t.Parallel()
 	doc := &FormatDoc{
 		Provider:         "test",
@@ -116,13 +169,142 @@ func TestDeriveSeederSpec_UnsupportedSkipped(t *testing.T) {
 	}
 	canonicalKeysPath := makeTestCanonicalKeysFile(t)
 
-	spec, err := DeriveSeederSpec(doc, canonicalKeysPath)
+	specs, err := DeriveSeederSpecs(doc, canonicalKeysPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Content types with status=unsupported should produce no proposed mappings.
-	if len(spec.ProposedMappings) != 0 {
-		t.Errorf("expected 0 proposed mappings for unsupported content type, got %d", len(spec.ProposedMappings))
+	// Content types with status=unsupported should produce no spec at all
+	// (not an empty spec — the whole content_type is omitted from output).
+	if len(specs) != 0 {
+		t.Errorf("expected 0 specs for doc with only unsupported content types, got %d", len(specs))
+	}
+}
+
+// TestDeriveSeederSpecs_ReturnsOnePerSupportedContentType is the tracer bullet
+// for the per-content-type derive shape. A doc with N supported content_types
+// must produce N specs, one per content_type, never lumped together.
+//
+// Regression for the bug where DeriveSeederSpec hardcoded ContentType:"skills"
+// and collapsed all content_types into a single spec — see commit 82b64ea4.
+func TestDeriveSeederSpecs_ReturnsOnePerSupportedContentType(t *testing.T) {
+	t.Parallel()
+	doc := makeMultiCTFormatDoc("amp")
+	canonicalKeysPath := makeMultiCTCanonicalKeysFile(t)
+
+	specs, err := DeriveSeederSpecs(doc, canonicalKeysPath)
+	if err != nil {
+		t.Fatalf("DeriveSeederSpecs: %v", err)
+	}
+
+	if len(specs) != 2 {
+		t.Fatalf("expected 2 specs (one per supported content_type), got %d", len(specs))
+	}
+
+	gotContentTypes := make(map[string]bool)
+	for _, s := range specs {
+		gotContentTypes[s.ContentType] = true
+		if s.Provider != "amp" {
+			t.Errorf("spec for content_type %q has wrong provider: got %q, want amp", s.ContentType, s.Provider)
+		}
+	}
+	if !gotContentTypes["skills"] {
+		t.Error("missing spec for content_type skills")
+	}
+	if !gotContentTypes["rules"] {
+		t.Error("missing spec for content_type rules")
+	}
+}
+
+// TestDeriveSeederSpecs_SortedByContentType pins the documented contract:
+// returned specs are sorted alphabetically by ContentType. Callers (and
+// drift-detection tests) rely on this for stable file output ordering.
+func TestDeriveSeederSpecs_SortedByContentType(t *testing.T) {
+	t.Parallel()
+	// Doc with three content_types in non-alphabetical map order to defeat any
+	// accidental input-order preservation (Go map iteration is randomized but
+	// not reverse-sorted).
+	doc := &FormatDoc{
+		Provider:         "test",
+		LastFetchedAt:    "2026-04-11T00:00:00Z",
+		GenerationMethod: "human-edited",
+		ContentTypes: map[string]ContentTypeFormatDoc{
+			"skills": {Status: "supported", CanonicalMappings: map[string]CanonicalMapping{"display_name": {Supported: true, Mechanism: "x", Confidence: "confirmed"}}},
+			"rules":  {Status: "supported", CanonicalMappings: map[string]CanonicalMapping{"description": {Supported: true, Mechanism: "x", Confidence: "confirmed"}}},
+			"agents": {Status: "supported", CanonicalMappings: map[string]CanonicalMapping{"display_name": {Supported: true, Mechanism: "x", Confidence: "confirmed"}}},
+		},
+	}
+	dir := t.TempDir()
+	keysPath := filepath.Join(dir, "canonical-keys.yaml")
+	keys := `content_types:
+  skills:
+    display_name: {description: "x", type: string}
+  rules:
+    description: {description: "x", type: string}
+  agents:
+    display_name: {description: "x", type: string}
+`
+	if err := os.WriteFile(keysPath, []byte(keys), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	specs, err := DeriveSeederSpecs(doc, keysPath)
+	if err != nil {
+		t.Fatalf("DeriveSeederSpecs: %v", err)
+	}
+
+	got := make([]string, 0, len(specs))
+	for _, s := range specs {
+		got = append(got, s.ContentType)
+	}
+	want := []string{"agents", "rules", "skills"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("spec order: got %v, want %v (sorted alphabetically)", got, want)
+	}
+}
+
+// TestDeriveSeederSpecs_NoCrossContentTypeBleed verifies each spec's
+// ProposedMappings come ONLY from its own content_type's canonical_mappings.
+// Cross-CT bleed was the symptom of the original bug — see derive.go before
+// the per-CT refactor, which iterated all content_types into a single spec.
+func TestDeriveSeederSpecs_NoCrossContentTypeBleed(t *testing.T) {
+	t.Parallel()
+	doc := makeMultiCTFormatDoc("amp")
+	canonicalKeysPath := makeMultiCTCanonicalKeysFile(t)
+
+	specs, err := DeriveSeederSpecs(doc, canonicalKeysPath)
+	if err != nil {
+		t.Fatalf("DeriveSeederSpecs: %v", err)
+	}
+
+	byCT := make(map[string]*SeederSpec)
+	for _, s := range specs {
+		byCT[s.ContentType] = s
+	}
+
+	skillsSpec, ok := byCT["skills"]
+	if !ok {
+		t.Fatal("missing spec for skills")
+	}
+	if len(skillsSpec.ProposedMappings) != 1 {
+		t.Errorf("skills spec: expected 1 proposed mapping, got %d", len(skillsSpec.ProposedMappings))
+	}
+	for _, m := range skillsSpec.ProposedMappings {
+		if m.CanonicalKey == "description" {
+			t.Errorf("cross-CT bleed: skills spec contains rules' canonical_key %q", m.CanonicalKey)
+		}
+	}
+
+	rulesSpec, ok := byCT["rules"]
+	if !ok {
+		t.Fatal("missing spec for rules")
+	}
+	if len(rulesSpec.ProposedMappings) != 1 {
+		t.Errorf("rules spec: expected 1 proposed mapping, got %d", len(rulesSpec.ProposedMappings))
+	}
+	for _, m := range rulesSpec.ProposedMappings {
+		if m.CanonicalKey == "display_name" {
+			t.Errorf("cross-CT bleed: rules spec contains skills' canonical_key %q", m.CanonicalKey)
+		}
 	}
 }
 

--- a/cli/internal/capmon/seederspec_audit_test.go
+++ b/cli/internal/capmon/seederspec_audit_test.go
@@ -1,17 +1,20 @@
 package capmon_test
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/OpenScribbler/syllago/cli/internal/capmon"
+	"gopkg.in/yaml.v3"
 )
 
-// TestSeederSpecs_AllLoad verifies every *-skills.yaml in .develop/seeder-specs/
-// parses cleanly against the current SeederSpec schema. Catches schema drift:
-// if the SeederSpec struct changes in a way that breaks existing specs, this
-// test fails before capmon pipelines break silently.
+// TestSeederSpecs_AllLoad verifies every <slug>-<content_type>.yaml in
+// .develop/seeder-specs/ parses cleanly against the current SeederSpec schema.
+// Catches schema drift: if the SeederSpec struct changes in a way that breaks
+// existing specs, this test fails before capmon pipelines break silently.
 func TestSeederSpecs_AllLoad(t *testing.T) {
 	specsDir := filepath.Join("..", "..", "..", ".develop", "seeder-specs")
 	entries, err := os.ReadDir(specsDir)
@@ -59,4 +62,71 @@ func TestSeederSpecs_AllLoad(t *testing.T) {
 		t.Fatalf("no seeder specs found in %s", specsDir)
 	}
 	t.Logf("loaded %d seeder specs cleanly", loaded)
+}
+
+// TestDeriveOutputMatchesCommitted is the drift gate for committed
+// docs/provider-capabilities/<slug>-<content_type>.yaml files. For every
+// provider format doc, it runs DeriveSeederSpecs and compares the marshalled
+// output byte-for-byte against the committed file. A non-zero diff means
+// committed YAMLs have drifted from what derive currently produces — every
+// downstream PR would carry the diff as incidental noise.
+//
+// This test was added to lock in the per-content-type fix from the derive.go
+// refactor so future regressions surface immediately instead of polluting
+// capmon-process PRs.
+func TestDeriveOutputMatchesCommitted(t *testing.T) {
+	repoRoot := filepath.Join("..", "..", "..")
+	formatsDir := filepath.Join(repoRoot, "docs", "provider-formats")
+	capsDir := filepath.Join(repoRoot, "docs", "provider-capabilities")
+	canonicalKeysPath := filepath.Join(repoRoot, "docs", "spec", "canonical-keys.yaml")
+
+	entries, err := os.ReadDir(formatsDir)
+	if err != nil {
+		t.Fatalf("read formats dir %s: %v", formatsDir, err)
+	}
+
+	checked := 0
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+		provider := strings.TrimSuffix(e.Name(), ".yaml")
+
+		doc, err := capmon.LoadFormatDoc(filepath.Join(formatsDir, e.Name()))
+		if err != nil {
+			t.Errorf("%s: load format doc: %v", provider, err)
+			continue
+		}
+
+		specs, err := capmon.DeriveSeederSpecs(doc, canonicalKeysPath)
+		if err != nil {
+			t.Errorf("%s: derive specs: %v", provider, err)
+			continue
+		}
+
+		for _, spec := range specs {
+			gotBytes, err := yaml.Marshal(spec)
+			if err != nil {
+				t.Errorf("%s/%s: marshal spec: %v", provider, spec.ContentType, err)
+				continue
+			}
+
+			committedPath := capmon.SeederSpecPath(capsDir, provider, spec.ContentType)
+			wantBytes, err := os.ReadFile(committedPath)
+			if err != nil {
+				t.Errorf("%s/%s: read committed %s: %v", provider, spec.ContentType, committedPath, err)
+				continue
+			}
+
+			if !bytes.Equal(gotBytes, wantBytes) {
+				t.Errorf("%s/%s: drift detected — derive output does not match committed %s\nRun: syllago capmon derive --provider=%s --output-dir docs/provider-capabilities", provider, spec.ContentType, committedPath, provider)
+			}
+			checked++
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no provider/content_type pairs checked — formatsDir empty or all derives failed")
+	}
+	t.Logf("verified %d (provider, content_type) pairs match committed bytes", checked)
 }

--- a/docs/provider-capabilities/amp-hooks.yaml
+++ b/docs/provider-capabilities/amp-hooks.yaml
@@ -1,0 +1,58 @@
+provider: amp
+content_type: hooks
+format: ""
+proposed_mappings:
+    - canonical_key: async_execution
+      supported: false
+      mechanism: Amp hooks run synchronously; no async execution documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: context_injection
+      supported: false
+      mechanism: Amp hooks cannot inject context into the agent session beyond the pre-execute 'send-user-message' action that cancels the tool call
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: decision_control
+      supported: true
+      mechanism: Pre-execute 'send-user-message' action cancels the pending tool call and injects a user message; exit code 0 = allow, non-zero = block
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: handler_types
+      supported: true
+      mechanism: 'command-only: hook ''action'' field runs a shell command; no HTTP, LLM, or agent handler types documented'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: hook_scopes
+      supported: false
+      mechanism: 'Project only: hooks live in a single ''amp.hooks'' array inside ''.amp/settings.json'' (or user-scope settings); no multi-scope layering documented'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: input_modification
+      supported: false
+      mechanism: Amp hooks cannot modify tool input before execution; only substring match and cancel-with-message are documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: json_io_protocol
+      supported: false
+      mechanism: Amp hooks signal decisions via exit codes and declarative action types; no JSON stdin/stdout protocol documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: matcher_patterns
+      supported: true
+      mechanism: Amp hooks filter firing via 'input.contains' — exact literal substring match against tool input
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: permission_control
+      supported: true
+      mechanism: 'permissions_system: Amp has a permissions system that hooks interact with to make tool availability decisions'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/amp-mcp.yaml
+++ b/docs/provider-capabilities/amp-mcp.yaml
@@ -1,0 +1,52 @@
+provider: amp
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: false
+      mechanism: Amp does not document pre-configured auto-approval for specific MCP tools separate from tool filtering
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: enterprise_management
+      supported: true
+      mechanism: 'enterprise_registry_allowlist: Amp supports organization-level MCP configuration with an enterprise registry and allowlist'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: env_var_expansion
+      supported: false
+      mechanism: Amp MCP configuration does not document environment variable expansion
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: marketplace
+      supported: false
+      mechanism: Amp does not have an in-IDE MCP marketplace
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: oauth_support
+      supported: true
+      mechanism: 'oauth_support: Amp supports OAuth 2.0 authentication for remote MCP servers'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: resource_referencing
+      supported: false
+      mechanism: Amp does not document MCP resource referencing
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_filtering
+      supported: true
+      mechanism: 'per_tool_enable_disable: Amp supports per-tool enable/disable configuration to control which MCP tools are exposed to the agent'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: transport_types
+      supported: false
+      mechanism: Amp MCP transport types not documented beyond basic MCP support
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/amp-rules.yaml
+++ b/docs/provider-capabilities/amp-rules.yaml
@@ -1,0 +1,34 @@
+provider: amp
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: false
+      mechanism: Amp rule files load unconditionally; no conditional or model-decision activation documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: auto_memory
+      supported: false
+      mechanism: Amp does not have an AI-generated auto-memory system
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: cross_provider_recognition
+      supported: false
+      mechanism: Amp reads its own rule format; no cross-provider rule file recognition documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: file_imports
+      supported: false
+      mechanism: No file import syntax documented for Amp rule files
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hierarchical_loading
+      supported: false
+      mechanism: Amp rule files are project-scoped; no subdirectory hierarchy documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/amp-skills.yaml
+++ b/docs/provider-capabilities/amp-skills.yaml
@@ -25,7 +25,7 @@ proposed_mappings:
       mechanism: not documented — no mechanism to prevent the model from auto-invoking a skill; the model always selects based on name and description match
       source_field: ""
       source_value: ""
-      confidence: unknown
+      confidence: confirmed
     - canonical_key: display_name
       supported: true
       mechanism: 'yaml frontmatter key: name (required)'
@@ -49,10 +49,10 @@ proposed_mappings:
       mechanism: not documented — only project-scope (.agents/skills/) and user-wide (~/.config/agents/skills/) are described; no enterprise or shared scope exists
       source_field: ""
       source_value: ""
-      confidence: unknown
+      confidence: confirmed
     - canonical_key: user_invocable
       supported: false
       mechanism: not documented — no mechanism to hide skills from user-facing menus is described; skills are managed via 'amp skill' CLI and command palette, not a slash-command invocation menu
       source_field: ""
       source_value: ""
-      confidence: unknown
+      confidence: confirmed

--- a/docs/provider-capabilities/claude-code-agents.yaml
+++ b/docs/provider-capabilities/claude-code-agents.yaml
@@ -1,0 +1,46 @@
+provider: claude-code
+content_type: agents
+format: ""
+proposed_mappings:
+    - canonical_key: agent_scopes
+      supported: true
+      mechanism: '5 scopes (highest-first): managed settings (org-wide), CLI --agents flag (session), project (.claude/agents/), user (~/.claude/agents/), plugin; highest-priority wins on name collision'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: definition_format
+      supported: true
+      mechanism: Markdown files with YAML frontmatter in .claude/agents/ (project) or ~/.claude/agents/ (user); file body becomes system prompt
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: invocation_patterns
+      supported: true
+      mechanism: natural language (Claude auto-delegates), @agent-<name> @-mention, or --agent flag at startup for session-wide agent; 3 patterns
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: model_selection
+      supported: true
+      mechanism: model frontmatter field accepts sonnet/opus/haiku alias, full model ID, or inherit (default); per-agent override
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: per_agent_mcp
+      supported: true
+      mechanism: 'mcpServers frontmatter field: list of server names referencing already-configured workspace servers or inline server definitions'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: subagent_spawning
+      supported: true
+      mechanism: main-thread agents spawn subagents via Agent tool; subagents cannot spawn further subagents; Agent(type) in tools allowlist restricts which subagent types are allowed
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: tool_restrictions
+      supported: true
+      mechanism: tools allowlist and disallowedTools denylist in frontmatter; Agent(type) syntax restricts which subagent types a main-thread agent can spawn
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/claude-code-commands.yaml
+++ b/docs/provider-capabilities/claude-code-commands.yaml
@@ -1,0 +1,16 @@
+provider: claude-code
+content_type: commands
+format: ""
+proposed_mappings:
+    - canonical_key: argument_substitution
+      supported: true
+      mechanism: $ARGUMENTS (all args), $ARGUMENTS[N] (Nth arg), $N (positional), ${CLAUDE_SESSION_ID} and other env vars; shared with skills argument substitution
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: builtin_commands
+      supported: true
+      mechanism: extensive set of built-in slash commands (/help, /clear, /compact, /config, /model, /mcp, /memory, /plan, etc.) plus bundled-skill commands (/batch, /debug, /loop); not user-modifiable
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/claude-code-hooks.yaml
+++ b/docs/provider-capabilities/claude-code-hooks.yaml
@@ -1,0 +1,58 @@
+provider: claude-code
+content_type: hooks
+format: ""
+proposed_mappings:
+    - canonical_key: async_execution
+      supported: true
+      mechanism: 'hook_async_execution: async: true on command handlers runs hook in background without blocking; decisions ignored; systemMessage delivered on next turn'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: context_injection
+      supported: true
+      mechanism: Hooks return systemMessage field in JSON output to inject context into agent's active session
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: decision_control
+      supported: true
+      mechanism: 'block: exit code 2 or decision=block; allow: permissionDecision=allow in hookSpecificOutput; modify: updatedInput replaces tool input before execution'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: handler_types
+      supported: true
+      mechanism: 'Four types: command (shell), http (POST to URL), prompt (LLM evaluation), agent (subagent with tools); prompt/agent restricted to subset of events'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: hook_scopes
+      supported: true
+      mechanism: 'Six scopes: user (~/.claude/settings.json), project (.claude/settings.json), local (.claude/settings.local.json), managed policy, plugin (hooks/hooks.json), component frontmatter'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: input_modification
+      supported: true
+      mechanism: 'hook_input_modification: PreToolUse returns updatedInput in hookSpecificOutput; entire input object replaced; compatible with all permissionDecision values except defer'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: json_io_protocol
+      supported: true
+      mechanism: 'Command hooks receive event JSON on stdin; respond with JSON on stdout (exit 0); structured fields: continue, stopReason, suppressOutput, systemMessage, hookSpecificOutput'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: matcher_patterns
+      supported: true
+      mechanism: 'hook_matcher_patterns: exact string, pipe-separated list, or JavaScript regex; matches on tool_name or event-specific fields'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: permission_control
+      supported: true
+      mechanism: 'hook_permission_update_entries: PermissionRequest hooks return updatedPermissions with addRules/replaceRules/removeRules/setMode entries'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/claude-code-mcp.yaml
+++ b/docs/provider-capabilities/claude-code-mcp.yaml
@@ -1,0 +1,52 @@
+provider: claude-code
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: false
+      mechanism: Claude Code does not support pre-configured auto-approval for specific MCP tools; all tool calls require user confirmation unless covered by session permission rules
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: enterprise_management
+      supported: true
+      mechanism: 'mcp_managed_config: managed-mcp.json for exclusive control, or allowedMcpServers/deniedMcpServers in managed settings for policy-based control'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: env_var_expansion
+      supported: true
+      mechanism: 'mcp_env_var_expansion: ${VAR} and ${VAR:-default} syntax in command, args, env, url, and headers fields of .mcp.json'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: marketplace
+      supported: false
+      mechanism: Claude Code does not have an in-IDE MCP marketplace for discovery and installation
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: oauth_support
+      supported: true
+      mechanism: 'mcp_oauth_authentication: OAuth 2.0 for HTTP MCP servers; dynamic client registration; token storage in macOS keychain or credentials file; auto-refresh'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: resource_referencing
+      supported: true
+      mechanism: 'mcp_resources: MCP resources accessible via @server:protocol://path syntax; appear in @ autocomplete; auto-fetched when referenced'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: tool_filtering
+      supported: false
+      mechanism: Claude Code exposes all tools from connected MCP servers; no per-server tool allowlist or blocklist for individual tool visibility
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: transport_types
+      supported: true
+      mechanism: 'mcp_transport_types: stdio (local process), SSE (deprecated, still supported), HTTP/streamable-HTTP (recommended for remote)'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/claude-code-rules.yaml
+++ b/docs/provider-capabilities/claude-code-rules.yaml
@@ -1,0 +1,34 @@
+provider: claude-code
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: true
+      mechanism: Always-on (CLAUDE.md loads at every session start); conditional via paths frontmatter in .claude/rules/*.md files (glob-based, triggers on file access)
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: auto_memory
+      supported: true
+      mechanism: Auto memory saves Claude's accumulated notes to ~/.claude/projects/<project>/memory/MEMORY.md; requires CC v2.1.59+; enabled by default
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: cross_provider_recognition
+      supported: false
+      mechanism: Claude Code does not natively read rule files defined by other providers
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: file_imports
+      supported: true
+      mechanism: '@path/to/file syntax in CLAUDE.md files; relative and absolute paths; recursive up to 5 hops; requires per-project approval'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: hierarchical_loading
+      supported: true
+      mechanism: CLAUDE.md files load from all ancestor directories up to repo root; .claude/rules/ files discovered recursively; user-level rules load before project rules
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/cline-commands.yaml
+++ b/docs/provider-capabilities/cline-commands.yaml
@@ -1,0 +1,16 @@
+provider: cline
+content_type: commands
+format: ""
+proposed_mappings:
+    - canonical_key: argument_substitution
+      supported: false
+      mechanism: Workflow markdown files are plain prompt templates with no documented argument-substitution placeholder (no {{args}} or equivalent)
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: builtin_commands
+      supported: true
+      mechanism: Built-in slash commands (e.g., /newtask, /smol alias /compact, /newrule, /deep-planning, /explain-changes in VS Code, /reportbug) are hardcoded and not user-modifiable; user-authored workflows are additive, invoked alongside built-ins
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/cline-hooks.yaml
+++ b/docs/provider-capabilities/cline-hooks.yaml
@@ -1,0 +1,58 @@
+provider: cline
+content_type: hooks
+format: ""
+proposed_mappings:
+    - canonical_key: async_execution
+      supported: false
+      mechanism: Cline hooks run synchronously before/after tool events; no async execution documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: context_injection
+      supported: true
+      mechanism: 'context_modification_output: Cline hooks can inject additional context into the agent''s session via hook output'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: decision_control
+      supported: true
+      mechanism: 'pre_tool_use_cancellation: PreToolUse hooks can cancel (block) the tool invocation; no allow or modify sub-capabilities documented'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: handler_types
+      supported: false
+      mechanism: Cline hooks execute shell commands only; no HTTP, LLM prompt, or agent handler types documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hook_scopes
+      supported: true
+      mechanism: 'global_and_project_hooks: Cline supports global (user-wide) and project-level hook configuration'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: input_modification
+      supported: true
+      mechanism: 'context_modification_output: Cline PreToolUse hooks can return modified context/input before tool execution'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: json_io_protocol
+      supported: false
+      mechanism: Cline hooks communicate via exit codes and output text; no structured JSON stdin/stdout protocol documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: matcher_patterns
+      supported: false
+      mechanism: Cline hooks fire on configured lifecycle events; no per-tool pattern matching documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: permission_control
+      supported: false
+      mechanism: Cline hooks can cancel tool invocations (decision_control) but cannot grant/deny tool availability
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/cline-mcp.yaml
+++ b/docs/provider-capabilities/cline-mcp.yaml
@@ -1,0 +1,52 @@
+provider: cline
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: true
+      mechanism: 'always_allow_tools (execution-gating scope): Cline''s always_allow list suppresses per-invocation confirmation prompts for listed tools that are already visible'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: enterprise_management
+      supported: false
+      mechanism: Cline does not document organization-level MCP configuration management
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: env_var_expansion
+      supported: false
+      mechanism: Cline MCP configuration does not document environment variable expansion syntax
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: marketplace
+      supported: true
+      mechanism: 'mcp_marketplace: Cline has an in-IDE MCP server discovery and installation experience'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: oauth_support
+      supported: false
+      mechanism: Cline MCP does not document OAuth 2.0 authentication for remote servers
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: resource_referencing
+      supported: false
+      mechanism: Cline does not document @-mention or equivalent access to MCP resources
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_filtering
+      supported: true
+      mechanism: 'always_allow_tools (visibility scope): Cline''s always_allow list controls which MCP tools are exposed in the agent''s available tool set without per-invocation prompts'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: transport_types
+      supported: true
+      mechanism: 'sse_transport_support: Cline supports SSE transport alongside stdio; HTTP transport support follows MCP protocol adoption'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/cline-rules.yaml
+++ b/docs/provider-capabilities/cline-rules.yaml
@@ -1,0 +1,34 @@
+provider: cline
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: true
+      mechanism: 'conditional_rules_paths: Cline supports path-conditional rules alongside always-on rules; conditions use glob patterns'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: auto_memory
+      supported: false
+      mechanism: Cline does not have an AI-generated auto-memory system distinct from user-authored rules
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: cross_provider_recognition
+      supported: true
+      mechanism: 'multi_source_rule_detection: Cline reads .clinerules/, .cursorrules, CLAUDE.md, and other provider rule files automatically'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: file_imports
+      supported: false
+      mechanism: No file import/include syntax documented for Cline rule files
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hierarchical_loading
+      supported: false
+      mechanism: Cline rules are project-scoped or global; no per-subdirectory loading hierarchy documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/cline-skills.yaml
+++ b/docs/provider-capabilities/cline-skills.yaml
@@ -25,7 +25,7 @@ proposed_mappings:
       mechanism: ""
       source_field: ""
       source_value: ""
-      confidence: unknown
+      confidence: confirmed
     - canonical_key: display_name
       supported: true
       mechanism: 'yaml frontmatter key: name (required) — must exactly match the directory name'
@@ -49,10 +49,10 @@ proposed_mappings:
       mechanism: ""
       source_field: ""
       source_value: ""
-      confidence: unknown
+      confidence: confirmed
     - canonical_key: user_invocable
       supported: false
       mechanism: ""
       source_field: ""
       source_value: ""
-      confidence: unknown
+      confidence: confirmed

--- a/docs/provider-capabilities/codex-agents.yaml
+++ b/docs/provider-capabilities/codex-agents.yaml
@@ -1,0 +1,46 @@
+provider: codex
+content_type: agents
+format: ""
+proposed_mappings:
+    - canonical_key: agent_scopes
+      supported: true
+      mechanism: built-in roles always available; user-defined roles in config.toml [agents] section; user-defined roles override built-in roles of same name
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: definition_format
+      supported: true
+      mechanism: TOML role config files referenced from config.toml [agents] section; built-in roles (default/explorer/worker) always available without user config
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: invocation_patterns
+      supported: true
+      mechanism: spawn-agent tool at LLM discretion; LLM selects role from dynamically-built role descriptions combining built-in and user-defined roles
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: model_selection
+      supported: true
+      mechanism: role config_file can override model and model_reasoning_effort; caller's current profile and model_provider preserved unless explicitly overridden
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: per_agent_mcp
+      supported: false
+      mechanism: MCP configuration is workspace-wide; no per-role MCP scoping mechanism
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: subagent_spawning
+      supported: true
+      mechanism: multi-agent V2 feature flag; max_threads controls concurrent agent count, max_depth controls nesting depth; spawn-agent tool initiates delegation
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: tool_restrictions
+      supported: false
+      mechanism: role config layers override model/settings but no explicit tool allowlist or denylist in role definitions
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/codex-commands.yaml
+++ b/docs/provider-capabilities/codex-commands.yaml
@@ -1,0 +1,16 @@
+provider: codex
+content_type: commands
+format: ""
+proposed_mappings:
+    - canonical_key: argument_substitution
+      supported: false
+      mechanism: no implementation details captured; only source is a redirect stub to external docs — cannot confirm argument substitution support
+      source_field: ""
+      source_value: ""
+      confidence: unknown
+    - canonical_key: builtin_commands
+      supported: false
+      mechanism: no implementation details captured; slash commands feature exists but format and capabilities are undocumented in cached sources
+      source_field: ""
+      source_value: ""
+      confidence: unknown

--- a/docs/provider-capabilities/codex-hooks.yaml
+++ b/docs/provider-capabilities/codex-hooks.yaml
@@ -1,0 +1,58 @@
+provider: codex
+content_type: hooks
+format: ""
+proposed_mappings:
+    - canonical_key: async_execution
+      supported: true
+      mechanism: 'hook_execution_mode: Codex supports async hook execution mode for fire-and-forget background hook runs'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: context_injection
+      supported: true
+      mechanism: 'hook_system_message: Codex hooks can inject a system message into the agent''s active session context'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: decision_control
+      supported: true
+      mechanism: 'hook_result_abort: Codex hooks can abort (block) the triggering action; allow and modify sub-capabilities documented via hook result schema'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: handler_types
+      supported: true
+      mechanism: 'hook_handler_types: Codex supports shell command and LLM prompt handler types; TypeScript extension type also documented'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: hook_scopes
+      supported: true
+      mechanism: 'hook_scope: Codex hooks can be scoped to global/user or project configuration'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: input_modification
+      supported: true
+      mechanism: 'hook_updated_input: Codex PreToolUse hooks return modified input arguments that replace the original tool input'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: json_io_protocol
+      supported: false
+      mechanism: Codex hooks communicate via exit codes and stdout text; no structured JSON stdin/stdout protocol documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: matcher_patterns
+      supported: true
+      mechanism: 'hook_matcher: Codex hooks support pattern matching to filter which tools or events trigger the hook'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: permission_control
+      supported: true
+      mechanism: 'hook_permission_decision: Codex hooks can return permission decisions that grant or deny tool availability'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/codex-mcp.yaml
+++ b/docs/provider-capabilities/codex-mcp.yaml
@@ -1,0 +1,52 @@
+provider: codex
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: true
+      mechanism: 'mcp_per_tool_approval: Codex supports per-tool approval configuration to suppress confirmation prompts for trusted tools'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: enterprise_management
+      supported: false
+      mechanism: Codex does not document organization-level MCP management
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: env_var_expansion
+      supported: false
+      mechanism: Codex MCP configuration does not document environment variable expansion
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: marketplace
+      supported: false
+      mechanism: Codex does not have an in-IDE MCP marketplace
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: oauth_support
+      supported: true
+      mechanism: 'mcp_oauth_support: Codex supports OAuth 2.0 authentication for remote MCP servers'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: resource_referencing
+      supported: false
+      mechanism: Codex does not document MCP resource referencing
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_filtering
+      supported: true
+      mechanism: 'mcp_enabled_disabled_tools: Codex supports per-server tool enable/disable configuration controlling which tools are exposed to the agent'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: transport_types
+      supported: false
+      mechanism: Codex MCP transport types not documented beyond basic MCP support; likely stdio only
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/codex-rules.yaml
+++ b/docs/provider-capabilities/codex-rules.yaml
@@ -1,0 +1,34 @@
+provider: codex
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: false
+      mechanism: Codex AGENTS.md files load unconditionally; no conditional or model-decision activation documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: auto_memory
+      supported: false
+      mechanism: Codex does not have an AI-generated auto-memory system
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: cross_provider_recognition
+      supported: true
+      mechanism: 'agents_md_filename: Codex reads AGENTS.md files using the standard filename used by multiple providers'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: file_imports
+      supported: false
+      mechanism: No file import syntax documented for Codex AGENTS.md files
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hierarchical_loading
+      supported: true
+      mechanism: 'hierarchical_agents_md: Codex loads AGENTS.md from subdirectories with defined precedence (deeper overrides higher)'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/codex-skills.yaml
+++ b/docs/provider-capabilities/codex-skills.yaml
@@ -49,4 +49,4 @@ proposed_mappings:
       mechanism: ""
       source_field: ""
       source_value: ""
-      confidence: unknown
+      confidence: confirmed

--- a/docs/provider-capabilities/copilot-cli-agents.yaml
+++ b/docs/provider-capabilities/copilot-cli-agents.yaml
@@ -1,0 +1,46 @@
+provider: copilot-cli
+content_type: agents
+format: ""
+proposed_mappings:
+    - canonical_key: agent_scopes
+      supported: true
+      mechanism: project scope (.github/agents/ or .claude/agents/), personal (~/.copilot/agents/), plugin (agents/); personal takes precedence over project
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: definition_format
+      supported: true
+      mechanism: .agent.md files with YAML frontmatter (description required); up to 30,000 chars of Markdown instructions as agent system prompt
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: invocation_patterns
+      supported: true
+      mechanism: /agent slash command, natural language instruction, auto-inference (suppressible with disable-model-invocation), or --agent flag; 4 patterns
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: model_selection
+      supported: true
+      mechanism: model field in frontmatter overrides default model for that agent
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: per_agent_mcp
+      supported: true
+      mechanism: mcp-servers inline config in frontmatter; available for cloud agent only; workspace MCP config shared by default
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: subagent_spawning
+      supported: true
+      mechanism: agents run as subagents with isolated context windows; Git-SHA-based versioning ensures consistency across PR interactions
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: tool_restrictions
+      supported: true
+      mechanism: tools field with cross-provider alias system (execute/shell/Bash, read/Read, edit/Edit, etc.); ["*"] grants all tools; unrecognized names silently ignored
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/copilot-cli-commands.yaml
+++ b/docs/provider-capabilities/copilot-cli-commands.yaml
@@ -1,0 +1,16 @@
+provider: copilot-cli
+content_type: commands
+format: ""
+proposed_mappings:
+    - canonical_key: argument_substitution
+      supported: false
+      mechanism: command file format undocumented; no evidence of argument substitution in plugin.json schema or available sources
+      source_field: ""
+      source_value: ""
+      confidence: unknown
+    - canonical_key: builtin_commands
+      supported: false
+      mechanism: Copilot CLI has no standalone slash-command mechanism; extensibility is via plugins that bundle agents/skills/hooks; command format within plugins is undocumented
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/copilot-cli-hooks.yaml
+++ b/docs/provider-capabilities/copilot-cli-hooks.yaml
@@ -1,0 +1,58 @@
+provider: copilot-cli
+content_type: hooks
+format: ""
+proposed_mappings:
+    - canonical_key: async_execution
+      supported: false
+      mechanism: Copilot CLI hooks run synchronously; no async execution documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: context_injection
+      supported: false
+      mechanism: Copilot CLI hooks cannot inject context into the agent session
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: decision_control
+      supported: true
+      mechanism: 'pre_tool_use_deny: Copilot CLI PreToolUse hooks can deny (block) the tool invocation; no allow or modify documented'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: handler_types
+      supported: false
+      mechanism: Copilot CLI hooks execute shell commands only; no HTTP, LLM prompt, or agent handler types documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hook_scopes
+      supported: false
+      mechanism: Copilot CLI hooks are configured at a single scope level; no multi-scope configuration documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: input_modification
+      supported: false
+      mechanism: Copilot CLI hooks cannot modify tool input before execution
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: json_io_protocol
+      supported: false
+      mechanism: Copilot CLI hooks communicate via exit codes; no JSON stdin/stdout protocol documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: matcher_patterns
+      supported: false
+      mechanism: Copilot CLI hooks fire on all events of their configured type; no per-tool filtering documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: permission_control
+      supported: false
+      mechanism: Copilot CLI hooks can deny tool invocations (decision_control) but do not govern tool availability
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/copilot-cli-mcp.yaml
+++ b/docs/provider-capabilities/copilot-cli-mcp.yaml
@@ -1,0 +1,52 @@
+provider: copilot-cli
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: false
+      mechanism: Copilot CLI does not document pre-configured auto-approval for MCP tools
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: enterprise_management
+      supported: false
+      mechanism: Copilot CLI does not document organization-level MCP management
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: env_var_expansion
+      supported: false
+      mechanism: Copilot CLI MCP configuration does not document environment variable expansion
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: marketplace
+      supported: false
+      mechanism: Copilot CLI does not have an in-IDE MCP marketplace
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: oauth_support
+      supported: false
+      mechanism: Copilot CLI MCP does not document OAuth 2.0 authentication
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: resource_referencing
+      supported: false
+      mechanism: Copilot CLI does not document MCP resource referencing
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_filtering
+      supported: true
+      mechanism: 'mcp_tool_allow_deny_flags: Copilot CLI supports per-tool allow and deny flags to control which MCP tools are exposed'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: transport_types
+      supported: false
+      mechanism: Copilot CLI MCP transport types not documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/copilot-cli-rules.yaml
+++ b/docs/provider-capabilities/copilot-cli-rules.yaml
@@ -1,0 +1,34 @@
+provider: copilot-cli
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: false
+      mechanism: Copilot CLI rules load unconditionally at session start; no conditional or manual activation modes documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: auto_memory
+      supported: false
+      mechanism: Copilot CLI does not have an AI-generated persistent memory system for rules
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: cross_provider_recognition
+      supported: true
+      mechanism: 'agents_md_instructions: Copilot CLI reads AGENTS.md files following the multi-provider shared format'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: file_imports
+      supported: false
+      mechanism: No @-import or file inclusion syntax documented for Copilot CLI rule files
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hierarchical_loading
+      supported: true
+      mechanism: Copilot CLI supports repo-wide instructions plus path-specific and personal instruction layers with defined precedence
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/copilot-cli-skills.yaml
+++ b/docs/provider-capabilities/copilot-cli-skills.yaml
@@ -7,31 +7,31 @@ proposed_mappings:
       mechanism: SKILL.md (fixed filename per Agent Skills open standard)
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: custom_filename
       supported: false
       mechanism: not observed — Agent Skills standard uses fixed SKILL.md filename
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: description
       supported: true
       mechanism: 'yaml frontmatter key: description (required per Agent Skills open standard)'
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: disable_model_invocation
       supported: false
       mechanism: ""
       source_field: ""
       source_value: ""
-      confidence: unknown
+      confidence: confirmed
     - canonical_key: display_name
       supported: true
       mechanism: 'yaml frontmatter key: name (required per Agent Skills open standard)'
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: global_scope
       supported: true
       mechanism: skill directory under ~/.copilot/skills/<name>/, ~/.claude/skills/<name>/, or ~/.agents/skills/<name>/

--- a/docs/provider-capabilities/crush-mcp.yaml
+++ b/docs/provider-capabilities/crush-mcp.yaml
@@ -1,0 +1,52 @@
+provider: crush
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: false
+      mechanism: Crush does not document pre-configured auto-approval for specific MCP tools
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: enterprise_management
+      supported: false
+      mechanism: Crush does not document organization-level MCP management
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: env_var_expansion
+      supported: true
+      mechanism: 'env_variable_expansion: Crush MCP configuration supports environment variable references in server env blocks'
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: marketplace
+      supported: false
+      mechanism: Crush does not have an in-app MCP marketplace
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: oauth_support
+      supported: false
+      mechanism: Crush MCP does not document OAuth 2.0 authentication for remote servers
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: resource_referencing
+      supported: false
+      mechanism: MCP resource referencing (as distinct from tool calls) not documented in Crush
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_filtering
+      supported: false
+      mechanism: Per-server tool allow/block list not documented in the Crush MCP schema
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: transport_types
+      supported: true
+      mechanism: 'transport_types: Crush documents stdio, http, and sse transports in its JSON schema for MCP server configuration'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/crush-rules.yaml
+++ b/docs/provider-capabilities/crush-rules.yaml
@@ -1,0 +1,34 @@
+provider: crush
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: false
+      mechanism: Crush rule files (AGENTS.md) load unconditionally as project context; no conditional activation syntax documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: auto_memory
+      supported: false
+      mechanism: No runtime memory/append command documented for Crush rule files
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: cross_provider_recognition
+      supported: true
+      mechanism: 'cross_provider_convention: Crush reads AGENTS.md, the cross-provider rules convention shared across multiple agents'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: file_imports
+      supported: false
+      mechanism: No file import directive documented for AGENTS.md in Crush
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hierarchical_loading
+      supported: false
+      mechanism: Crush documents AGENTS.md at the project root only; no hierarchical/subdirectory loading documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/crush-skills.yaml
+++ b/docs/provider-capabilities/crush-skills.yaml
@@ -1,46 +1,46 @@
-provider: gemini-cli
+provider: crush
 content_type: skills
 format: ""
 proposed_mappings:
     - canonical_key: canonical_filename
       supported: true
-      mechanism: SKILL.md (required, fixed name)
+      mechanism: SKILL.md (required, fixed name per the Agent Skills standard)
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: custom_filename
       supported: false
-      mechanism: not observed — filename is fixed as SKILL.md
+      mechanism: filename is fixed as SKILL.md per the Agent Skills standard
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: description
       supported: true
-      mechanism: 'yaml frontmatter key: description (required); documents what the skill does and when Gemini should use it — drives auto-invocation decisions'
+      mechanism: 'yaml frontmatter key: description (required); documents what the skill does and when Crush should invoke it'
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: disable_model_invocation
-      supported: false
-      mechanism: ""
+      supported: true
+      mechanism: 'yaml frontmatter key: disable-model-invocation (optional boolean) per the Agent Skills standard'
       source_field: ""
       source_value: ""
-      confidence: confirmed
+      confidence: inferred
     - canonical_key: display_name
       supported: true
-      mechanism: 'yaml frontmatter key: name (required); value should match the skill''s directory name'
+      mechanism: 'yaml frontmatter key: name (required); follows the Anthropic Agent Skills standard'
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: global_scope
       supported: true
-      mechanism: ~/.gemini/skills/<name>/SKILL.md
+      mechanism: ~/.config/crush/skills/<name>/SKILL.md (XDG-compliant native path) and ~/.agents/skills/<name>/SKILL.md (cross-provider convention)
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: project_scope
       supported: true
-      mechanism: .gemini/skills/<name>/SKILL.md
+      mechanism: .crush/skills/<name>/SKILL.md (native) and .agents/skills/<name>/SKILL.md (cross-provider convention)
       source_field: ""
       source_value: ""
       confidence: confirmed
@@ -49,10 +49,10 @@ proposed_mappings:
       mechanism: ""
       source_field: ""
       source_value: ""
-      confidence: confirmed
+      confidence: inferred
     - canonical_key: user_invocable
       supported: false
       mechanism: ""
       source_field: ""
       source_value: ""
-      confidence: confirmed
+      confidence: inferred

--- a/docs/provider-capabilities/cursor-agents.yaml
+++ b/docs/provider-capabilities/cursor-agents.yaml
@@ -1,0 +1,46 @@
+provider: cursor
+content_type: agents
+format: ""
+proposed_mappings:
+    - canonical_key: agent_scopes
+      supported: true
+      mechanism: 'Two scopes: project (.cursor/agents/) and user-global (~/.cursor/agents/).'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: definition_format
+      supported: true
+      mechanism: Markdown files with YAML frontmatter in .cursor/agents/ (project) or ~/.cursor/agents/ (user); the frontmatter declares name, description, model, readonly, and is_background, and the Markdown body becomes the agent's system prompt.
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: invocation_patterns
+      supported: true
+      mechanism: Custom agents are invoked through the Cursor IDE agent picker; background-enabled agents can also run concurrently via the background agents UI.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: model_selection
+      supported: true
+      mechanism: model frontmatter field selects a specific model for the agent, overriding the session default.
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: per_agent_mcp
+      supported: false
+      mechanism: Cursor custom agents do not document a per-agent mcpServers field; they inherit the workspace MCP configuration.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: subagent_spawning
+      supported: false
+      mechanism: Cursor custom agent files do not document spawning additional subagents from a user-defined agent; the three built-in subagents (Explore, Bash, Browser) are harness-provided, not file-overridable.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_restrictions
+      supported: true
+      mechanism: readonly frontmatter flag restricts an agent to read-only tools; fine-grained per-tool allow/deny lists are not documented.
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/cursor-hooks.yaml
+++ b/docs/provider-capabilities/cursor-hooks.yaml
@@ -1,0 +1,58 @@
+provider: cursor
+content_type: hooks
+format: ""
+proposed_mappings:
+    - canonical_key: async_execution
+      supported: false
+      mechanism: Hooks run synchronously; no async/background flag documented.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: context_injection
+      supported: false
+      mechanism: Cursor hooks do not document a mechanism to inject additional context into the agent session.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: decision_control
+      supported: true
+      mechanism: 'Exit codes drive decisions: non-zero blocks the action and surfaces stderr, zero allows it to proceed; JSON on stdout can also return structured decision fields.'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: handler_types
+      supported: false
+      mechanism: 'Cursor hooks execute shell commands only (type: command); no HTTP, LLM prompt, or agent handler types documented.'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: hook_scopes
+      supported: true
+      mechanism: Project-scope hooks live under .cursor/hooks/ and are wired through .cursor/settings.json; user-global hooks live under ~/.cursor/ using the same shape.
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: input_modification
+      supported: false
+      mechanism: Cursor hooks are not documented to rewrite tool input before execution.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: json_io_protocol
+      supported: true
+      mechanism: Command hooks receive event data as JSON on stdin and may return structured JSON on stdout to signal decisions and supply output fields.
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: matcher_patterns
+      supported: true
+      mechanism: Hook entries accept a matcher string that filters which tool or event fires the hook (for example a specific shell command or tool name).
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: permission_control
+      supported: false
+      mechanism: Cursor hooks control allow/block via exit codes but do not govern tool availability through permission rule updates.
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/cursor-mcp.yaml
+++ b/docs/provider-capabilities/cursor-mcp.yaml
@@ -1,0 +1,52 @@
+provider: cursor
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: false
+      mechanism: Cursor does not document pre-configured auto-approval for specific MCP tools.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: enterprise_management
+      supported: false
+      mechanism: Cursor does not document organization-level managed MCP policy controls.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: env_var_expansion
+      supported: true
+      mechanism: Server env blocks reference environment variables so secrets can be read from the shell environment rather than hardcoded.
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: marketplace
+      supported: true
+      mechanism: Cursor ships an in-IDE MCP directory for discovering and installing community MCP servers.
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: oauth_support
+      supported: false
+      mechanism: Cursor's MCP documentation does not describe OAuth 2.0 flows for remote servers.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: resource_referencing
+      supported: false
+      mechanism: Cursor's MCP documentation does not describe referencing MCP resources by URI.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_filtering
+      supported: false
+      mechanism: Cursor does not document per-server tool allowlists or blocklists for MCP servers.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: transport_types
+      supported: true
+      mechanism: 'Cursor documents three MCP transports: stdio for local processes, sse for Server-Sent Events, and streamable-http for HTTP-based remote servers.'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/cursor-rules.yaml
+++ b/docs/provider-capabilities/cursor-rules.yaml
@@ -1,0 +1,34 @@
+provider: cursor
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: true
+      mechanism: 'Four activation modes documented: Always (alwaysApply: true injects rule into every prompt), Auto-Attached (globs frontmatter matches edited files), Agent Requested (description frontmatter triggers model to pull in the rule), and Manual (no frontmatter triggers, referenced explicitly with @ruleName).'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: auto_memory
+      supported: false
+      mechanism: Cursor does not document an AI-generated auto-memory system distinct from user-authored rules.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: cross_provider_recognition
+      supported: false
+      mechanism: Cursor reads its own .cursor/rules/*.mdc and legacy .cursorrules file; no documented recognition of other providers' rule files.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: file_imports
+      supported: true
+      mechanism: MDC rule bodies may reference other files via @path syntax that inlines the referenced file into the rule context.
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: hierarchical_loading
+      supported: true
+      mechanism: Rules can live in nested .cursor/rules/ directories within a project; rules in a subtree apply when working with files under that subtree, enabling monorepo-style scoping.
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/cursor-skills.yaml
+++ b/docs/provider-capabilities/cursor-skills.yaml
@@ -1,64 +1,64 @@
-provider: kiro
+provider: cursor
 content_type: skills
 format: ""
 proposed_mappings:
     - canonical_key: canonical_filename
       supported: true
-      mechanism: Fixed filename POWER.md (required, all caps)
+      mechanism: SKILL.md (required, fixed name per Agent Skills convention).
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: compatibility
       supported: true
-      mechanism: 'yaml frontmatter key: compatibility (optional)'
+      mechanism: 'yaml frontmatter key: compatibility (optional).'
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: custom_filename
       supported: false
-      mechanism: Not observed — POWER.md is fixed
+      mechanism: Not observed — the skill filename is fixed as SKILL.md.
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: description
       supported: true
-      mechanism: 'yaml frontmatter key: description (required)'
+      mechanism: 'yaml frontmatter key: description (required); documents what the skill does and when to use it.'
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: disable_model_invocation
-      supported: false
-      mechanism: ""
+      supported: true
+      mechanism: 'yaml frontmatter key: disable-model-invocation (optional bool, default false).'
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: display_name
       supported: true
-      mechanism: 'yaml frontmatter key: name (required, slug-style identifier)'
+      mechanism: 'yaml frontmatter key: name (required); matches the skill directory name per the Agent Skills convention.'
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: global_scope
-      supported: false
-      mechanism: ""
+      supported: true
+      mechanism: ~/.agents/skills/<name>/SKILL.md for user-global scope via the cross-provider Agent Skills convention.
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: license
       supported: true
-      mechanism: 'yaml frontmatter key: license (optional)'
+      mechanism: 'yaml frontmatter key: license (optional).'
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: metadata_map
       supported: true
-      mechanism: 'yaml frontmatter key: metadata (optional map)'
+      mechanism: 'yaml frontmatter key: metadata (optional map of arbitrary key/value pairs).'
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: project_scope
       supported: true
-      mechanism: Self-contained directory installed via Kiro Powers panel (UI installation, no fixed filesystem path)
+      mechanism: .cursor/skills/<name>/SKILL.md for Cursor-native project scope; .agents/skills/<name>/SKILL.md is also recognized via the cross-provider Agent Skills convention.
       source_field: ""
       source_value: ""
       confidence: confirmed
@@ -67,10 +67,10 @@ proposed_mappings:
       mechanism: ""
       source_field: ""
       source_value: ""
-      confidence: confirmed
+      confidence: inferred
     - canonical_key: user_invocable
       supported: false
       mechanism: ""
       source_field: ""
       source_value: ""
-      confidence: confirmed
+      confidence: inferred

--- a/docs/provider-capabilities/factory-droid-agents.yaml
+++ b/docs/provider-capabilities/factory-droid-agents.yaml
@@ -1,0 +1,46 @@
+provider: factory-droid
+content_type: agents
+format: ""
+proposed_mappings:
+    - canonical_key: agent_scopes
+      supported: true
+      mechanism: project (.factory/droids/) overrides personal (~/.factory/droids/) on name collision — reverse of skills precedence
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: definition_format
+      supported: true
+      mechanism: .md files in .factory/droids/ (project) or ~/.factory/droids/ (personal); single-file with system prompt, model preference, and tooling policy
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: invocation_patterns
+      supported: true
+      mechanism: exposed as subagent_type targets for the Task tool; droids enabled by default with live progress reporting in UI
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: model_selection
+      supported: true
+      mechanism: per-droid model preference field independent of global model setting; enables mixed-model agent compositions
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: per_agent_mcp
+      supported: false
+      mechanism: no per-droid MCP configuration documented; MCP is workspace-wide
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: subagent_spawning
+      supported: true
+      mechanism: droids exposed as subagent_type targets for Task tool delegation; /import-subagent converts Claude Code .claude/agents/*.md to droid format
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_restrictions
+      supported: true
+      mechanism: categorical tool policy using named categories (filesystem, shell, search, browser, web_fetch); differs from per-tool allowlists used by other providers
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/factory-droid-commands.yaml
+++ b/docs/provider-capabilities/factory-droid-commands.yaml
@@ -1,0 +1,16 @@
+provider: factory-droid
+content_type: commands
+format: ""
+proposed_mappings:
+    - canonical_key: argument_substitution
+      supported: true
+      mechanism: $ARGUMENTS substitution in Markdown-type commands; equivalent to Claude Code's $ARGUMENTS pattern; Executable commands receive args via shell process stdin/args
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: builtin_commands
+      supported: false
+      mechanism: no built-in slash commands documented; Factory commands are user-defined Markdown templates or executables
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/factory-droid-hooks.yaml
+++ b/docs/provider-capabilities/factory-droid-hooks.yaml
@@ -1,0 +1,58 @@
+provider: factory-droid
+content_type: hooks
+format: ""
+proposed_mappings:
+    - canonical_key: async_execution
+      supported: false
+      mechanism: Factory Droid hooks run synchronously; no async execution documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: context_injection
+      supported: false
+      mechanism: Factory Droid hooks cannot inject context into the agent session
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: decision_control
+      supported: true
+      mechanism: 'hook_exit_code_behavior: Factory Droid hooks use exit codes to signal block (non-zero) or allow (zero) decisions on the triggering action'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: handler_types
+      supported: false
+      mechanism: Factory Droid hooks execute shell commands only; no other handler types documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hook_scopes
+      supported: false
+      mechanism: Factory Droid hooks are project-scoped; no multi-scope configuration documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: input_modification
+      supported: false
+      mechanism: Factory Droid hooks cannot modify tool input before execution
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: json_io_protocol
+      supported: false
+      mechanism: Factory Droid hooks communicate via exit codes; no JSON stdin/stdout protocol documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: matcher_patterns
+      supported: false
+      mechanism: Factory Droid hooks fire on configured lifecycle events; no per-tool pattern matching documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: permission_control
+      supported: false
+      mechanism: Factory Droid hooks cannot make permission decisions about tool availability
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/factory-droid-mcp.yaml
+++ b/docs/provider-capabilities/factory-droid-mcp.yaml
@@ -1,0 +1,52 @@
+provider: factory-droid
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: false
+      mechanism: Factory Droid does not document pre-configured auto-approval for MCP tools
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: enterprise_management
+      supported: false
+      mechanism: Factory Droid does not document organization-level MCP management
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: env_var_expansion
+      supported: false
+      mechanism: Factory Droid MCP configuration does not document environment variable expansion
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: marketplace
+      supported: false
+      mechanism: Factory Droid does not have an in-IDE MCP marketplace
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: oauth_support
+      supported: false
+      mechanism: Factory Droid MCP does not document OAuth 2.0 authentication
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: resource_referencing
+      supported: false
+      mechanism: Factory Droid does not document MCP resource referencing
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_filtering
+      supported: false
+      mechanism: Factory Droid does not document per-server MCP tool filtering
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: transport_types
+      supported: false
+      mechanism: Factory Droid MCP transport types not documented beyond basic MCP support
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/factory-droid-rules.yaml
+++ b/docs/provider-capabilities/factory-droid-rules.yaml
@@ -1,0 +1,34 @@
+provider: factory-droid
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: false
+      mechanism: Factory Droid rule files load unconditionally; no conditional or model-decision activation documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: auto_memory
+      supported: false
+      mechanism: Factory Droid does not have an AI-generated auto-memory system
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: cross_provider_recognition
+      supported: true
+      mechanism: 'agents_md_format: Factory Droid reads AGENTS.md files in the shared multi-provider format'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: file_imports
+      supported: false
+      mechanism: No file import syntax documented for Factory Droid rule files
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hierarchical_loading
+      supported: true
+      mechanism: Factory Droid loads global and project rule layers; innermost (most specific) layer takes precedence
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/factory-droid-skills.yaml
+++ b/docs/provider-capabilities/factory-droid-skills.yaml
@@ -49,7 +49,7 @@ proposed_mappings:
       mechanism: ""
       source_field: ""
       source_value: ""
-      confidence: unknown
+      confidence: confirmed
     - canonical_key: user_invocable
       supported: true
       mechanism: 'yaml frontmatter key: user-invocable (optional bool, default: true)'

--- a/docs/provider-capabilities/gemini-cli-commands.yaml
+++ b/docs/provider-capabilities/gemini-cli-commands.yaml
@@ -1,0 +1,16 @@
+provider: gemini-cli
+content_type: commands
+format: ""
+proposed_mappings:
+    - canonical_key: argument_substitution
+      supported: true
+      mechanism: '{{args}} placeholder injects all user-provided arguments; processed before shell injection (!{...}) and other substitutions; default argument handling collapses newlines'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: builtin_commands
+      supported: true
+      mechanism: built-in slash commands include /commands reload (reload command files without restart) and /help; user-defined commands supplement but do not replace built-ins
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/gemini-cli-hooks.yaml
+++ b/docs/provider-capabilities/gemini-cli-hooks.yaml
@@ -1,0 +1,58 @@
+provider: gemini-cli
+content_type: hooks
+format: ""
+proposed_mappings:
+    - canonical_key: async_execution
+      supported: false
+      mechanism: Gemini CLI hooks run synchronously; no async execution documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: context_injection
+      supported: false
+      mechanism: Gemini CLI hooks cannot inject context into the agent session
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: decision_control
+      supported: true
+      mechanism: 'exit_code_semantics: Gemini CLI uses exit codes to signal block (non-zero) or allow (zero) decisions; no modify sub-capability documented'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: handler_types
+      supported: false
+      mechanism: Gemini CLI hooks execute shell commands only; no HTTP, LLM prompt, or agent handler types documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hook_scopes
+      supported: false
+      mechanism: Gemini CLI hooks are project-scoped; no multi-scope configuration documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: input_modification
+      supported: false
+      mechanism: Gemini CLI hooks cannot modify tool input before execution
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: json_io_protocol
+      supported: true
+      mechanism: 'hook_io_protocol: Gemini CLI hooks receive event data as JSON on stdin and return structured JSON responses on stdout'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: matcher_patterns
+      supported: true
+      mechanism: 'hook_matchers: Gemini CLI hooks support event and tool name matching to filter when hooks fire'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: permission_control
+      supported: false
+      mechanism: Gemini CLI hooks control invocation flow via exit codes but do not govern tool availability
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/gemini-cli-mcp.yaml
+++ b/docs/provider-capabilities/gemini-cli-mcp.yaml
@@ -1,0 +1,52 @@
+provider: gemini-cli
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: false
+      mechanism: Gemini CLI does not document pre-configured auto-approval for specific MCP tools
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: enterprise_management
+      supported: false
+      mechanism: Gemini CLI does not document organization-level MCP management
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: env_var_expansion
+      supported: true
+      mechanism: 'env_variable_expansion: Gemini CLI MCP configuration supports environment variable expansion for secrets and paths'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: marketplace
+      supported: false
+      mechanism: Gemini CLI does not have an in-IDE MCP marketplace
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: oauth_support
+      supported: false
+      mechanism: Gemini CLI MCP does not document OAuth 2.0 authentication for remote servers
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: resource_referencing
+      supported: true
+      mechanism: 'resource_referencing: Gemini CLI supports accessing MCP resources in addition to tools'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: tool_filtering
+      supported: true
+      mechanism: 'tool_filtering: Gemini CLI supports per-server tool filtering to control which MCP tools are exposed to the agent'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: transport_types
+      supported: true
+      mechanism: 'transport_types: Gemini CLI documents supported MCP transport protocols including stdio and HTTP'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/gemini-cli-rules.yaml
+++ b/docs/provider-capabilities/gemini-cli-rules.yaml
@@ -1,0 +1,34 @@
+provider: gemini-cli
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: false
+      mechanism: Gemini CLI rule files load unconditionally; no conditional activation syntax documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: auto_memory
+      supported: true
+      mechanism: 'memory_command: Gemini CLI /memory command saves notes that persist across sessions as rule-like content'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: cross_provider_recognition
+      supported: false
+      mechanism: Gemini CLI reads its own GEMINI.md format; no cross-provider rule file recognition documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: file_imports
+      supported: true
+      mechanism: 'file_imports extension: Gemini CLI supports including external file content into rule files via import directives'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: hierarchical_loading
+      supported: true
+      mechanism: 'hierarchical_context_loading: Gemini CLI loads GEMINI.md files from multiple directory levels with defined precedence'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/kiro-agents.yaml
+++ b/docs/provider-capabilities/kiro-agents.yaml
@@ -1,0 +1,46 @@
+provider: kiro
+content_type: agents
+format: ""
+proposed_mappings:
+    - canonical_key: agent_scopes
+      supported: true
+      mechanism: project (.kiro/agents/) + global (~/.kiro/agents/); global overrides local on name collision — reverse of most Kiro content types
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: definition_format
+      supported: true
+      mechanism: JSON config files in .kiro/agents/ (project) or ~/.kiro/agents/ (global); prompt field accepts inline string or file:// URI to external .md file
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: invocation_patterns
+      supported: true
+      mechanism: keyboard shortcut binding for IDE invocation; welcomeMessage shown on agent start; manual selection via agent picker
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: model_selection
+      supported: true
+      mechanism: model field in agent JSON config overrides workspace default for that agent
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: per_agent_mcp
+      supported: true
+      mechanism: inline mcpServers map per agent config; includeMcpJson boolean controls whether workspace .kiro/mcp.json is merged into agent's server set
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: subagent_spawning
+      supported: false
+      mechanism: no subagent spawning mechanism documented for Kiro custom agents
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_restrictions
+      supported: true
+      mechanism: tools array with exact names, wildcards (computer_*), or MCP-namespaced refs (mcp:serverName:toolName); toolsSettings for per-tool config objects
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/kiro-hooks.yaml
+++ b/docs/provider-capabilities/kiro-hooks.yaml
@@ -1,0 +1,58 @@
+provider: kiro
+content_type: hooks
+format: ""
+proposed_mappings:
+    - canonical_key: async_execution
+      supported: false
+      mechanism: Kiro hooks run synchronously; no async execution documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: context_injection
+      supported: false
+      mechanism: Kiro hooks cannot inject context into the agent session
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: decision_control
+      supported: false
+      mechanism: Kiro hooks are observational; no mechanism to block, allow, or modify tool invocations documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: handler_types
+      supported: false
+      mechanism: Kiro hooks execute shell commands only; no HTTP, LLM prompt, or agent handler types documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hook_scopes
+      supported: false
+      mechanism: Kiro hooks are project-scoped; no multi-scope configuration documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: input_modification
+      supported: false
+      mechanism: Kiro hooks cannot modify tool input before execution
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: json_io_protocol
+      supported: false
+      mechanism: Kiro hooks communicate via exit codes; no JSON stdin/stdout protocol documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: matcher_patterns
+      supported: false
+      mechanism: Kiro hooks fire on configured lifecycle events; no per-tool filtering documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: permission_control
+      supported: false
+      mechanism: Kiro hooks do not participate in permission decisions
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/kiro-mcp.yaml
+++ b/docs/provider-capabilities/kiro-mcp.yaml
@@ -1,0 +1,52 @@
+provider: kiro
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: true
+      mechanism: 'kiro_mcp_auto_approve: Kiro supports per-server or per-tool auto-approval configuration to suppress confirmation prompts'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: enterprise_management
+      supported: false
+      mechanism: Kiro does not document organization-level MCP management
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: env_var_expansion
+      supported: false
+      mechanism: Kiro MCP configuration does not document environment variable expansion
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: marketplace
+      supported: false
+      mechanism: Kiro does not have an in-IDE MCP marketplace
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: oauth_support
+      supported: false
+      mechanism: Kiro MCP does not document OAuth 2.0 authentication
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: resource_referencing
+      supported: false
+      mechanism: Kiro does not document MCP resource referencing
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_filtering
+      supported: true
+      mechanism: 'kiro_mcp_disabled_tools: Kiro supports per-server tool disable configuration to control which MCP tools are available to the agent'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: transport_types
+      supported: false
+      mechanism: Kiro MCP transport types not documented beyond basic MCP support
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/kiro-rules.yaml
+++ b/docs/provider-capabilities/kiro-rules.yaml
@@ -1,0 +1,34 @@
+provider: kiro
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: true
+      mechanism: 'kiro_steering_inclusion_mode: Kiro steering files support always, conditional, and manual inclusion modes'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: auto_memory
+      supported: false
+      mechanism: Kiro does not have an AI-generated auto-memory system separate from user-authored steering files
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: cross_provider_recognition
+      supported: true
+      mechanism: 'kiro_agents_md_recognition: Kiro reads AGENTS.md files from other providers in addition to its own steering files'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: file_imports
+      supported: true
+      mechanism: 'kiro_steering_file_references: Kiro steering files can reference other files using @file syntax'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: hierarchical_loading
+      supported: false
+      mechanism: Kiro steering files are project-scoped; no multi-level subdirectory hierarchy documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/opencode-agents.yaml
+++ b/docs/provider-capabilities/opencode-agents.yaml
@@ -1,0 +1,46 @@
+provider: opencode
+content_type: agents
+format: ""
+proposed_mappings:
+    - canonical_key: agent_scopes
+      supported: true
+      mechanism: 'Two scopes: project (.opencode/agents/) and user-global (~/.config/opencode/agents/). Both scopes are loaded and coexist.'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: definition_format
+      supported: true
+      mechanism: Markdown files with YAML frontmatter loaded from .opencode/agents/*.md (project) and ~/.config/opencode/agents/*.md (global). The loader glob accepts both agent/ and agents/ directory names and recurses. Frontmatter declares description (required), mode, model, permission, steps, temperature, top_p, color, and hidden; the markdown body becomes the system prompt.
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: invocation_patterns
+      supported: true
+      mechanism: 'Agent name derives from the filename (configEntryNameFromPath). Agents with mode: primary can be selected as the session agent; agents with mode: subagent are invoked by other agents via description-driven matching; mode: all allows both.'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: model_selection
+      supported: true
+      mechanism: Frontmatter model field selects a specific model alias or full model string for the agent, overriding the session default.
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: per_agent_mcp
+      supported: false
+      mechanism: OpenCode agent frontmatter does not document a per-agent mcpServers field; agents inherit the workspace MCP configuration.
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: subagent_spawning
+      supported: true
+      mechanism: 'Agents with mode: subagent (or mode: all) can be invoked from other agents; delegation is driven by the callee''s description field.'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: tool_restrictions
+      supported: true
+      mechanism: The permission frontmatter map configures ask/allow/deny per tool, replacing the deprecated tools allow/deny map.
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/opencode-commands.yaml
+++ b/docs/provider-capabilities/opencode-commands.yaml
@@ -1,0 +1,16 @@
+provider: opencode
+content_type: commands
+format: ""
+proposed_mappings:
+    - canonical_key: argument_substitution
+      supported: true
+      mechanism: Named arguments via $VAR tokens substituted from user input at invocation (pattern observed in custom_commands.go — e.g. $ISSUE_NUMBER).
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: builtin_commands
+      supported: false
+      mechanism: OpenCode documentation describes only user-authored slash commands loaded from .opencode/commands/ and ~/.config/opencode/commands/; no built-in commands are documented for this namespace.
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/opencode-mcp.yaml
+++ b/docs/provider-capabilities/opencode-mcp.yaml
@@ -1,0 +1,34 @@
+provider: opencode
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: enterprise_management
+      supported: false
+      mechanism: No organization-level MCP management documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: env_var_expansion
+      supported: true
+      mechanism: 'env_variable_expansion: environment variables configured in server env blocks'
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: oauth_support
+      supported: false
+      mechanism: No OAuth 2.0 authentication for remote MCP servers documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_filtering
+      supported: false
+      mechanism: No per-server tool allowlist/blocklist documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: transport_types
+      supported: true
+      mechanism: 'transport_types: OpenCode documents stdio transport; remote transports (http/sse) are available on sst/opencode depending on version'
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/opencode-rules.yaml
+++ b/docs/provider-capabilities/opencode-rules.yaml
@@ -1,0 +1,34 @@
+provider: opencode
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: false
+      mechanism: OpenCode rule files load unconditionally as context; no conditional activation syntax documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: auto_memory
+      supported: false
+      mechanism: No runtime command documented for persisting notes into rule files
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: cross_provider_recognition
+      supported: true
+      mechanism: OpenCode reads both AGENTS.md (cross-provider convention) and CLAUDE.md (historical Claude Code convention) from project root
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: file_imports
+      supported: false
+      mechanism: No documented import directive for rule files
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hierarchical_loading
+      supported: true
+      mechanism: Project-root AGENTS.md/CLAUDE.md combined with global context files at ~/.config/opencode/
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/opencode-skills.yaml
+++ b/docs/provider-capabilities/opencode-skills.yaml
@@ -1,10 +1,10 @@
-provider: kiro
+provider: opencode
 content_type: skills
 format: ""
 proposed_mappings:
     - canonical_key: canonical_filename
       supported: true
-      mechanism: Fixed filename POWER.md (required, all caps)
+      mechanism: Fixed filename SKILL.md inside skill directory (Agent Skills spec)
       source_field: ""
       source_value: ""
       confidence: confirmed
@@ -14,33 +14,21 @@ proposed_mappings:
       source_field: ""
       source_value: ""
       confidence: confirmed
-    - canonical_key: custom_filename
-      supported: false
-      mechanism: Not observed — POWER.md is fixed
-      source_field: ""
-      source_value: ""
-      confidence: confirmed
     - canonical_key: description
       supported: true
       mechanism: 'yaml frontmatter key: description (required)'
       source_field: ""
       source_value: ""
       confidence: confirmed
-    - canonical_key: disable_model_invocation
-      supported: false
-      mechanism: ""
-      source_field: ""
-      source_value: ""
-      confidence: confirmed
     - canonical_key: display_name
       supported: true
-      mechanism: 'yaml frontmatter key: name (required, slug-style identifier)'
+      mechanism: 'yaml frontmatter key: name (required)'
       source_field: ""
       source_value: ""
       confidence: confirmed
     - canonical_key: global_scope
-      supported: false
-      mechanism: ""
+      supported: true
+      mechanism: cross-provider convention at ~/.config/opencode/skills/<name>/SKILL.md
       source_field: ""
       source_value: ""
       confidence: confirmed
@@ -58,19 +46,7 @@ proposed_mappings:
       confidence: confirmed
     - canonical_key: project_scope
       supported: true
-      mechanism: Self-contained directory installed via Kiro Powers panel (UI installation, no fixed filesystem path)
-      source_field: ""
-      source_value: ""
-      confidence: confirmed
-    - canonical_key: shared_scope
-      supported: false
-      mechanism: ""
-      source_field: ""
-      source_value: ""
-      confidence: confirmed
-    - canonical_key: user_invocable
-      supported: false
-      mechanism: ""
+      mechanism: cross-provider SKILL.md convention at .opencode/skill/<name>/SKILL.md
       source_field: ""
       source_value: ""
       confidence: confirmed

--- a/docs/provider-capabilities/pi-commands.yaml
+++ b/docs/provider-capabilities/pi-commands.yaml
@@ -1,0 +1,16 @@
+provider: pi
+content_type: commands
+format: ""
+proposed_mappings:
+    - canonical_key: argument_substitution
+      supported: true
+      mechanism: 'positional expansion: $1, $2 (specific positions), $@ or $ARGUMENTS (all args joined), ${@:N} (args from position N), ${@:N:L} (L args starting at N); richer syntax than most providers'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: builtin_commands
+      supported: false
+      mechanism: pi prompt templates are entirely user-defined; no built-in slash commands documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/pi-hooks.yaml
+++ b/docs/provider-capabilities/pi-hooks.yaml
@@ -1,0 +1,58 @@
+provider: pi
+content_type: hooks
+format: ""
+proposed_mappings:
+    - canonical_key: async_execution
+      supported: false
+      mechanism: Pi hooks run synchronously; no async execution documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: context_injection
+      supported: false
+      mechanism: Pi hooks cannot inject context into the agent session via hook output
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: decision_control
+      supported: false
+      mechanism: Pi hooks are observational; no mechanism to block, allow, or modify tool invocations documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: handler_types
+      supported: true
+      mechanism: 'pi_extension_typescript_native: Pi hooks support TypeScript/native extension handler type beyond shell commands'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: hook_scopes
+      supported: false
+      mechanism: Pi hooks are project-scoped; no multi-scope configuration documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: input_modification
+      supported: true
+      mechanism: 'pi_extension_tool_call_blocking: Pi extensions can intercept and modify tool call inputs before execution'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: json_io_protocol
+      supported: false
+      mechanism: Pi hooks communicate via TypeScript extension API; no JSON stdin/stdout protocol for shell hooks
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: matcher_patterns
+      supported: false
+      mechanism: Pi hooks fire on configured lifecycle events; no per-tool filtering documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: permission_control
+      supported: false
+      mechanism: Pi hooks cannot make permission decisions about tool availability
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/pi-rules.yaml
+++ b/docs/provider-capabilities/pi-rules.yaml
@@ -1,0 +1,34 @@
+provider: pi
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: false
+      mechanism: Pi rule files load unconditionally; no conditional or model-decision activation documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: auto_memory
+      supported: false
+      mechanism: Pi does not have an AI-generated auto-memory system
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: cross_provider_recognition
+      supported: false
+      mechanism: Pi reads its own rule format; no cross-provider rule file recognition documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: file_imports
+      supported: false
+      mechanism: No file import syntax documented for Pi rule files
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hierarchical_loading
+      supported: false
+      mechanism: Pi rule files are not documented as supporting multi-level directory loading
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/pi-skills.yaml
+++ b/docs/provider-capabilities/pi-skills.yaml
@@ -7,25 +7,25 @@ proposed_mappings:
       mechanism: SKILL.md (required, fixed filename for directory-form skills)
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: compatibility
       supported: true
       mechanism: 'yaml frontmatter key: compatibility (optional, max 500 chars)'
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: custom_filename
       supported: true
       mechanism: Any .md filename at root of ~/.pi/agent/skills/ or .pi/skills/ (shorthand single-file form)
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: description
       supported: true
       mechanism: 'yaml frontmatter key: description (required, max 1024 chars)'
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: disable_model_invocation
       supported: true
       mechanism: 'yaml frontmatter key: disable-model-invocation (optional bool); confirmed in SkillFrontmatter TypeScript interface as disable-model-invocation?: boolean'
@@ -37,40 +37,40 @@ proposed_mappings:
       mechanism: 'yaml frontmatter key: name (required, max 64 chars, lowercase a-z/0-9/hyphens, must match parent directory name)'
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: global_scope
       supported: true
       mechanism: ~/.pi/agent/skills/<name>/SKILL.md or ~/.agents/skills/<name>/SKILL.md
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: license
       supported: true
       mechanism: 'yaml frontmatter key: license (optional)'
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: metadata_map
       supported: true
       mechanism: 'yaml frontmatter key: metadata (optional, arbitrary key-value mapping)'
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: project_scope
       supported: true
       mechanism: .pi/skills/<name>/SKILL.md or .agents/skills/<name>/SKILL.md
       source_field: ""
       source_value: ""
-      confidence: inferred
+      confidence: confirmed
     - canonical_key: shared_scope
       supported: false
       mechanism: ""
       source_field: ""
       source_value: ""
-      confidence: unknown
+      confidence: confirmed
     - canonical_key: user_invocable
       supported: false
       mechanism: ""
       source_field: ""
       source_value: ""
-      confidence: unknown
+      confidence: confirmed

--- a/docs/provider-capabilities/roo-code-agents.yaml
+++ b/docs/provider-capabilities/roo-code-agents.yaml
@@ -1,0 +1,46 @@
+provider: roo-code
+content_type: agents
+format: ""
+proposed_mappings:
+    - canonical_key: agent_scopes
+      supported: true
+      mechanism: 'Two scopes: project (.roomodes at the project root) and global (custom_modes.yaml in Roo Code''s settings dir); project entries override global entries with the same slug'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: definition_format
+      supported: true
+      mechanism: YAML file (.roomodes for project scope, custom_modes.yaml for global scope) containing an array of custom mode entries with slug, name, roleDefinition, groups, and optional whenToUse, description, customInstructions fields
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: invocation_patterns
+      supported: true
+      mechanism: Users switch modes via the mode selector or /mode command; each mode is a distinct operating persona with its own roleDefinition and tool groups
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: model_selection
+      supported: false
+      mechanism: No per-mode model selection field documented in the mode schema
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: per_agent_mcp
+      supported: false
+      mechanism: Custom modes do not declare their own MCP server lists — MCP configuration is global per the .roo/mcp.json and global MCP settings
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: subagent_spawning
+      supported: false
+      mechanism: Custom modes are switched-to by the user rather than spawned as subagents; Roo Code's orchestrator mode delegates to other modes at runtime but mode files themselves do not spawn peers
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_restrictions
+      supported: true
+      mechanism: groups array declares which tool groups (e.g., read, edit, browser, command, mcp) the mode may use; group entries may be strings or objects with fileRegex restrictions
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/roo-code-commands.yaml
+++ b/docs/provider-capabilities/roo-code-commands.yaml
@@ -1,0 +1,16 @@
+provider: roo-code
+content_type: commands
+format: ""
+proposed_mappings:
+    - canonical_key: argument_substitution
+      supported: true
+      mechanism: argument-hint frontmatter field documents expected arguments; user-supplied arguments are appended to the command body at invocation time
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: builtin_commands
+      supported: false
+      mechanism: Roo Code commands are user-defined Markdown files in .roo/commands/ — no user-overridable built-in slash-command layer documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/roo-code-mcp.yaml
+++ b/docs/provider-capabilities/roo-code-mcp.yaml
@@ -1,0 +1,52 @@
+provider: roo-code
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: true
+      mechanism: 'always_allow_list: alwaysAllow tool names bypass confirmation prompts for that server'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: enterprise_management
+      supported: false
+      mechanism: No organization-level MCP management documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: env_var_expansion
+      supported: true
+      mechanism: 'env_variable_expansion: server env blocks accept environment variables so secrets can be referenced from the shell environment'
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: marketplace
+      supported: false
+      mechanism: No in-app MCP marketplace documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: oauth_support
+      supported: false
+      mechanism: No OAuth 2.0 authentication flow documented for Roo Code MCP servers
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: resource_referencing
+      supported: false
+      mechanism: MCP resource referencing is not documented as a first-class feature in Roo Code
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_filtering
+      supported: true
+      mechanism: 'per_server_tool_filtering: alwaysAllow and disabledTools arrays on each server entry filter which MCP tools are exposed and which bypass confirmation'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: transport_types
+      supported: true
+      mechanism: 'transport_types: stdio, sse, and streamable-http are supported and selected via the type field on each server entry'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/roo-code-rules.yaml
+++ b/docs/provider-capabilities/roo-code-rules.yaml
@@ -1,0 +1,34 @@
+provider: roo-code
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: true
+      mechanism: 'mode_partitioned_activation: rule files in mode-specific directories (.roo/rules-<mode-slug>/) activate only when that mode is active; files in .roo/rules/ activate for all modes'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: auto_memory
+      supported: false
+      mechanism: No auto-append or persistent memory command documented for rule content
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: cross_provider_recognition
+      supported: true
+      mechanism: 'legacy_clinerules_fallback: Roo Code reads .clinerules/ as a backward-compatibility fallback when native .roo/rules/ is absent'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: file_imports
+      supported: false
+      mechanism: No import directive syntax documented — rule files are loaded as plain markdown bodies
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hierarchical_loading
+      supported: true
+      mechanism: 'mode_scoped_loading: files under .roo/rules/ load universally; files under .roo/rules-<mode>/ load conditionally based on the active mode'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/roo-code-skills.yaml
+++ b/docs/provider-capabilities/roo-code-skills.yaml
@@ -1,0 +1,76 @@
+provider: roo-code
+content_type: skills
+format: ""
+proposed_mappings:
+    - canonical_key: canonical_filename
+      supported: true
+      mechanism: SKILL.md (required, fixed name per Agent Skills standard)
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: compatibility
+      supported: false
+      mechanism: No compatibility frontmatter field observed in Roo Code skill examples
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: custom_filename
+      supported: false
+      mechanism: Filename is fixed as SKILL.md — no alternate filenames observed
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: description
+      supported: true
+      mechanism: 'yaml frontmatter key: description (required); documents what the skill does and when Roo should load it'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: disable_model_invocation
+      supported: false
+      mechanism: No disable-model-invocation frontmatter field observed
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: display_name
+      supported: true
+      mechanism: 'yaml frontmatter key: name (required); identifies the skill and typically matches the directory name'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: global_scope
+      supported: true
+      mechanism: ~/.roo/skills/<slug>/SKILL.md
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: license
+      supported: false
+      mechanism: No license frontmatter field observed in Roo Code skill examples
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: metadata_map
+      supported: false
+      mechanism: No metadata frontmatter key observed in Roo Code skill examples
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: project_scope
+      supported: true
+      mechanism: .roo/skills/<slug>/SKILL.md
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: shared_scope
+      supported: true
+      mechanism: .agents/skills/<slug>/SKILL.md cross-provider convention directory read alongside .roo/skills/
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: user_invocable
+      supported: false
+      mechanism: No user-invocation flag observed — skills are auto-loaded based on description matching
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/windsurf-commands.yaml
+++ b/docs/provider-capabilities/windsurf-commands.yaml
@@ -1,0 +1,16 @@
+provider: windsurf
+content_type: commands
+format: ""
+proposed_mappings:
+    - canonical_key: argument_substitution
+      supported: false
+      mechanism: Cascade Workflows are plain Markdown prompt templates; no `{{args}}` or equivalent placeholder syntax is documented for user-provided arguments
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: builtin_commands
+      supported: true
+      mechanism: Cascade exposes its own built-in chat slash commands (e.g. for conversation control) independently of user-authored Workflows; the `/<workflow-name>` namespace is reserved for user files
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/windsurf-hooks.yaml
+++ b/docs/provider-capabilities/windsurf-hooks.yaml
@@ -1,0 +1,58 @@
+provider: windsurf
+content_type: hooks
+format: ""
+proposed_mappings:
+    - canonical_key: async_execution
+      supported: false
+      mechanism: Windsurf hooks run synchronously; no async/background execution documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: context_injection
+      supported: false
+      mechanism: Windsurf hooks cannot inject context into the agent's active session
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: decision_control
+      supported: false
+      mechanism: Windsurf hooks are observational; no mechanism to block, allow, or modify the triggering action documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: handler_types
+      supported: false
+      mechanism: Windsurf hooks execute shell commands only; no HTTP, LLM prompt, or agent handler types documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hook_scopes
+      supported: true
+      mechanism: 'three_config_scopes: global (user-wide), workspace, and managed/enterprise hook configuration scopes'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: input_modification
+      supported: false
+      mechanism: Windsurf hooks cannot modify tool input arguments before execution
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: json_io_protocol
+      supported: true
+      mechanism: 'json_stdin_context: Windsurf hooks receive event context as JSON on stdin'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: matcher_patterns
+      supported: false
+      mechanism: Windsurf hooks fire on all events of their configured type; no per-tool or regex matching documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: permission_control
+      supported: false
+      mechanism: Windsurf hooks do not participate in permission decisions
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/windsurf-mcp.yaml
+++ b/docs/provider-capabilities/windsurf-mcp.yaml
@@ -1,0 +1,52 @@
+provider: windsurf
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: false
+      mechanism: Windsurf does not support pre-configured auto-approval for specific MCP tools
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: enterprise_management
+      supported: true
+      mechanism: 'enterprise_whitelist_and_registry: Windsurf supports organization-level MCP server allowlists and enterprise registries'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: env_var_expansion
+      supported: true
+      mechanism: 'config_interpolation: Windsurf MCP configuration supports ${VAR} interpolation for environment variables'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: marketplace
+      supported: true
+      mechanism: 'mcp_marketplace: Windsurf has an in-IDE MCP server discovery and one-click installation experience'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: oauth_support
+      supported: false
+      mechanism: Windsurf MCP does not document OAuth 2.0 authentication for remote servers
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: resource_referencing
+      supported: false
+      mechanism: Windsurf does not document @-mention or equivalent access to MCP resources
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_filtering
+      supported: false
+      mechanism: Windsurf exposes all tools from connected MCP servers; no per-server tool allowlist or blocklist documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: transport_types
+      supported: true
+      mechanism: 'three_transport_types: Windsurf supports stdio, SSE, and HTTP/streamable-HTTP transports'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/windsurf-rules.yaml
+++ b/docs/provider-capabilities/windsurf-rules.yaml
@@ -1,0 +1,34 @@
+provider: windsurf
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: true
+      mechanism: 'activation_modes extension: always (unconditional), conditional (glob patterns), model (AI decides), manual (explicit toggle)'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: auto_memory
+      supported: true
+      mechanism: 'auto_generated_memories: Windsurf AI generates persistent memories stored in .windsurf/memories/ as rule-like files'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: cross_provider_recognition
+      supported: true
+      mechanism: 'agents_md_auto_scoping: Windsurf reads AGENTS.md files from other providers and applies them with workspace-aware scoping'
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: file_imports
+      supported: false
+      mechanism: No @-import or file inclusion syntax documented for Windsurf rule files
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: hierarchical_loading
+      supported: false
+      mechanism: Windsurf rule files are global or workspace-scoped; no subdirectory precedence model documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred

--- a/docs/provider-capabilities/windsurf-skills.yaml
+++ b/docs/provider-capabilities/windsurf-skills.yaml
@@ -40,7 +40,7 @@ proposed_mappings:
       confidence: confirmed
     - canonical_key: user_invocable
       supported: true
-      mechanism: Explicit @mention by skill name in Cascade input (e.g., @deploy-to-production). Always available regardless of auto-invocation eligibility. Skills can also be created via Cascade UI (three dots → Skills → + Workspace / + Global).
+      mechanism: Explicit @mention by skill name in Cascade input (e.g., @deploy-to-production). Always available regardless of auto-invocation eligibility.
       source_field: ""
       source_value: ""
       confidence: confirmed

--- a/docs/provider-capabilities/zed-mcp.yaml
+++ b/docs/provider-capabilities/zed-mcp.yaml
@@ -1,0 +1,52 @@
+provider: zed
+content_type: mcp
+format: ""
+proposed_mappings:
+    - canonical_key: auto_approve
+      supported: false
+      mechanism: Zed does not document a pre-approved MCP tools list
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: enterprise_management
+      supported: false
+      mechanism: Zed does not document org-level MCP management
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: env_var_expansion
+      supported: false
+      mechanism: no automatic environment variable expansion documented in Zed MCP env blocks
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: marketplace
+      supported: true
+      mechanism: Zed exposes an in-app MCP server gallery where servers can be browsed and installed
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: oauth_support
+      supported: false
+      mechanism: Zed MCP configuration does not document OAuth 2.0 authentication for MCP servers
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: resource_referencing
+      supported: false
+      mechanism: MCP resource referencing via @-style syntax is not documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: tool_filtering
+      supported: false
+      mechanism: no per-server include/exclude tool filter documented in Zed MCP configuration
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: transport_types
+      supported: true
+      mechanism: MCP servers are configured with a stdio command under context_servers in settings.json
+      source_field: ""
+      source_value: ""
+      confidence: confirmed

--- a/docs/provider-capabilities/zed-rules.yaml
+++ b/docs/provider-capabilities/zed-rules.yaml
@@ -1,0 +1,34 @@
+provider: zed
+content_type: rules
+format: ""
+proposed_mappings:
+    - canonical_key: activation_mode
+      supported: false
+      mechanism: Zed rule files load unconditionally when present at project root; no conditional activation syntax documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: auto_memory
+      supported: false
+      mechanism: Zed does not document a command that persists agent memory into the rules file
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: cross_provider_recognition
+      supported: true
+      mechanism: Zed discovers .rules, .cursorrules, and CLAUDE.md at project root, so rule files authored for other agents are picked up
+      source_field: ""
+      source_value: ""
+      confidence: confirmed
+    - canonical_key: file_imports
+      supported: false
+      mechanism: no import directive documented for Zed's .rules file
+      source_field: ""
+      source_value: ""
+      confidence: inferred
+    - canonical_key: hierarchical_loading
+      supported: false
+      mechanism: Zed loads rule files from the project root only; no multi-tier hierarchical loading documented
+      source_field: ""
+      source_value: ""
+      confidence: inferred


### PR DESCRIPTION
## Summary

- Replace `DeriveSeederSpec` (which hardcoded `ContentType: "skills"` and collapsed all canonical keys into one YAML) with `DeriveSeederSpecs`, returning one `*SeederSpec` per supported content type from the format doc, sorted deterministically.
- Add `TestDeriveOutputMatchesCommitted` — a byte-for-byte drift gate covering all (provider, content_type) pairs (72 verified). Future format-doc edits without regenerated YAMLs fail CI before any downstream PR can inherit the diff as incidental noise.
- Realign 9 stale `*-skills.yaml` files with current format-doc confidence values; add 62 new `<slug>-<content_type>.yaml` files filling in every supported content type across 15 providers.
- `capmon verify` skips files where `slug == ""` so seeder-spec YAMLs (`provider:` not `slug:`) don't trip canonical-validation; pinned by `TestCapmonVerify_SkipsSeederSpecs`.

## Test plan

- [x] `make build` clean
- [x] `make test` full suite green
- [x] `TestDeriveSeederSpecs_*` (6 cases) verifying determinism, no cross-content-type bleed, content-type sort, unknown-key rejection, unsupported-skipped, one-per-CT
- [x] `TestSeederSpecs_AllLoad` — all 30 dev seeder specs parse cleanly
- [x] `TestDeriveOutputMatchesCommitted` — 72/72 (provider, content_type) pairs match committed bytes
- [x] `TestCapmonVerify_SkipsSeederSpecs` — verify command no longer flags per-CT files
- [x] `gofmt` clean (pre-commit + pre-push hooks both passed)
- [x] `golangci-lint` clean (pre-push hook)
- [x] `commands.json` and `telemetry.json` freshness gates passed

## Out of scope (follow-up PRs already chained)

- Recognizer completeness (28 missing/broken recognizers) and 8 format-doc edits — PR1.
- Extract+seed pipeline runs to populate canonical YAMLs + by-content-type/* regeneration — PR2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)