### PR TITLE
feat(release): sign checksums.txt with Ed25519 for self-update verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,16 @@ jobs:
         working-directory: cli
         env:
           SYLLAGO_POSTHOG_KEY: ${{ secrets.SYLLAGO_POSTHOG_KEY }}
+          SYLLAGO_SIGNING_PUBLIC_KEY: ${{ vars.SYLLAGO_SIGNING_PUBLIC_KEY }}
         run: |
           LDFLAGS="-X main.version=${VERSION}"
           if [ -n "$SYLLAGO_POSTHOG_KEY" ]; then
             LDFLAGS="$LDFLAGS -X github.com/OpenScribbler/syllago/cli/internal/telemetry.apiKey=$SYLLAGO_POSTHOG_KEY"
+          fi
+          if [ -n "$SYLLAGO_SIGNING_PUBLIC_KEY" ]; then
+            LDFLAGS="$LDFLAGS -X github.com/OpenScribbler/syllago/cli/internal/updater.SigningPublicKey=$SYLLAGO_SIGNING_PUBLIC_KEY"
+          else
+            echo "::warning::SYLLAGO_SIGNING_PUBLIC_KEY not set — release binaries will skip self-update signature verification with a warning."
           fi
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o syllago-linux-amd64 ./cmd/syllago
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o syllago-linux-arm64 ./cmd/syllago
@@ -80,6 +86,28 @@ jobs:
         working-directory: cli
         run: cosign sign-blob --yes checksums.txt --bundle checksums.txt.bundle
 
+      - name: Get Ed25519 signing key from Aembit
+        id: aembit-signing
+        continue-on-error: true
+        uses: Aembit/get-credentials@652c3288eba4b0f3f03d0fee970b0d6c490f010a # v1.1.2
+        with:
+          client-id: aembit:useast2:c7053f:identity:github_idtoken:2bbc8270-85a4-4c27-8c49-19e5590dfa87
+          credential-type: ApiKey
+          server-host: ${{ vars.SYLLAGO_SIGNING_AEMBIT_HOST }}
+
+      - name: Sign checksums.txt with Ed25519
+        if: steps.aembit-signing.outcome == 'success' && steps.aembit-signing.outputs.api-key != ''
+        working-directory: cli
+        env:
+          SYLLAGO_SIGNING_PRIVATE_KEY: ${{ steps.aembit-signing.outputs.api-key }}
+        run: |
+          go run ./cmd/syllago-sign sign checksums.txt > checksums.txt.sig
+          echo "Wrote checksums.txt.sig ($(wc -c < checksums.txt.sig) bytes)"
+
+      - name: Warn if Ed25519 signing was skipped
+        if: steps.aembit-signing.outcome != 'success' || steps.aembit-signing.outputs.api-key == ''
+        run: echo "::warning::Ed25519 signing skipped — release will not include checksums.txt.sig. Configure the Aembit Access Policy and SYLLAGO_SIGNING_AEMBIT_HOST repo variable to enable self-update signature verification."
+
       - name: Prepare release notes
         id: notes
         run: |
@@ -103,6 +131,9 @@ jobs:
             content-format.json syllago-yaml-schema.json sbom.spdx.json
             checksums.txt checksums.txt.bundle
           )
+          if [ -f checksums.txt.sig ]; then
+            ASSETS+=(checksums.txt.sig)
+          fi
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             echo "Release $GITHUB_REF_NAME already exists; updating notes and re-uploading assets."
             gh release edit "$GITHUB_REF_NAME" \
@@ -130,6 +161,9 @@ jobs:
             content-format.json syllago-yaml-schema.json sbom.spdx.json
             checksums.txt checksums.txt.bundle
           )
+          if [ -f checksums.txt.sig ]; then
+            ASSETS+=(checksums.txt.sig)
+          fi
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             echo "Release $GITHUB_REF_NAME already exists; updating title and re-uploading assets."
             gh release edit "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME"

--- a/cli/cmd/syllago-sign/main.go
+++ b/cli/cmd/syllago-sign/main.go
@@ -1,0 +1,86 @@
+// Build-time Ed25519 signing utility for syllago release artifacts.
+// Not shipped to end users — invoked from .github/workflows/release.yml via
+// `go run ./cmd/syllago-sign`. The companion verifier lives in
+// cli/internal/updater and runs inside the user-facing binary at self-update
+// time (see verifyChecksumSignature in cli/internal/updater/updater.go).
+//
+// Subcommands:
+//
+//	syllago-sign keygen        Print a fresh "private=<hex>\npublic=<hex>" pair.
+//	syllago-sign sign <file>   Sign <file> with the seed in $SYLLAGO_SIGNING_PRIVATE_KEY
+//	                           and write the 64-byte raw signature to stdout.
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "syllago-sign:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return errors.New("usage: syllago-sign <keygen|sign> [args]")
+	}
+	switch args[0] {
+	case "keygen":
+		if len(args) != 1 {
+			return errors.New("usage: syllago-sign keygen")
+		}
+		return doKeygen(out)
+	case "sign":
+		if len(args) != 2 {
+			return errors.New("usage: syllago-sign sign <file>")
+		}
+		return doSign(args[1], out)
+	default:
+		return fmt.Errorf("unknown command %q (want keygen or sign)", args[0])
+	}
+}
+
+func doKeygen(out io.Writer) error {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generating key: %w", err)
+	}
+	_, err = fmt.Fprintf(out, "private=%s\npublic=%s\n",
+		hex.EncodeToString(priv.Seed()),
+		hex.EncodeToString(pub))
+	return err
+}
+
+func doSign(path string, out io.Writer) error {
+	keyHex := os.Getenv("SYLLAGO_SIGNING_PRIVATE_KEY")
+	if keyHex == "" {
+		return errors.New("SYLLAGO_SIGNING_PRIVATE_KEY is not set")
+	}
+	seed, err := hex.DecodeString(keyHex)
+	if err != nil {
+		return fmt.Errorf("decoding private key: %w", err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		return fmt.Errorf("private key must be %d hex characters (got %d)", ed25519.SeedSize*2, len(keyHex))
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	sig := ed25519.Sign(priv, data)
+	if _, err := out.Write(sig); err != nil {
+		return fmt.Errorf("writing signature: %w", err)
+	}
+	return nil
+}

--- a/cli/cmd/syllago-sign/main_test.go
+++ b/cli/cmd/syllago-sign/main_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunKeygen_ProducesValidKeyPair(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := run([]string{"keygen"}, &buf); err != nil {
+		t.Fatalf("keygen failed: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 output lines; got %d: %q", len(lines), buf.String())
+	}
+	privHex := strings.TrimPrefix(lines[0], "private=")
+	pubHex := strings.TrimPrefix(lines[1], "public=")
+	if privHex == lines[0] {
+		t.Fatalf("first line missing 'private=' prefix: %q", lines[0])
+	}
+	if pubHex == lines[1] {
+		t.Fatalf("second line missing 'public=' prefix: %q", lines[1])
+	}
+
+	seed, err := hex.DecodeString(privHex)
+	if err != nil {
+		t.Fatalf("private hex invalid: %v", err)
+	}
+	pub, err := hex.DecodeString(pubHex)
+	if err != nil {
+		t.Fatalf("public hex invalid: %v", err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		t.Errorf("seed len = %d; want %d", len(seed), ed25519.SeedSize)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		t.Errorf("pub len = %d; want %d", len(pub), ed25519.PublicKeySize)
+	}
+
+	derived := ed25519.NewKeyFromSeed(seed).Public().(ed25519.PublicKey)
+	if !bytes.Equal(derived, pub) {
+		t.Error("printed public key does not match the public key derived from the printed seed")
+	}
+}
+
+func TestRunSign_RoundTripsThroughUpdaterVerifier(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedHex := hex.EncodeToString(priv.Seed())
+
+	dir := t.TempDir()
+	payload := []byte("abc123  syllago-linux-amd64\ndef456  syllago-darwin-arm64\n")
+	payloadPath := filepath.Join(dir, "checksums.txt")
+	if err := os.WriteFile(payloadPath, payload, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SYLLAGO_SIGNING_PRIVATE_KEY", seedHex)
+
+	var sigBuf bytes.Buffer
+	if err := run([]string{"sign", payloadPath}, &sigBuf); err != nil {
+		t.Fatalf("sign failed: %v", err)
+	}
+	sig := sigBuf.Bytes()
+	if len(sig) != ed25519.SignatureSize {
+		t.Fatalf("signature size = %d; want %d", len(sig), ed25519.SignatureSize)
+	}
+	if !ed25519.Verify(pub, payload, sig) {
+		t.Fatal("ed25519.Verify rejected the produced signature — sign/verify symmetry broken")
+	}
+}
+
+func TestRunSign_RejectsBadKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     string
+		wantSub string
+	}{
+		{"missing", "", "is not set"},
+		{"bad hex", "zzzz", "decoding private key"},
+		{"too short", strings.Repeat("aa", 16), "private key must be"},
+		{"too long", strings.Repeat("aa", 64), "private key must be"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SYLLAGO_SIGNING_PRIVATE_KEY", tc.env)
+			err := run([]string{"sign", "irrelevant.txt"}, &bytes.Buffer{})
+			if err == nil {
+				t.Fatal("want error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q should contain %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestRunSign_MissingInputFile(t *testing.T) {
+	t.Setenv("SYLLAGO_SIGNING_PRIVATE_KEY", strings.Repeat("aa", 32))
+	err := run([]string{"sign", filepath.Join(t.TempDir(), "does-not-exist")}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("want error for missing input file, got nil")
+	}
+	if !strings.Contains(err.Error(), "reading") {
+		t.Errorf("error %q should mention reading the input", err)
+	}
+}
+
+func TestRun_UsageErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"no args", nil},
+		{"unknown subcommand", []string{"verify"}},
+		{"keygen with extra args", []string{"keygen", "extra"}},
+		{"sign without file", []string{"sign"}},
+		{"sign with too many args", []string{"sign", "a", "b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := run(tc.args, &bytes.Buffer{})
+			if err == nil {
+				t.Fatal("want error, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a build-time Ed25519 signer at `cli/cmd/syllago-sign` (stdlib `crypto/ed25519` only) with `keygen` + `sign` subcommands
- Wires `release.yml` to fetch a private key from Aembit and sign `checksums.txt`, producing `checksums.txt.sig` as a release asset
- Injects the matching public key into all release binaries via `-ldflags`, enabling the existing self-update verifier in `cli/internal/updater` to validate downloaded checksums

## Why
The `updater.SigningPublicKey` variable and `verifyChecksumSignature` were added in the H1 security fix but never reached release builds — the workflow inlines its own `go build` and never passed the key. Without this PR, releases warn "no signing key configured" during self-update instead of verifying signatures.

## Graceful degradation
The workflow runs to completion even without the secrets configured:
- No `SYLLAGO_SIGNING_PUBLIC_KEY` repo var → binaries built without embedded key, self-update skips signature check with the existing warning
- No Aembit credential or `SYLLAGO_SIGNING_AEMBIT_HOST` repo var → signing step is skipped, workflow emits a warning, no `checksums.txt.sig` uploaded

This mirrors the verifier's existing tolerance and lets the workflow keep working for forks and during the transition period.

## Manual setup required before signing becomes load-bearing
Once these are done, the next release will produce a signed checksums file and signature-verifying binaries:

- [x] Generate keypair: `cd ~/.local/src/syllago-signing && go run ./cli/cmd/syllago-sign keygen`
- [x] Configure Aembit Server Workload + Access Policy delivering the private key (hex) as `ApiKey` credential type
- [x] Set repo variable `SYLLAGO_SIGNING_PUBLIC_KEY` to the public key hex
- [x] Set repo variable `SYLLAGO_SIGNING_AEMBIT_HOST` to the Aembit Server Workload host identifier
- [ ] Cut a release and verify `checksums.txt.sig` is uploaded
- [ ] Run `syllago _update` against that release and confirm the "Signature verified" message

Refs syllago-8hp6r.

## Test plan
- [ ] CI passes (build, tests, golangci-lint, gofmt)
- [ ] `go test ./cmd/syllago-sign/...` — five tests covering keygen, sign roundtrip with `ed25519.Verify`, bad-key rejection, missing-input handling, and usage errors
- [ ] Existing `cli/internal/updater` signature tests still green
- [ ] After Aembit + repo vars are configured, `workflow_dispatch` a release and confirm `checksums.txt.sig` uploads
- [ ] Self-update from a previous unsigned release to the first signed release succeeds without errors

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)