### PR TITLE
fix(moat): route fetch tests through per-server transports

### DIFF
--- a/cli/internal/moat/fetch_test.go
+++ b/cli/internal/moat/fetch_test.go
@@ -29,7 +29,10 @@ func TestFetcher_Fetch_Success(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	f := &Fetcher{}
+	// srv.Client() gives each test its own transport. A zero-value Fetcher
+	// falls back to http.DefaultTransport, where another parallel test's
+	// srv.Close → CloseIdleConnections breaks in-flight requests (syllago-jm704).
+	f := &Fetcher{Client: srv.Client()}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
@@ -73,7 +76,7 @@ func TestFetcher_Fetch_NotModified(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	f := &Fetcher{}
+	f := &Fetcher{Client: srv.Client()}
 	ctx := context.Background()
 
 	res, err := f.Fetch(ctx, srv.URL, etag)
@@ -107,7 +110,7 @@ func TestFetcher_Fetch_CustomUserAgent(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	f := &Fetcher{UserAgent: want}
+	f := &Fetcher{UserAgent: want, Client: srv.Client()}
 	if _, err := f.Fetch(context.Background(), srv.URL, ""); err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -129,7 +132,7 @@ func TestFetcher_Fetch_DefaultUserAgent(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	f := &Fetcher{}
+	f := &Fetcher{Client: srv.Client()}
 	if _, err := f.Fetch(context.Background(), srv.URL, ""); err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -163,10 +166,9 @@ func TestFetcher_Fetch_UnexpectedStatus(t *testing.T) {
 			t.Cleanup(srv.Close)
 
 			// Disable automatic redirect following so 308 surfaces as a status error.
-			client := &http.Client{
-				CheckRedirect: func(*http.Request, []*http.Request) error {
-					return http.ErrUseLastResponse
-				},
+			client := srv.Client()
+			client.CheckRedirect = func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
 			}
 			f := &Fetcher{Client: client}
 			_, err := f.Fetch(context.Background(), srv.URL, "")
@@ -190,7 +192,7 @@ func TestFetcher_Fetch_MalformedBody(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	f := &Fetcher{}
+	f := &Fetcher{Client: srv.Client()}
 	_, err := f.Fetch(context.Background(), srv.URL, "")
 	if err == nil {
 		t.Fatal("expected parse error for malformed JSON")
@@ -212,7 +214,7 @@ func TestFetcher_Fetch_OversizedBody(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	f := &Fetcher{}
+	f := &Fetcher{Client: srv.Client()}
 	_, err := f.Fetch(context.Background(), srv.URL, "")
 	if err == nil {
 		t.Fatal("expected oversized body to error")
@@ -251,7 +253,7 @@ func TestFetcher_Fetch_ContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	f := &Fetcher{}
+	f := &Fetcher{Client: srv.Client()}
 	_, err := f.Fetch(ctx, srv.URL, "")
 	if err == nil {
 		t.Fatal("expected context-cancel error")


### PR DESCRIPTION
Fixes the flaky `TestFetcher_Fetch_UnexpectedStatus/not_found` failure seen on PR #488 CI (bead syllago-r7o80).

Every network-touching test in `fetch_test.go` used a zero-value `Fetcher` (or a client with nil Transport), falling back to the process-wide `http.DefaultTransport`. Under `t.Parallel()` + `-race`, any test's `srv.Close` cleanup calls `CloseIdleConnections` on that shared transport and can sever another test's in-flight request. Fix per the `syncHarness` precedent (syllago-jm704): each test now uses `srv.Client()`, which carries a per-server transport. `TestFetcher_Fetch_EmptyURL` is untouched (no HTTP request). Verified locally with `-race -count=20`.

Codex-reviewed (GPT-5.5): no findings on this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWYKtPV2Ruh3MF11fWppQe