### PR TITLE
feat(capmon): per-provider docs_conventions block for heal pipeline

### DIFF
--- a/.beads/last-touched
+++ b/.beads/last-touched
@@ -1,1 +1,1 @@
-syllago-ryu2a
+syllago-yogqh

--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,7 +1,7 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-30T19:28:42.849Z
-> Files: 1297 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-30T23:19:16.281Z
+> Files: 1299 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../../../
 
@@ -45,6 +45,7 @@
 - `feedback_no_vague_limitations.md` (~349 tok)
 - `feedback_release_notes_no_internal_labels.md` — Declares breakdowns (~803 tok)
 - `feedback_smoke_uses_real_cli.md` (~453 tok)
+- `feedback_tdd_discipline.md` — Declares definitions (~451 tok)
 - `learning_hook_event_translation.md` (~430 tok)
 - `learning_moat_dual_attested_verification.md` — Spec-grounded fact (~824 tok)
 - `learning_moat_source_uri_content_hash.md` (~571 tok)
@@ -52,7 +53,7 @@
 - `learning_resolve_cross_provider_fallback.md` (~439 tok)
 - `learning_signing_public_key_var_not_secret.md` (~388 tok)
 - `learning_tui_add_container_types.md` — Declares whose (~453 tok)
-- `MEMORY.md` — Syllago Project Memory (~2813 tok)
+- `MEMORY.md` — Syllago Project Memory (~2875 tok)
 - `project_provider_eligibility.md` (~475 tok)
 - `reference_stealth_fetch.md` — stealth-fetch (~308 tok)
 - `user_commit_email.md` — Global git config (as of 2026-04-27) (~478 tok)
@@ -64,11 +65,11 @@
 
 ## ../../../.claude/skills/syllago-capmon-process/
 
-- `SKILL.md` — syllago-capmon-process (~1466 tok)
+- `SKILL.md` — syllago-capmon-process (~1826 tok)
 
 ## ../../../.claude/skills/syllago-capmon-process/workflows/
 
-- `process-issues.md` — Process Issues Workflow (~3101 tok)
+- `process-issues.md` — Process Issues Workflow (~3538 tok)
 
 ## ../../../.config/pai/
 
@@ -1768,10 +1769,10 @@
 - `healing_pr_test.go` — TestUpdateManifestURL_ReplacesTargetOnly, TestUpdateManifestURL_WrongOldURL, TestUpdateManifestURL_I (~3415 tok)
 - `healing_pr.go` — Struct: HealPRInputs (~2631 tok)
 - `healing_redirect.go` — Struct: RedirectChain (~1340 tok)
-- `healing_test.go` — TestAttemptHeal_DisabledShortCircuits, TestAttemptHeal_VariantStrategySucceeds, TestAttemptHeal_Vari (~6211 tok)
-- `healing.go` — Struct: HealResult (~2814 tok)
+- `healing_test.go` — TestAttemptHeal_DisabledShortCircuits, TestAttemptHeal_VariantStrategySucceeds, TestAttemptHeal_Vari (~8287 tok)
+- `healing.go` — Struct: HealResult (~3656 tok)
 - `pipeline_heal_test.go` — TestTryHealSource_DisabledReturnsNil, TestTryHealSource_FailureRecordsCounter, TestTryHealSource_Pro (~1718 tok)
-- `pipeline.go` — Struct: PipelineOptions (~4188 tok)
+- `pipeline.go` — Struct: PipelineOptions (~4205 tok)
 - `recognize_agents_test.go` — TestAgentsContentType, TestCanonicalAgentsKeys_MatchesCanonicalKeysYAML, TestIsCanonicalAgentsKey, T (~2192 tok)
 - `recognize_agents.go` — IsCanonicalAgentsKey, AgentsLandmarkOptions, AgentsLandmarkPattern (~1526 tok)
 - `recognize_amp_test.go` — TestRecognizeAmp_RealLandmarks, TestRecognizeAmp_AnchorsMissing, TestRecognizeAmp_NoLandmarks, TestR (~3302 tok)
@@ -1825,9 +1826,10 @@
 - `seederspec_audit_test.go` — TestSeederSpecs_AllLoad (~508 tok)
 - `seederspec_test.go` — TestLoadSeederSpec_Valid, TestSeederSpecPath (~712 tok)
 - `seederspec.go` — Struct: ProposedMapping (~535 tok)
+- `sourceman_test.go` — TestLoadSourceManifest, TestLoadSourceManifest_NotFound, TestLoadAllSourceManifests, TestLoadAllSour (~2636 tok)
 - `sourceman_validate_test.go` — TestValidateSources_AllHaveSources, TestValidateSources_MissingURIs, TestValidateSources_SupportedFa (~1387 tok)
 - `sourceman_validate.go` — ValidateSources (~660 tok)
-- `sourceman.go` — Struct: SourceManifest (~1139 tok)
+- `sourceman.go` — Struct: SourceManifest (~1620 tok)
 - `types_test.go` — TestExtractedSource_ZeroValue, TestRunManifest_ExitClasses, TestSelectorConfig_Fields, TestRunManife (~1067 tok)
 - `types.go` — implements the syllago capability monitor pipeline. (~1398 tok)
 
@@ -2321,8 +2323,8 @@
 
 ## docs/provider-sources/
 
-- `_template.yaml` — {Provider Name} — Provider Source Manifest (~1466 tok)
-- `amp.yaml` — Amp — Provider Source Manifest (~1104 tok)
+- `_template.yaml` — {Provider Name} — Provider Source Manifest (~1846 tok)
+- `amp.yaml` — Amp — Provider Source Manifest (~1387 tok)
 - `claude-code.yaml` — Claude Code — Provider Source Manifest (~1146 tok)
 - `cline.yaml` — Cline — Provider Source Manifest (~1050 tok)
 - `codex.yaml` — Codex (OpenAI) — Provider Source Manifest (~2476 tok)

--- a/cli/internal/capmon/healing.go
+++ b/cli/internal/capmon/healing.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -32,9 +34,17 @@ type HealResult struct {
 // bypass opt-out (healing.enabled=false causes AttemptHeal to return
 // Success=false with a FailReason explaining the skip, never an error).
 //
+// conventions, when non-nil, applies provider-specific URL hints from
+// the source manifest's docs_conventions block: variant candidates
+// matching RetiredPaths are dropped before probing, and OutcomeRedirected
+// outcomes are enriched with an "auth gate" detail when the final URL
+// matches an AuthGatedPaths substring. Conventions never change
+// success/failure outcomes — they only filter inputs and annotate
+// diagnostics.
+//
 // The orchestrator never mutates src. All new URLs are proposed via
 // the PR flow downstream of this call.
-func AttemptHeal(ctx context.Context, src SourceEntry, fetchErr error) (*HealResult, error) {
+func AttemptHeal(ctx context.Context, src SourceEntry, conventions *DocsConventions, fetchErr error) (*HealResult, error) {
 	result := &HealResult{}
 	if !src.IsHealingEnabled() {
 		result.FailReason = "healing disabled for this source"
@@ -78,6 +88,10 @@ func AttemptHeal(ctx context.Context, src SourceEntry, fetchErr error) (*HealRes
 			}
 		case "variant":
 			variants := GenerateVariants(src.URL)
+			variants, retiredDropped := filterRetiredVariants(variants, conventions)
+			if retiredDropped > 0 {
+				declineReasons = append(declineReasons, fmt.Sprintf("variant: dropped %d candidate(s) matching retired_paths", retiredDropped))
+			}
 			if len(variants) == 0 {
 				declineReasons = append(declineReasons, "variant: no candidates generated")
 				continue
@@ -94,6 +108,7 @@ func AttemptHeal(ctx context.Context, src SourceEntry, fetchErr error) (*HealRes
 
 		for _, cand := range candidates {
 			outcome := validateHealCandidate(ctx, src.URL, cand, strategy)
+			enrichAuthGateDetail(&outcome, conventions)
 			result.CandidateOutcomes = append(result.CandidateOutcomes, outcome)
 			if outcome.Outcome == OutcomeSuccess {
 				result.Success = true
@@ -284,6 +299,72 @@ func invalidKindToOutcome(k InvalidKind) CandidateOutcomeKind {
 		// Unknown kinds shouldn't reach here, but treat as a generic
 		// connect_error rather than crashing.
 		return OutcomeConnectError
+	}
+}
+
+// filterRetiredVariants drops candidates whose URL path matches any
+// docs_conventions.retired_paths entry exactly. Returns the surviving
+// candidates and the count of dropped ones (for diagnostic surfacing).
+// Matching is exact path equality — a retired_paths entry of
+// "/manual/hooks.md" matches a candidate URL with path "/manual/hooks.md"
+// regardless of host or query string.
+func filterRetiredVariants(variants []VariantCandidate, conventions *DocsConventions) ([]VariantCandidate, int) {
+	if conventions == nil || len(conventions.RetiredPaths) == 0 {
+		return variants, 0
+	}
+	retired := make(map[string]bool, len(conventions.RetiredPaths))
+	for _, p := range conventions.RetiredPaths {
+		retired[p] = true
+	}
+	out := make([]VariantCandidate, 0, len(variants))
+	dropped := 0
+	for _, v := range variants {
+		u, err := url.Parse(v.URL)
+		if err != nil {
+			out = append(out, v)
+			continue
+		}
+		if retired[u.Path] {
+			dropped++
+			continue
+		}
+		out = append(out, v)
+	}
+	return out, dropped
+}
+
+// enrichAuthGateDetail annotates a CandidateOutcome whose Outcome is
+// OutcomeRedirected and whose redirect chain (any hop's destination, or
+// the final URL) contains an AuthGatedPaths substring with a
+// human-readable Detail. This is triage signal only — the redirect
+// outcome is already drift, this just tells the human "the redirect
+// went somewhere meaningful (login wall) rather than a generic alias".
+// Scanning every hop matters because real auth flows often bounce out
+// to a separate host (e.g. ampcode.com/auth/sign-in →
+// auth.ampcode.com/?client_id=...) so the gate path lives mid-chain,
+// not at the terminal URL. No-op when conventions is nil or
+// auth_gated_paths is empty. Preserves any pre-existing Detail.
+func enrichAuthGateDetail(out *CandidateOutcome, conventions *DocsConventions) {
+	if out.Outcome != OutcomeRedirected || conventions == nil || len(conventions.AuthGatedPaths) == 0 {
+		return
+	}
+	if out.Detail != "" {
+		return
+	}
+	for _, gate := range conventions.AuthGatedPaths {
+		if gate == "" {
+			continue
+		}
+		if strings.Contains(out.FinalURL, gate) {
+			out.Detail = fmt.Sprintf("candidate redirected to known auth gate (%s)", gate)
+			return
+		}
+		for _, hop := range out.Redirects {
+			if strings.Contains(hop.To, gate) {
+				out.Detail = fmt.Sprintf("candidate redirected to known auth gate (%s)", gate)
+				return
+			}
+		}
 	}
 }
 

--- a/cli/internal/capmon/healing_test.go
+++ b/cli/internal/capmon/healing_test.go
@@ -22,7 +22,7 @@ func TestAttemptHeal_DisabledShortCircuits(t *testing.T) {
 		URL:     "https://example.com/docs/foo.md",
 		Healing: &HealingConfig{Enabled: &enabled},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("fetch 404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("fetch 404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestAttemptHeal_VariantStrategySucceeds(t *testing.T) {
 			Strategies: []string{"variant"},
 		},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestAttemptHeal_VariantFailsContentValidation(t *testing.T) {
 			Strategies: []string{"variant"},
 		},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestAttemptHeal_VariantTooSmall(t *testing.T) {
 			Strategies: []string{"variant"},
 		},
 	}
-	result, _ := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, _ := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if result.Success {
 		t.Error("expected failure when candidate body too small")
 	}
@@ -125,7 +125,7 @@ func TestAttemptHeal_UnknownStrategyIgnored(t *testing.T) {
 			Strategies: []string{"telepathy"},
 		},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestAttemptHeal_RedirectStrategyRejectsTemporary(t *testing.T) {
 			Strategies: []string{"redirect"},
 		},
 	}
-	result, _ := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, _ := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if result.Success {
 		t.Error("302 chain must not produce a successful heal")
 	}
@@ -184,7 +184,7 @@ func TestAttemptHeal_RedirectStrategySucceedsOnPermanent(t *testing.T) {
 			Strategies: []string{"redirect"},
 		},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestAttemptHeal_VariantRejectsRedirectedCandidate(t *testing.T) {
 			Strategies: []string{"variant"},
 		},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestAttemptHeal_VariantMultiHopRedirectChainCaptured(t *testing.T) {
 			Strategies: []string{"variant"},
 		},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestAttemptHeal_VariantHTTPError(t *testing.T) {
 			Strategies: []string{"variant"},
 		},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -369,7 +369,7 @@ func TestAttemptHeal_VariantConnectError(t *testing.T) {
 			Strategies: []string{"variant"},
 		},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -421,7 +421,7 @@ func TestAttemptHeal_SuccessCapturesOutcomes(t *testing.T) {
 			Strategies: []string{"variant"},
 		},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -456,7 +456,7 @@ func TestAttemptHeal_FailReasonDerivedSummary(t *testing.T) {
 			Strategies: []string{"variant"},
 		},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -503,7 +503,7 @@ func TestAttemptHeal_StrategyDeclinesPopulatedAlongsideOutcomes(t *testing.T) {
 			Strategies: []string{"redirect", "variant"},
 		},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -575,7 +575,7 @@ func TestAttemptHeal_StrategiesTriedInOrder(t *testing.T) {
 			Strategies: []string{"redirect", "variant"},
 		},
 	}
-	result, err := AttemptHeal(context.Background(), src, errors.New("404"))
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
 	if err != nil {
 		t.Fatalf("AttemptHeal: %v", err)
 	}
@@ -699,5 +699,213 @@ func TestRunRedirectStrategy_AcceptsSameRegistrableDomain(t *testing.T) {
 	}
 	if cand != "https://docs.example.com/new" {
 		t.Errorf("cand = %q, want https://docs.example.com/new", cand)
+	}
+}
+
+// TestAttemptHeal_RetiredPathFiltersVariant pins the docs_conventions
+// retired_paths semantics. Original URL has stem "Hooks" — variant
+// generator emits "/manual/hooks.md" via the lowercase-stem rule. That
+// path is in retired_paths, so it must be dropped before probing.
+// Without conventions, the same variant would be probed and (in this
+// fixture) succeed; with conventions, no variant remains and the heal
+// fails with a "retired_paths" decline reason.
+func TestAttemptHeal_RetiredPathFiltersVariant(t *testing.T) {
+	mux := http.NewServeMux()
+	// /manual/hooks.md returns valid content. Without conventions, the
+	// lowercase-stem variant of /manual/Hooks.md would heal here.
+	mux.HandleFunc("/manual/hooks.md", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/markdown")
+		_, _ = w.Write(validBody)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	src := SourceEntry{
+		URL: srv.URL + "/manual/Hooks.md",
+		Healing: &HealingConfig{
+			Strategies: []string{"variant"},
+		},
+	}
+	conventions := &DocsConventions{
+		RetiredPaths: []string{"/manual/hooks.md"},
+	}
+	result, err := AttemptHeal(context.Background(), src, conventions, errors.New("404"))
+	if err != nil {
+		t.Fatalf("AttemptHeal: %v", err)
+	}
+	// The retired path must not appear in CandidateOutcomes — filtering
+	// happens before any probe.
+	for _, o := range result.CandidateOutcomes {
+		if strings.HasSuffix(o.URL, "/manual/hooks.md") {
+			t.Errorf("retired path %q was probed; expected to be filtered. CandidateOutcomes=%+v", o.URL, result.CandidateOutcomes)
+		}
+	}
+	// At least one strategy decline should record the drop.
+	foundDecline := false
+	for _, d := range result.StrategyDeclines {
+		if strings.Contains(d, "retired_paths") {
+			foundDecline = true
+			break
+		}
+	}
+	if !foundDecline {
+		t.Errorf("StrategyDeclines = %v, want one mentioning retired_paths", result.StrategyDeclines)
+	}
+}
+
+// TestAttemptHeal_AuthGateDetailEnriched pins the docs_conventions
+// auth_gated_paths semantics. Variant candidate 302-redirects to
+// /auth/sign-in (qc7yf already rejects this on correctness grounds).
+// With conventions populated, the resulting CandidateOutcome.Detail
+// should call out the auth gate so triagers see the cause, not just
+// "redirected".
+func TestAttemptHeal_AuthGateDetailEnriched(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/sign-in", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write(validBody)
+	})
+	mux.HandleFunc("/manual/hooks/index.md", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "/auth/sign-in?returnTo="+r.URL.Path)
+		w.WriteHeader(http.StatusFound) // 302
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	src := SourceEntry{
+		URL: srv.URL + "/manual/hooks.md",
+		Healing: &HealingConfig{
+			Strategies: []string{"variant"},
+		},
+	}
+	conventions := &DocsConventions{
+		AuthGatedPaths: []string{"/auth/sign-in", "/login"},
+	}
+	result, err := AttemptHeal(context.Background(), src, conventions, errors.New("404"))
+	if err != nil {
+		t.Fatalf("AttemptHeal: %v", err)
+	}
+	if result.Success {
+		t.Fatalf("expected rejection on auth-gate redirect; got NewURL=%q", result.NewURL)
+	}
+	var redirected *CandidateOutcome
+	for i := range result.CandidateOutcomes {
+		o := &result.CandidateOutcomes[i]
+		if o.Outcome == OutcomeRedirected {
+			redirected = o
+			break
+		}
+	}
+	if redirected == nil {
+		t.Fatalf("expected a redirected outcome; got %+v", result.CandidateOutcomes)
+	}
+	if !strings.Contains(redirected.Detail, "auth gate") {
+		t.Errorf("redirected.Detail = %q, want mention of auth gate", redirected.Detail)
+	}
+	if !strings.Contains(redirected.Detail, "/auth/sign-in") {
+		t.Errorf("redirected.Detail = %q, want the matched gate path included", redirected.Detail)
+	}
+}
+
+// TestAttemptHeal_AuthGateDetail_MidChainHop pins the live amp pattern
+// observed during yogqh end-to-end testing: the candidate redirects
+// through /auth/sign-in but the chain terminates on a different host
+// (e.g. auth.ampcode.com/?client_id=...). Enrichment must scan the
+// redirect hops, not just FinalURL — otherwise the qc7yf incident's
+// most common surface (Hooks/index.md → /auth/sign-in → cross-host
+// auth bootstrap) shows up as a generic "redirected" cell.
+func TestAttemptHeal_AuthGateDetail_MidChainHop(t *testing.T) {
+	// External "auth bootstrap" host the chain terminates on.
+	authHost := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write(validBody)
+	}))
+	defer authHost.Close()
+
+	mux := http.NewServeMux()
+	// /auth/sign-in is the gate path — bounces to the external host.
+	mux.HandleFunc("/auth/sign-in", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", authHost.URL+"/?client_id=fake")
+		w.WriteHeader(http.StatusFound)
+	})
+	// Variant landing page — 302s to /auth/sign-in.
+	mux.HandleFunc("/manual/hooks/index.md", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "/auth/sign-in")
+		w.WriteHeader(http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	src := SourceEntry{
+		URL: srv.URL + "/manual/hooks.md",
+		Healing: &HealingConfig{
+			Strategies: []string{"variant"},
+		},
+	}
+	conventions := &DocsConventions{
+		AuthGatedPaths: []string{"/auth/sign-in", "/login"},
+	}
+	result, err := AttemptHeal(context.Background(), src, conventions, errors.New("404"))
+	if err != nil {
+		t.Fatalf("AttemptHeal: %v", err)
+	}
+	if result.Success {
+		t.Fatalf("expected rejection on cross-host auth-gate redirect; got NewURL=%q", result.NewURL)
+	}
+	var redirected *CandidateOutcome
+	for i := range result.CandidateOutcomes {
+		o := &result.CandidateOutcomes[i]
+		if o.Outcome == OutcomeRedirected {
+			redirected = o
+			break
+		}
+	}
+	if redirected == nil {
+		t.Fatalf("expected a redirected outcome; got %+v", result.CandidateOutcomes)
+	}
+	// Sanity: chain must have a hop into /auth/sign-in but final URL must
+	// be the external auth host (no /auth/sign-in substring).
+	if strings.Contains(redirected.FinalURL, "/auth/sign-in") {
+		t.Fatalf("test setup wrong: FinalURL still contains gate substring: %s", redirected.FinalURL)
+	}
+	if !strings.Contains(redirected.Detail, "auth gate") {
+		t.Errorf("mid-chain auth gate not surfaced; Detail = %q", redirected.Detail)
+	}
+	if !strings.Contains(redirected.Detail, "/auth/sign-in") {
+		t.Errorf("Detail should name matched gate path; got %q", redirected.Detail)
+	}
+}
+
+// TestAttemptHeal_AuthGateDetail_NilConventionsNoOp ensures the
+// enrichment is genuinely additive — when conventions is nil, the
+// Detail field for OutcomeRedirected stays empty (matching pre-bead
+// behavior).
+func TestAttemptHeal_AuthGateDetail_NilConventionsNoOp(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/sign-in", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write(validBody)
+	})
+	mux.HandleFunc("/manual/hooks/index.md", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "/auth/sign-in")
+		w.WriteHeader(http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	src := SourceEntry{
+		URL: srv.URL + "/manual/hooks.md",
+		Healing: &HealingConfig{
+			Strategies: []string{"variant"},
+		},
+	}
+	result, err := AttemptHeal(context.Background(), src, nil, errors.New("404"))
+	if err != nil {
+		t.Fatalf("AttemptHeal: %v", err)
+	}
+	for _, o := range result.CandidateOutcomes {
+		if o.Outcome == OutcomeRedirected && o.Detail != "" {
+			t.Errorf("with nil conventions, redirected outcome should have empty Detail; got %q", o.Detail)
+		}
 	}
 }

--- a/cli/internal/capmon/pipeline.go
+++ b/cli/internal/capmon/pipeline.go
@@ -192,7 +192,7 @@ func runStage1Fetch(ctx context.Context, opts PipelineOptions, manifest *RunMani
 					// in-run — it records the heal outcome and proposes a PR.
 					// The next pipeline run (after PR merge) will pick up the
 					// corrected URL.
-					heal := tryHealSource(ctx, opts, m.Slug, ctName, i, src, fetchErr, manifest.RunID)
+					heal := tryHealSource(ctx, opts, m.Slug, ctName, i, src, m.DocsConventions, fetchErr, manifest.RunID)
 					if heal != nil {
 						status.HealEvents = append(status.HealEvents, *heal)
 					}
@@ -224,11 +224,11 @@ func runStage1Fetch(ctx context.Context, opts PipelineOptions, manifest *RunMani
 // Returns a non-nil HealEvent in every case (success OR failure) so the
 // run manifest captures what was tried. Returns nil only when healing
 // is disabled for this source.
-func tryHealSource(ctx context.Context, opts PipelineOptions, providerSlug, contentType string, sourceIndex int, src SourceEntry, fetchErr error, runID string) *HealEvent {
+func tryHealSource(ctx context.Context, opts PipelineOptions, providerSlug, contentType string, sourceIndex int, src SourceEntry, conventions *DocsConventions, fetchErr error, runID string) *HealEvent {
 	if !src.IsHealingEnabled() {
 		return nil
 	}
-	result, err := AttemptHeal(ctx, src, fetchErr)
+	result, err := AttemptHeal(ctx, src, conventions, fetchErr)
 	event := &HealEvent{
 		ContentType: contentType,
 		SourceIndex: sourceIndex,

--- a/cli/internal/capmon/pipeline_heal_test.go
+++ b/cli/internal/capmon/pipeline_heal_test.go
@@ -30,7 +30,7 @@ func TestTryHealSource_DisabledReturnsNil(t *testing.T) {
 		URL:     "https://example.com/missing.md",
 		Healing: &HealingConfig{Enabled: &disabled},
 	}
-	evt := tryHealSource(context.Background(), PipelineOptions{}, "test-provider", "skills", 0, src, errors.New("404"), "run-1")
+	evt := tryHealSource(context.Background(), PipelineOptions{}, "test-provider", "skills", 0, src, nil, errors.New("404"), "run-1")
 	if evt != nil {
 		t.Errorf("expected nil when healing disabled, got %+v", evt)
 	}
@@ -45,7 +45,7 @@ func TestTryHealSource_FailureRecordsCounter(t *testing.T) {
 	}
 	opts := PipelineOptions{CacheRoot: cacheRoot, RepoRoot: t.TempDir()}
 
-	evt := tryHealSource(context.Background(), opts, "test-provider", "skills", 0, src, errors.New("404"), "run-1")
+	evt := tryHealSource(context.Background(), opts, "test-provider", "skills", 0, src, nil, errors.New("404"), "run-1")
 	if evt == nil {
 		t.Fatal("expected event, got nil")
 	}
@@ -78,7 +78,7 @@ func TestTryHealSource_PropagatesCandidateOutcomes(t *testing.T) {
 		Healing: &HealingConfig{Strategies: []string{"variant"}},
 	}
 	opts := PipelineOptions{CacheRoot: t.TempDir(), RepoRoot: t.TempDir()}
-	evt := tryHealSource(context.Background(), opts, "test-provider", "skills", 0, src, errors.New("404"), "run-prop")
+	evt := tryHealSource(context.Background(), opts, "test-provider", "skills", 0, src, nil, errors.New("404"), "run-prop")
 	if evt == nil {
 		t.Fatal("expected event, got nil")
 	}
@@ -121,7 +121,7 @@ func TestTryHealSource_DryRunDoesNotOpenPR(t *testing.T) {
 		Healing: &HealingConfig{Strategies: []string{"variant"}},
 	}
 	opts := PipelineOptions{DryRun: true, CacheRoot: t.TempDir(), RepoRoot: t.TempDir()}
-	evt := tryHealSource(context.Background(), opts, "test-provider", "skills", 0, src, errors.New("404"), "run-1")
+	evt := tryHealSource(context.Background(), opts, "test-provider", "skills", 0, src, nil, errors.New("404"), "run-1")
 	if evt == nil || !evt.Success {
 		t.Fatalf("expected success event, got %+v", evt)
 	}
@@ -186,7 +186,7 @@ func TestTryHealSource_SuccessOpensPRAndClearsCounter(t *testing.T) {
 		RepoRoot:           repoDir,
 		SourceManifestsDir: manifestsDir,
 	}
-	evt := tryHealSource(context.Background(), opts, "test-provider", "skills", 0, src, errors.New("404"), "run-42")
+	evt := tryHealSource(context.Background(), opts, "test-provider", "skills", 0, src, nil, errors.New("404"), "run-42")
 	if evt == nil || !evt.Success {
 		t.Fatalf("expected success event, got %+v", evt)
 	}

--- a/cli/internal/capmon/sourceman.go
+++ b/cli/internal/capmon/sourceman.go
@@ -10,13 +10,45 @@ import (
 
 // SourceManifest is the parsed form of docs/provider-sources/<slug>.yaml.
 type SourceManifest struct {
-	SchemaVersion string                       `yaml:"schema_version"`
-	Slug          string                       `yaml:"slug"`
-	DisplayName   string                       `yaml:"display_name"`
-	LastVerified  string                       `yaml:"last_verified"`
-	FetchTier     string                       `yaml:"fetch_tier,omitempty"`
-	FetchMethod   string                       `yaml:"fetch_method,omitempty"`
-	ContentTypes  map[string]ContentTypeSource `yaml:"content_types"`
+	SchemaVersion   string                       `yaml:"schema_version"`
+	Slug            string                       `yaml:"slug"`
+	DisplayName     string                       `yaml:"display_name"`
+	LastVerified    string                       `yaml:"last_verified"`
+	FetchTier       string                       `yaml:"fetch_tier,omitempty"`
+	FetchMethod     string                       `yaml:"fetch_method,omitempty"`
+	DocsConventions *DocsConventions             `yaml:"docs_conventions,omitempty"`
+	ContentTypes    map[string]ContentTypeSource `yaml:"content_types"`
+}
+
+// DocsConventions carries provider-specific URL hints used by the heal
+// pipeline and the syllago-capmon-process skill. All fields are optional;
+// the schema is designed to accrete new fields per-provider as quirks
+// surface (Cursor docs versioning, Cline auth-gated changelog, etc.).
+//
+// This block is provider-wide, not per-content-type — conventions like
+// "always append ?internal" apply to every doc URL on the host.
+type DocsConventions struct {
+	// QueryParamRequired is the literal query-string fragment (e.g.
+	// "?internal") that must be present on every doc URL fetched from this
+	// provider. Currently informational — read by the syllago-capmon-process
+	// skill when proposing replacement URLs. Not auto-applied at fetch time;
+	// manifest URLs stay literal.
+	QueryParamRequired string `yaml:"query_param_required,omitempty"`
+
+	// AuthGatedPaths lists path substrings that, if a redirect lands on
+	// them, mean the candidate URL doesn't really exist for unauthenticated
+	// callers. Used by the heal pipeline to enrich the redirect diagnostic
+	// Detail so triagers see "auth gate" rather than just "redirected".
+	// Does NOT change correctness — any redirect on a heal candidate is
+	// already rejected (see qc7yf). This is human-triage signal only.
+	AuthGatedPaths []string `yaml:"auth_gated_paths,omitempty"`
+
+	// RetiredPaths lists URL paths the variant generator must NOT propose
+	// replacements for. Known-dead paths whose 404 is a permanent fact (the
+	// content moved to a query-param-gated section, an in-page anchor, or
+	// was removed outright). Matching is exact path equality against the
+	// candidate URL's path.
+	RetiredPaths []string `yaml:"retired_paths,omitempty"`
 }
 
 // ContentTypeSource groups all source entries for one content type.

--- a/cli/internal/capmon/sourceman_test.go
+++ b/cli/internal/capmon/sourceman_test.go
@@ -229,3 +229,112 @@ func TestSourceEntry_EffectiveStrategies_ReturnsCopy(t *testing.T) {
 		t.Errorf("EffectiveStrategies() returned aliased slice: after mutation got %q, want %q", got2[0], "redirect")
 	}
 }
+
+func TestSourceManifest_DocsConventions_Absent(t *testing.T) {
+	dir := t.TempDir()
+	yamlContent := `schema_version: "1"
+slug: test-provider
+content_types:
+  skills:
+    sources:
+      - url: "https://example.com/skills"
+        type: documentation
+        format: md
+        selector: {}
+`
+	path := filepath.Join(dir, "test-provider.yaml")
+	if err := os.WriteFile(path, []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := capmon.LoadSourceManifest(path)
+	if err != nil {
+		t.Fatalf("LoadSourceManifest: %v", err)
+	}
+	if m.DocsConventions != nil {
+		t.Errorf("DocsConventions = %+v, want nil when block absent", m.DocsConventions)
+	}
+}
+
+func TestSourceManifest_DocsConventions_Present(t *testing.T) {
+	dir := t.TempDir()
+	yamlContent := `schema_version: "1"
+slug: test-provider
+docs_conventions:
+  query_param_required: "?internal"
+  auth_gated_paths:
+    - "/auth/sign-in"
+    - "/login"
+  retired_paths:
+    - "/manual/hooks.md"
+content_types:
+  skills:
+    sources:
+      - url: "https://example.com/skills"
+        type: documentation
+        format: md
+        selector: {}
+`
+	path := filepath.Join(dir, "test-provider.yaml")
+	if err := os.WriteFile(path, []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := capmon.LoadSourceManifest(path)
+	if err != nil {
+		t.Fatalf("LoadSourceManifest: %v", err)
+	}
+	if m.DocsConventions == nil {
+		t.Fatal("DocsConventions = nil, want non-nil")
+	}
+	if got := m.DocsConventions.QueryParamRequired; got != "?internal" {
+		t.Errorf("QueryParamRequired = %q, want %q", got, "?internal")
+	}
+	wantAuth := []string{"/auth/sign-in", "/login"}
+	if got := m.DocsConventions.AuthGatedPaths; len(got) != len(wantAuth) || got[0] != wantAuth[0] || got[1] != wantAuth[1] {
+		t.Errorf("AuthGatedPaths = %v, want %v", got, wantAuth)
+	}
+	wantRetired := []string{"/manual/hooks.md"}
+	if got := m.DocsConventions.RetiredPaths; len(got) != len(wantRetired) || got[0] != wantRetired[0] {
+		t.Errorf("RetiredPaths = %v, want %v", got, wantRetired)
+	}
+}
+
+// TestAmpManifest_DocsConventions_Populated pins the real amp.yaml to the
+// values that motivated this bead's docs_conventions block. If amp.yaml
+// regresses on these fields, the heal pipeline silently loses the
+// auth-gate diagnostic and re-introduces the /manual/hooks/index.md
+// variant-generation bug.
+func TestAmpManifest_DocsConventions_Populated(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "docs", "provider-sources", "amp.yaml")
+	m, err := capmon.LoadSourceManifest(path)
+	if err != nil {
+		t.Fatalf("LoadSourceManifest(amp.yaml): %v", err)
+	}
+	if m.DocsConventions == nil {
+		t.Fatal("amp.yaml DocsConventions = nil, want populated block")
+	}
+	if m.DocsConventions.QueryParamRequired != "?internal" {
+		t.Errorf("amp QueryParamRequired = %q, want %q",
+			m.DocsConventions.QueryParamRequired, "?internal")
+	}
+	wantGate := map[string]bool{"/auth/sign-in": false, "/login": false}
+	for _, g := range m.DocsConventions.AuthGatedPaths {
+		if _, ok := wantGate[g]; ok {
+			wantGate[g] = true
+		}
+	}
+	for g, seen := range wantGate {
+		if !seen {
+			t.Errorf("amp AuthGatedPaths missing %q; got %v", g, m.DocsConventions.AuthGatedPaths)
+		}
+	}
+	wantRetired := "/manual/hooks.md"
+	found := false
+	for _, p := range m.DocsConventions.RetiredPaths {
+		if p == wantRetired {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("amp RetiredPaths missing %q; got %v", wantRetired, m.DocsConventions.RetiredPaths)
+	}
+}

--- a/docs/provider-sources/_template.yaml
+++ b/docs/provider-sources/_template.yaml
@@ -30,6 +30,35 @@ changelog:
   - url: ""
     label: ""
 
+# Provider-specific URL conventions used by the heal pipeline and the
+# syllago-capmon-process skill. All fields are optional. Add only the
+# conventions this provider actually has — the schema is designed to
+# accrete new fields per-provider as quirks surface.
+#
+# docs_conventions:
+#   # Literal query-string fragment (e.g. "?internal") that must be
+#   # present on every doc URL fetched from this provider. Currently
+#   # informational — read by the syllago-capmon-process skill when
+#   # proposing replacement URLs. Not auto-applied at fetch time;
+#   # manifest URLs stay literal.
+#   query_param_required: ""
+#
+#   # Path substrings that, if a redirect lands on them, mean "the URL
+#   # doesn't really exist for unauthenticated callers." Used by the
+#   # heal pipeline to enrich the redirect diagnostic Detail. Does NOT
+#   # change correctness — any redirect on a heal candidate is already
+#   # rejected. Human-triage signal only.
+#   auth_gated_paths:
+#     - "/auth/sign-in"
+#     - "/login"
+#
+#   # URL paths the variant generator must NOT propose replacements for.
+#   # Known-dead paths whose 404 is a permanent fact (the content moved
+#   # to a query-param-gated section, an in-page anchor, or was removed
+#   # outright). Matching is exact path equality.
+#   retired_paths:
+#     - "/example-retired-page.md"
+
 # Primary config schema (omit if provider has no machine-readable schema)
 # Some providers publish a single schema covering hooks, MCP, and settings.
 # When present, the pipeline can extract multiple content types from this one file.

--- a/docs/provider-sources/amp.yaml
+++ b/docs/provider-sources/amp.yaml
@@ -21,6 +21,26 @@ changelog:
   - url: https://ampcode.com/llms.txt
     label: llms.txt (stub — only 2 URLs)
 
+# Provider-specific URL conventions. See _template.yaml for field docs.
+docs_conventions:
+  # ampcode.com/manual is a thin public surface; the full manual (including
+  # the hooks section) is reachable only via ?internal. Skill use only —
+  # not auto-applied at fetch time.
+  query_param_required: "?internal"
+  # Anything that looks like /manual/<topic>/index.md or /manual/<topic>.md
+  # 302-redirects to /auth/sign-in for unauthenticated callers. The heal
+  # validator already rejects any redirect; this list lets the diagnostic
+  # surface "auth gate" instead of a generic "redirected" cell.
+  auth_gated_paths:
+    - "/auth/sign-in"
+    - "/login"
+  # Known-dead path: the hooks.md page was retired in favor of an inline
+  # section at /manual?internal#hooks. Variant generator must not propose
+  # replacements for this path (e.g. /manual/hooks/index.md still 302s to
+  # /auth/sign-in, which is the bug pattern that triggered this bead).
+  retired_paths:
+    - "/manual/hooks.md"
+
 content_types:
   # ── Support summary ───────────────────────────────────────────────────
   # Amp supports: rules, skills, mcp, hooks


### PR DESCRIPTION
## Summary

Adds a `docs_conventions:` block to provider source manifests so the heal pipeline can encode provider-specific URL quirks the variant generator and validator would otherwise miss. Closes the bug pattern from ampcode #92 / PR #174 (qc7yf), where `/manual/hooks.md` was retired but the variant generator emitted `/manual/hooks/index.md` as a heal target — that URL 302'd into an auth gate and the heal merged anyway.

Three optional fields, all top-level on `SourceManifest`:

- **`retired_paths`** — variant candidates whose path matches are dropped *before* probing. Surfaces a structured decline reason (`variant: dropped N candidate(s) matching retired_paths`) so the loss is visible in heal-event JSON.
- **`auth_gated_paths`** — OutcomeRedirected candidates whose redirect chain (any hop OR the final URL) touches one of these substrings get a Detail like `candidate redirected to known auth gate (/auth/sign-in)`. Scanning the full chain matters because real auth flows often bounce out to a separate host (e.g., `ampcode.com/auth/sign-in` → `auth.ampcode.com/?client_id=…`), so the gate path lives mid-chain rather than at the final URL.
- **`query_param_required`** — schema-only field for skill consumption (e.g., amp's `?internal`). Not auto-applied at fetch time; the manifest URL stays literal.

### What changed

- `cli/internal/capmon/sourceman.go` — `DocsConventions` struct + pointer field on `SourceManifest`
- `cli/internal/capmon/healing.go` — `AttemptHeal` takes `*DocsConventions`; `filterRetiredVariants` runs before variant probing; `enrichAuthGateDetail` runs after `validateHealCandidate` (post-fix: scans `out.Redirects[].To`, not just `FinalURL`)
- `cli/internal/capmon/pipeline.go` — plumbs `m.DocsConventions` through `tryHealSource`
- `docs/provider-sources/amp.yaml` — populated with the live amp values (`?internal`, `/auth/sign-in` + `/login`, `/manual/hooks.md`)
- `docs/provider-sources/_template.yaml` — documented commented block for new providers

### Tests

Four new tests in `healing_test.go` covering the three behaviors plus the nil-conventions no-op:

- `TestAttemptHeal_RetiredPathFiltersVariant` — variant `/manual/hooks.md` filtered, retired URL absent from `CandidateOutcomes`, decline reason populated
- `TestAttemptHeal_AuthGateDetailEnriched` — single-hop redirect to `/auth/sign-in`, Detail names the gate
- `TestAttemptHeal_AuthGateDetail_MidChainHop` — two-host setup where the chain passes through `/auth/sign-in` and lands on a different host; Detail still fires (caught by end-to-end testing on the live amp pattern)
- `TestAttemptHeal_AuthGateDetail_NilConventionsNoOp` — nil conventions leaves Detail empty (additive behavior)

Plus `sourceman_test.go` tests for the YAML schema and a pin against the populated `amp.yaml`.

### End-to-end validation

Ran `syllago capmon run --provider=amp --stage=fetch-extract --json --dry-run` with the amp hooks URL temporarily pointed at a 404 (`Hooks.md`). Output carried both signals:

- `strategy_declines` included `variant: dropped 1 candidate(s) matching retired_paths`
- The `Hooks/index.md` index-fallback variant produced `detail: "candidate redirected to known auth gate (/auth/sign-in)"` after the mid-chain enrichment fix

## Test plan

- [x] `make test` green across the repo
- [x] `make fmt` clean
- [x] golangci-lint clean (pre-push hook)
- [x] End-to-end `syllago capmon run` against amp with retired-path bait emits both new signals
- [x] End-to-end `syllago capmon run` against codex (nil conventions) runs without regression — `tryHealSource` plumbing is non-disruptive when conventions absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)