### PR TITLE
fix(capmon): skip local_file sources in runSourceCheck

### DIFF
--- a/cli/internal/capmon/check.go
+++ b/cli/internal/capmon/check.go
@@ -282,6 +282,11 @@ func RunCapmonCheck(ctx context.Context, opts CapmonCheckOptions) error {
 // batch for deferred issue creation. All GitHub API calls are deferred to
 // flushProviderBatch, which fires once after the full provider loop completes.
 func runSourceCheck(ctx context.Context, contentType string, src SourceRef, batch *providerBatch) error {
+	// local_file sources live in the repo; drift is detected by git, not HTTP.
+	if src.FetchMethod == "local_file" {
+		return nil
+	}
+
 	// Fetch content.
 	body, respContentType, finalURL, fetchErr := fetchForCheck(ctx, src.URI)
 	if fetchErr != nil {

--- a/cli/internal/capmon/check_test.go
+++ b/cli/internal/capmon/check_test.go
@@ -745,3 +745,67 @@ content_types:
 		t.Errorf("issue body should mention 'hooks' content type, got: %q", capturedBody)
 	}
 }
+
+// TestRunCapmonCheck_LocalFileSource_Skipped verifies that sources with
+// fetch_method: local_file are silently skipped — no HTTP fetch attempt and
+// no GitHub issue created, even when the stored hash is stale.
+func TestRunCapmonCheck_LocalFileSource_Skipped(t *testing.T) {
+	env := newCheckTestEnv(t)
+
+	env.writeProviders(t, []string{"test-provider"})
+	env.writeSourceManifest(t, "test-provider")
+
+	// Format doc with a local_file source that has a stale hash.
+	localFileDoc := `provider: test-provider
+docs_url: "https://example.com/docs"
+category: cli
+last_fetched_at: "2026-04-11T00:00:00Z"
+generation_method: human-edited
+content_types:
+  hooks:
+    status: supported
+    sources:
+      - uri: "example-hooks.json"
+        type: example
+        fetch_method: local_file
+        content_hash: "sha256:stale"
+        fetched_at: "2026-04-11T00:00:00Z"
+    canonical_mappings: {}
+    provider_extensions: []
+`
+	os.WriteFile(filepath.Join(env.opts.FormatsDir, "test-provider.yaml"), []byte(localFileDoc), 0644)
+
+	// If fetchForCheck is called, it will error because "example-hooks.json" has no scheme.
+	// Verify no HTTP or gh calls occur.
+	httpCalled := false
+	capmon.SetHTTPClientForTest(&http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			httpCalled = true
+			return nil, errors.New("should not be called")
+		}),
+	})
+	t.Cleanup(func() { capmon.SetHTTPClientForTest(nil) })
+
+	ghCalled := false
+	capmon.SetGHCommandForTest(func(args ...string) ([]byte, error) {
+		ghCalled = true
+		return []byte("[]"), nil
+	})
+	t.Cleanup(func() { capmon.SetGHCommandForTest(nil) })
+
+	err := capmon.RunCapmonCheck(context.Background(), env.opts)
+	if err != nil {
+		t.Fatalf("RunCapmonCheck: %v", err)
+	}
+	if httpCalled {
+		t.Error("local_file source should not trigger an HTTP fetch")
+	}
+	if ghCalled {
+		t.Error("local_file source should not produce any GitHub issue calls")
+	}
+}
+
+// roundTripFunc is a helper RoundTripper backed by a function.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }


### PR DESCRIPTION
## Summary

`runSourceCheck` never checked `fetch_method` before attempting an HTTP GET. Sources with `fetch_method: local_file` have bare relative paths (e.g. `example-hooks.json`), not URLs — so they always failed with `unsupported protocol scheme ""` and were recorded as fetch errors.

Local file sources are part of the repo; drift is detected by git, not the HTTP fetching pipeline. The fix is a one-line skip at the top of `runSourceCheck`.

## Root cause

Surfaced immediately by the per-provider batching change (PR #372). The consolidated issue body for `claude-code` contained a `## Fetch Errors` section listing three local file sources from `docs/provider-formats/claude-code.yaml`. Previously these were buried in 178 individual `capmon-fetch-error` issues.

## What changed

- `check.go`: Skip sources where `src.FetchMethod == "local_file"` at the top of `runSourceCheck`
- `check_test.go`: `TestRunCapmonCheck_LocalFileSource_Skipped` — verifies no HTTP or gh calls are made for a local_file source with a stale hash

## Affected providers

`claude-code` has three local_file sources under `content_types.hooks`:
- `hooks-example-hooks.json`
- `settings-strict-example.json`
- `settings-lax-example.json`