### PR TITLE
capmon(amp): retire dead hooks.md, enrich hooks+skills from refetch

### DIFF
--- a/cli/internal/capmon/recognize_amp.go
+++ b/cli/internal/capmon/recognize_amp.go
@@ -67,18 +67,22 @@ func ampRulesLandmarkOptions() LandmarkOptions {
 }
 
 // ampHooksLandmarkOptions returns the landmark patterns for Amp's hooks
-// capabilities. Evidence is split across two cache sources:
-//   - hooks.0 (hooks.md): only one landmark "Hooks" — too thin to anchor on
-//   - hooks.1 (permissions-reference.md): rich landmarks describing match
+// capabilities. Evidence comes from a single cache source:
+//   - hooks.0 (permissions-reference.md): rich landmarks describing match
 //     conditions, regex patterns, and rule management
+//
+// The previous /manual/hooks.md page was retired in early 2026 (drift
+// detection issue #92, 2026-04-29) and the runtime hooks feature is now
+// documented inline at https://ampcode.com/manual?internal#hooks. That page
+// only carries one "Hooks" heading — too thin to anchor on — so recognition
+// continues to be driven entirely by the permissions reference doc.
 //
 // Per the curated format YAML (docs/provider-formats/amp.yaml), 2 of the 9
 // canonical hooks keys are supported: matcher_patterns
 // (hook_match_input_contains via "Match Conditions" + "Regular Expression
 // Patterns") and permission_control (permissions_system via "How Permissions
-// Work" + "Add Rules"). Both pieces of evidence live in the permissions
-// reference doc — amp's hooks integrate with the permission system rather
-// than expose a hook-specific protocol.
+// Work" + "Add Rules"). Amp's hooks integrate with the permission system
+// rather than expose a hook-specific protocol.
 //
 // Required anchors are unique to the permissions doc:
 //   - "Permissions Reference" — H1 of permissions-reference.md
@@ -142,9 +146,10 @@ func ampMcpLandmarkOptions() LandmarkOptions {
 // documentation; recognition uses landmark (heading) matching. Static facts
 // merge in at "confirmed" confidence after a successful skills landmark match.
 //
-// Amp's hooks doc itself (hooks.0) has only a single H1 landmark, so hooks
-// recognition is anchored against the permissions reference doc (hooks.1)
-// where the matcher_patterns and permission_control evidence lives.
+// Hooks recognition runs against the permissions reference doc (the only
+// fetched hooks source) where the matcher_patterns and permission_control
+// evidence lives. See ampHooksLandmarkOptions for context on the retired
+// /manual/hooks.md page.
 func recognizeAmp(ctx RecognitionContext) RecognitionResult {
 	skillsResult := recognizeLandmarks(ctx, ampLandmarkOptions())
 	if len(skillsResult.Capabilities) > 0 {

--- a/docs/provider-capabilities/amp-hooks.yaml
+++ b/docs/provider-capabilities/amp-hooks.yaml
@@ -52,7 +52,7 @@ proposed_mappings:
       confidence: confirmed
     - canonical_key: permission_control
       supported: true
-      mechanism: 'permissions_system: Amp has a permissions system that hooks interact with to make tool availability decisions'
+      mechanism: amp.permissions ordered first-match-wins rule list returns one of allow / reject / ask / delegate for every tool invocation before execution; default fallback is ask on the main thread and reject in sub-agents
       source_field: ""
       source_value: ""
       confidence: confirmed

--- a/docs/provider-formats/amp.yaml
+++ b/docs/provider-formats/amp.yaml
@@ -2,7 +2,7 @@ provider: amp
 docs_url: "https://ampcode.com/manual"
 category: cli
 last_fetched_at: "2026-04-11T21:49:38Z"
-last_changed_at: "2026-04-17T00:00:00Z"
+last_changed_at: "2026-04-29T00:00:00Z"
 generation_method: subagent
 
 content_types:
@@ -169,11 +169,6 @@ content_types:
   hooks:
     status: supported
     sources:
-      - uri: "https://ampcode.com/manual/hooks.md"
-        type: documentation
-        fetch_method: http
-        content_hash: "sha256:1f080df99fc26d005c22b16cba57120e3bed450d3b5521f5f40d7f594aa7f6b6"
-        fetched_at: "2026-04-11T21:49:36Z"
       - uri: "https://ampcode.com/manual/appendix/permissions-reference.md"
         type: documentation
         fetch_method: http
@@ -222,49 +217,49 @@ content_types:
       - id: settings_json_merge
         name: "JSON merge into amp.hooks array"
         summary: "Hooks are stored as an array under the 'amp.hooks' key inside '.amp/settings.json' (workspace) or user-scope settings; they are not a standalone hooks file."
-        source_ref: "https://ampcode.com/manual/hooks.md"
+        source_ref: "https://ampcode.com/manual?internal#hooks"
         graduation_candidate: false
         conversion: not-portable
         provider_field: "amp.hooks"
       - id: command_handler_only
         name: "Command handler type only"
         summary: "The hook 'action' field invokes a shell command (declarative pre-execute 'send-user-message' and post-execute 'redact-tool-input' actions); no HTTP, LLM, or agent handler types are documented."
-        source_ref: "https://ampcode.com/manual/hooks.md"
+        source_ref: "https://ampcode.com/manual?internal#hooks"
         graduation_candidate: false
         conversion: translated
         provider_field: "action"
       - id: hook_events
         name: "Hook trigger events"
         summary: "Two events: 'tool:pre-execute' (before tool runs) and 'tool:post-execute' (after); each event accepts only specific actions. Canonical mapping: before_tool_execute → tool:pre-execute, after_tool_execute → tool:post-execute."
-        source_ref: "https://ampcode.com/manual/hooks.md"
+        source_ref: "https://ampcode.com/manual?internal#hooks"
         graduation_candidate: false
         conversion: translated
         provider_field: "event"
       - id: hook_action_send_user_message
         name: "Hook action: send-user-message"
         summary: "Pre-execute action that injects a user message and cancels the pending tool call to enforce behavioral constraints."
-        source_ref: "https://ampcode.com/manual/hooks.md"
+        source_ref: "https://ampcode.com/manual?internal#hooks"
         graduation_candidate: false
         conversion: not-portable
         provider_field: "action.type"
       - id: hook_action_redact_tool_input
         name: "Hook action: redact-tool-input"
         summary: "Post-execute action that redacts tool input fields after execution to avoid storing sensitive arguments."
-        source_ref: "https://ampcode.com/manual/hooks.md"
+        source_ref: "https://ampcode.com/manual?internal#hooks"
         graduation_candidate: false
         conversion: not-portable
         provider_field: "action.type"
       - id: hook_match_input_contains
         name: "Hook match condition: input.contains"
         summary: "Filter hook firing by exact literal substring match in tool input — no regex or glob support."
-        source_ref: "https://ampcode.com/manual/hooks.md"
+        source_ref: "https://ampcode.com/manual?internal#hooks"
         graduation_candidate: false
         conversion: translated
         provider_field: "input.contains"
       - id: hook_config_location
         name: "Hook configuration in settings file"
         summary: "Hook definitions live as an array in Amp settings files (.amp/settings.json or user-scope settings)."
-        source_ref: "https://ampcode.com/manual/hooks.md"
+        source_ref: "https://ampcode.com/manual?internal#hooks"
         graduation_candidate: false
         conversion: not-portable
         provider_field: "amp.hooks"
@@ -304,16 +299,17 @@ content_types:
         conversion: not-portable
     loading_model: "Hooks and permissions are loaded from the Amp settings file at startup. Hook definitions live under 'amp.hooks' and permission rules under 'amp.permissions'. Permission rules are evaluated as an ordered list — the first matching rule wins. No lazy loading is described; both systems are active for the duration of the Amp session."
     notes: >
-      Amp has two distinct but related interception systems in these sources. The 'hooks' system
-      (hooks-0 source) is simpler: two events (tool:pre-execute, tool:post-execute) with two
-      actions (send-user-message, redact-tool-input). The 'permissions' system (hooks-1 source)
-      is richer: ordered allow/reject/ask/delegate rules with glob and regex matching, context
+      Amp has two distinct but related interception systems. The 'hooks' system is simpler:
+      two events (tool:pre-execute, tool:post-execute) with two actions (send-user-message,
+      redact-tool-input); the runtime feature is documented at
+      https://ampcode.com/manual?internal#hooks (the dedicated /manual/hooks.md page was
+      retired in early 2026 — the consolidated single-page manual is now the canonical source,
+      and the news announcement at https://ampcode.com/news/hooks remains for historical
+      context). The 'permissions' system (the sole fetched source for this content type) is
+      richer: ordered allow/reject/ask/delegate rules with glob and regex matching, context
       restriction, and external delegation. The permissions doc explicitly notes that the plugin
       API is the preferred path for new permission hooks and is expected to replace the built-in
-      permissions system. The raw.bin content for hooks-0 contains truncated JSON examples (the
-      example payloads appear partially redacted in the fetched source), but the event names,
-      action names, input.contains behavior, and settings file location are all explicitly stated
-      in the surrounding prose.
+      permissions system.
   mcp:
     status: supported
     sources:

--- a/docs/provider-formats/amp.yaml
+++ b/docs/provider-formats/amp.yaml
@@ -12,8 +12,8 @@ content_types:
       - uri: "https://ampcode.com/manual/agent-skills.md"
         type: documentation
         fetch_method: md_url
-        content_hash: "sha256:f4fca62a6b5a7d94d4995cbb0be4fbadc11a4166fd9faf345139bc0b4c6a5e90"
-        fetched_at: "2026-04-11T21:49:40Z"
+        content_hash: "sha256:624b341cdc99453666703ca02acc9783338ca165cbe8641e9204beaaec7e367c"
+        fetched_at: "2026-04-29T16:15:06Z"
     canonical_mappings:
       display_name:
         supported: true
@@ -67,7 +67,7 @@ content_types:
     provider_extensions:
       - id: mcp_bundling
         name: "MCP server bundling"
-        summary: "Bundle an MCP server with the skill via mcp.json (local command or remote URL); tools stay hidden until skill loads."
+        summary: "Bundle an MCP server with the skill via mcp.json (local command/args/env or remote url/headers); supports an includeTools glob-pattern allowlist to filter exposed tools; tools stay hidden until skill loads."
         source_ref: "https://ampcode.com/manual/agent-skills.md"
         graduation_candidate: false
         conversion: not-portable
@@ -85,7 +85,13 @@ content_types:
         conversion: embedded
       - id: skill_cli
         name: "CLI and command palette skill management"
-        summary: "Manage skills via 'amp skill' CLI or command palette (add/list/remove); supports GitHub shorthand paths."
+        summary: "Manage skills via 'amp skill' CLI or command palette (Ctrl+O in the CLI) using 'skill: add', 'skill: list', 'skill: remove'; install from GitHub shorthand (org/repo/path), git URL, or local path."
+        source_ref: "https://ampcode.com/manual/agent-skills.md"
+        graduation_candidate: false
+        conversion: not-portable
+      - id: building_skills_assistant
+        name: "Built-in 'building-skills' skill"
+        summary: "Amp ships a built-in 'building-skills' skill that authors new skills tailored to the current codebase via natural-language request (e.g., 'Create a skill for deploying to staging'); user picks 'project-specific' or 'user-wide' scope."
         source_ref: "https://ampcode.com/manual/agent-skills.md"
         graduation_candidate: false
         conversion: not-portable
@@ -172,8 +178,8 @@ content_types:
       - uri: "https://ampcode.com/manual/appendix/permissions-reference.md"
         type: documentation
         fetch_method: http
-        content_hash: "sha256:47ad540681b67823f587fb4d4e5b04f1bd6a0e635db56f459446358caa4b25dc"
-        fetched_at: "2026-04-11T21:49:36Z"
+        content_hash: "sha256:05d7e9a34503c66e61ee90515a39fbe18a6964aab3b7d196102da24c2275b872"
+        fetched_at: "2026-04-29T16:15:03Z"
     canonical_mappings:
       handler_types:
         supported: true
@@ -211,7 +217,7 @@ content_types:
         confidence: inferred
       permission_control:
         supported: true
-        mechanism: "permissions_system: Amp has a permissions system that hooks interact with to make tool availability decisions"
+        mechanism: "amp.permissions ordered first-match-wins rule list returns one of allow / reject / ask / delegate for every tool invocation before execution; default fallback is ask on the main thread and reject in sub-agents"
         confidence: confirmed
     provider_extensions:
       - id: settings_json_merge
@@ -272,18 +278,31 @@ content_types:
         provider_field: "amp.permissions"
       - id: permissions_match_conditions
         name: "Permission match condition types"
-        summary: "Match values support globs, regex (slash-delimited), arrays (OR), literals, and nested objects with dot notation."
+        summary: "Match values support glob patterns ('*'), regex (strings starting and ending with '/'), arrays (OR across entries), literals (boolean/number/null/undefined as exact match), and nested objects (deep property matching with dot notation for objects and numeric strings for array indices). Tool name field also accepts globs (e.g., 'Bash', 'mcp__playwright__*')."
         source_ref: "https://ampcode.com/manual/appendix/permissions-reference.md"
         graduation_candidate: false
         conversion: not-portable
         provider_field: "matches"
       - id: permissions_delegate_action
         name: "Permission delegate action"
-        summary: "Delegate decisions to an external program (JSON via stdin, exit code = decision); plugin API is the recommended successor."
+        summary: "Delegate decisions to an external program named in the rule's 'to' field (must be on $PATH or an absolute path). Amp pipes tool parameters as JSON to stdin and exports AMP_THREAD_ID, AGENT_TOOL_NAME, and AGENT=amp env vars. Exit status: 0=allow, 1=ask operator, ≥2=reject (stderr surfaced to the model). Plugin API is the documented successor; a compatibility plugin enforcing amp.permissions rules is planned."
         source_ref: "https://ampcode.com/manual/appendix/permissions-reference.md"
         graduation_candidate: false
         conversion: not-portable
         provider_field: "action"
+      - id: permissions_reject_message
+        name: "Permission reject with continuation message"
+        summary: "A 'reject' rule may carry a 'message' string returned to the model; when set, the rejection continues the conversation with that feedback instead of halting it."
+        source_ref: "https://ampcode.com/manual/appendix/permissions-reference.md"
+        graduation_candidate: false
+        conversion: not-portable
+        provider_field: "message"
+      - id: permissions_default_behavior
+        name: "Default action when no rule matches"
+        summary: "If no user rule and no built-in rule matches, Amp asks the operator on the main thread and rejects the call in sub-agents. Built-in rules (e.g., allowing 'ls' via Bash) are consulted after user rules."
+        source_ref: "https://ampcode.com/manual/appendix/permissions-reference.md"
+        graduation_candidate: false
+        conversion: not-portable
       - id: permissions_context_restriction
         name: "Permission context restriction (thread vs subagent)"
         summary: "Optionally scopes a rule to main thread, sub-agent only, or both (omitted); defaults differ by context."
@@ -293,7 +312,7 @@ content_types:
         provider_field: "context"
       - id: permissions_cli
         name: "Permissions CLI (amp permissions)"
-        summary: "'amp permissions' subcommands (list/add/edit/test) manage rules in a UNIX-shell-style text format without editing JSON."
+        summary: "'amp permissions' subcommands manage rules in a UNIX-shell-style text format without editing JSON: 'list' (with '--builtin' for built-ins only), 'add' (e.g., 'add reject web_search'), 'edit' (opens $EDITOR; also accepts STDIN), and 'test' (dry-runs a tool+args call and prints the matched rule, action, and source). Single/double-quoted strings supported; unquoted true/false/null/numbers parsed as JSON literals; values containing '*' must be quoted."
         source_ref: "https://ampcode.com/manual/appendix/permissions-reference.md"
         graduation_candidate: false
         conversion: not-portable

--- a/docs/provider-sources/amp.yaml
+++ b/docs/provider-sources/amp.yaml
@@ -54,17 +54,15 @@ content_types:
 
   hooks:
     sources:
-      - url: https://ampcode.com/manual/hooks.md
-        type: docs
-        format: markdown
-        extracts: [config_schema, event_names, match_conditions]
-
       - url: https://ampcode.com/manual/appendix/permissions-reference.md
         type: docs
         format: markdown
         extracts: [permissions_schema, match_conditions]
     # Amp supports hooks via amp.hooks array in settings JSON (tool:pre-execute / tool:post-execute).
     # NOT file-based — stored as JSON config entries. Syllago manages via JSON merge into settings.
+    # Note: ampcode.com/manual/hooks.md was retired; the hooks section now lives inline at
+    # ampcode.com/manual?internal#hooks (auth-gated). Recognition is anchored entirely on
+    # permissions-reference.md — see recognize_amp.go:71.
 
   mcp:
     sources:


### PR DESCRIPTION
## Summary

Curation-only batch for the amp provider, addressing five open capmon-change issues.

### What changed

- **Format doc** (\`docs/provider-formats/amp.yaml\`):
  - Drops the retired \`manual/hooks.md\` source — the recognizer (\`recognize_amp.go:71\`) was already documented as anchoring exclusively on \`permissions-reference.md\`, so this is alignment, not a behavior change
  - Updates seven \`provider_extensions[].source_ref\` fields that pointed at the dead URL
  - Refreshes content hashes + \`fetched_at\` timestamps against fresh fetches (2026-04-29)
  - Enriches existing \`provider_extensions\` for skills (\`mcp_bundling\`, \`skill_cli\`) and hooks (\`permission_control\`, \`permissions_match_conditions\`, \`permissions_delegate_action\`, \`permissions_cli\`)
  - Adds three new \`provider_extensions\`: \`building_skills_assistant\` (skills), \`permissions_reject_message\` (hooks), \`permissions_default_behavior\` (hooks)

- **Source manifest** (\`docs/provider-sources/amp.yaml\`):
  - Drops the same retired URL so capmon-fetch never targets it again
  - Adds an inline note that the hooks docs moved to \`ampcode.com/manual?internal#hooks\` (auth-gated, not fetchable)

- **Recognizer** (\`cli/internal/capmon/recognize_amp.go\`):
  - Updates the doc comment to reflect that hooks recognition is single-source

- **Derived spec** (\`docs/provider-capabilities/amp-hooks.yaml\`):
  - \`permission_control.mechanism\` field updated to match the enriched format-doc mechanism (only diff)

### Why this is curation-only

\`recognize_amp.go:71\` documented \`hooks.0\` (manual/hooks.md) as "too thin to anchor on" before this branch. Recognition was already driven entirely by \`hooks.1\` (permissions-reference.md). Dropping the dead source aligns the format/source docs with what the recognizer was already doing — no recognition behavior changes, no canonical mapping changes.

### Process note

An automated capmon heal run produced \`capmon/heal-amp/hooks/w0kui5hu\` mid-conversation, attempting to swap the dead URL for \`manual/hooks/index.md\`. That candidate returns 302 → \`/auth/sign-in\` (same host) but was misclassified as success because the heal validator silently follows redirects and short-circuits on same-host. Heal branch + remote deleted; the validator bug will be addressed in a separate change.

## Issues closed

- Closes #92 (capmon-fetch-error: amp/hooks)
- Closes #93 (capmon-change: amp/skills)
- Closes #135 (capmon-change: amp/hooks)
- Closes #156 (capmon-change: amp/hooks)
- Closes #157 (capmon-change: amp/hooks)

## Test plan

- [x] \`syllago capmon validate-format-doc --provider=amp\` → all checks pass
- [x] \`syllago capmon validate-sources --provider=amp\` → manifest valid
- [x] \`syllago capmon derive --provider=amp --output-dir docs/provider-capabilities\` → only the expected 1-line mechanism update in amp-hooks.yaml
- [x] \`go test ./cli/internal/capmon/ -run Amp -count=1\` → ok
- [x] \`make fmt\` → clean
- [ ] CI green