### PR TITLE
ci: tighten workflow token permissions and pin smoke-test deps

### DIFF
--- a/.github/workflows/capmon-check.yml
+++ b/.github/workflows/capmon-check.yml
@@ -16,6 +16,9 @@ on:
         default: 'false'
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Hash Check

--- a/.github/workflows/capmon.yml
+++ b/.github/workflows/capmon.yml
@@ -11,6 +11,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   fetch-extract:
     name: Fetch + Extract (Stage 1-2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   dependency-review:
     name: Dependency Review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   claude-review:
     if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
     - cron: '0 6 * * 1' # Weekly on Monday at 06:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: CodeQL Analysis

--- a/.github/workflows/moat-trusted-root-check.yml
+++ b/.github/workflows/moat-trusted-root-check.yml
@@ -24,6 +24,9 @@ concurrency:
   group: moat-trusted-root-check
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check bundled trusted-root staleness

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test-providers.yml
+++ b/.github/workflows/smoke-test-providers.yml
@@ -18,6 +18,9 @@ concurrency:
   group: smoke-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   claude-code:
     name: Claude Code Smoke Tests
@@ -41,7 +44,7 @@ jobs:
 
       - name: Install Claude Code
         run: |
-          npm install -g @anthropic-ai/claude-code
+          npm install -g @anthropic-ai/claude-code@2.1.136
           claude --version
 
       # TODO: Configure SSO/service account auth for Claude Code.
@@ -82,7 +85,7 @@ jobs:
 
       - name: Install Gemini CLI
         run: |
-          npm install -g @google/gemini-cli
+          npm install -g @google/gemini-cli@0.41.2
           gemini --version
 
       # TODO: Configure SSO/service account auth for Gemini CLI.

--- a/.github/workflows/vouch-manage.yml
+++ b/.github/workflows/vouch-manage.yml
@@ -8,6 +8,9 @@ concurrency:
   group: vouch-manage
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   manage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Resolves the actionable code-scanning alerts from OpenSSF Scorecard.

- **Token-Permissions** (alerts #3, #4, #5, #6, #7, #10, #21, #22, #23, #25, #26): add top-level `permissions: contents: read` to 11 workflows. Each workflow's existing job-level `permissions:` block is preserved and continues to override.
- **Pinned-Dependencies** (alerts #13, #14): pin `npm install -g @anthropic-ai/claude-code` to `2.1.136` and `npm install -g @google/gemini-cli` to `0.41.2` in `smoke-test-providers.yml`. Pure SHA-pinning isn't possible for `npm install -g`; version-pinning is the closest practical fix.

## Out-of-band changes already applied

- **Branch ruleset:** strict status checks (`strict_required_status_checks_policy: true`) enabled on the existing `Branch-Protection` ruleset for `main`. PR branches must now be up-to-date before merge.
- **PostHog key rotation:** the leaked `phc_…` project API key from secret-scanning alert #1 was rotated by @holdenhewett. The `SYLLAGO_POSTHOG_KEY` repo secret was updated. A new release will need to be cut so existing installs receive a binary built against the new key.

## Out of scope (not code-fixable)

| Alert | Reason |
|---|---|
| #1 Branch-Protection | Ruleset is configured. Required reviews stay at 0 and admin-bypass stays on, intentionally, for solo-maintainer workflow. Score won't reach maximal but the gaps are deliberate. |
| #2, #19, #20 | Informational `jobLevel 'contents' permission set to 'write'` warnings on legitimate writes (capmon report job, release publishing, vouch state). Candidates for manual dismissal as "won't fix" after merge. |
| #15 Maintained | Project-age check; resolves itself once the project is >90 days old. |
| #16 CodeReview | Historical "0/28 approved changesets"; improves as future reviewed PRs accumulate. |
| #17 CIIBestPractices | Requires external application at bestpractices.dev. |
| #18 Fuzzing | Deferred to a separate PR; adding meaningful Go fuzz targets is real engineering work. |

## Post-merge follow-up

1. Trigger Scorecard manually so we don't wait for the weekly cron:
   ```
   gh workflow run scorecard.yml --ref main
   ```
2. Confirm the Token-Permissions and Pinned-Dependencies alerts auto-close on the next SARIF upload.
3. Manually dismiss the three informational `contents: write` warnings (#2, #19, #20) as "won't fix" with explanatory comments.
4. Cut a release so existing syllago installs pick up a binary built with the rotated PostHog key.

## Test plan

- [ ] CI green on the PR (lint + test + build + dependency review)
- [ ] No workflow regressions on push to `main` after merge (CI, capmon-check, capmon scheduled run all execute as before)
- [ ] Next Scorecard run shows Token-Permissions alerts as resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)