### PR TITLE
fix(capfeed): enforce the freshness gate on the 304 path

### DIFF
--- a/cli/internal/capfeed/run.go
+++ b/cli/internal/capfeed/run.go
@@ -21,8 +21,9 @@ type Options struct {
 	FeedURL string
 	// RepoRoot is the syllago repo root containing docs/provider-capabilities.
 	RepoRoot string
-	// ETagFile persists the index ETag between runs (best-effort politeness;
-	// empty disables persistence).
+	// ETagFile persists the index ETag plus the last verified index's
+	// freshness fields between runs (best-effort politeness; empty disables
+	// persistence — and with it the conditional GET).
 	ETagFile string
 	// SummaryFile receives the machine-readable run summary consumed by the
 	// cron workflow (empty disables).
@@ -52,7 +53,7 @@ var mirrorExcluded = map[string]bool{"advisories.json": true}
 
 // Run is the complete Capmon Pull pipeline with fail-closed ordering:
 //
-//	fetch index (conditional GET) → 304 short-circuit
+//	fetch index (conditional GET) → 304 short-circuit (freshness-gated)
 //	→ parse shape → fetch attestation → verify provenance → freshness
 //	→ data_revision marker short-circuit (only AFTER verification)
 //	→ fetch + sha256-verify every file → write mirror
@@ -71,15 +72,27 @@ func Run(ctx context.Context, opts Options) (*Summary, error) {
 
 	f := &Fetcher{}
 
-	prevETag := readETag(opts.ETagFile)
+	state := readETagState(opts.ETagFile)
+	prevETag := ""
+	if state != nil {
+		prevETag = state.ETag
+	}
 	res, err := f.Fetch(ctx, opts.FeedURL, prevETag)
 	if err != nil {
 		return nil, err
 	}
 
 	// 304: the exact bytes we last processed. Nothing to verify, nothing to
-	// write — the polite no-op.
+	// write — the polite no-op. The freshness gate still runs, against the
+	// state persisted with the ETag: an endlessly replayed 304 must not
+	// keep the cron green while the feed goes stale (syllago-u9s3l).
 	if res.NotModified {
+		if state == nil {
+			return nil, errors.New("capfeed run: server returned 304 Not Modified to a request without If-None-Match (writing nothing)")
+		}
+		if err := CheckFreshness(state.GeneratedAt, now(), state.MaxStalenessHours); err != nil {
+			return nil, err
+		}
 		sum := &Summary{Changed: false}
 		if err := writeSummary(opts.SummaryFile, sum); err != nil {
 			return nil, err
@@ -122,7 +135,7 @@ func Run(ctx context.Context, opts Options) (*Summary, error) {
 	}
 	if marker.DataRevision == idx.DataRevision {
 		sum := &Summary{Changed: false, DataRevision: idx.DataRevision, GeneratedAt: idx.GeneratedAt}
-		if err := persistETag(opts.ETagFile, res.ETag); err != nil {
+		if err := persistETagState(opts.ETagFile, res.ETag, idx); err != nil {
 			return nil, err
 		}
 		if err := writeSummary(opts.SummaryFile, sum); err != nil {
@@ -148,7 +161,7 @@ func Run(ctx context.Context, opts Options) (*Summary, error) {
 		return nil, err
 	}
 
-	if err := persistETag(opts.ETagFile, res.ETag); err != nil {
+	if err := persistETagState(opts.ETagFile, res.ETag, idx); err != nil {
 		return nil, err
 	}
 	sum := &Summary{
@@ -172,23 +185,61 @@ func baseURLOf(feedURL string) string {
 	return feedURL
 }
 
-func readETag(path string) string {
+// etagState is the between-runs conditional-GET state. GeneratedAt and
+// MaxStalenessHours are captured from the last verified index so the 304
+// path — which has no body to read them from — can still run the
+// freshness gate.
+type etagState struct {
+	ETag              string    `json:"etag"`
+	GeneratedAt       time.Time `json:"generated_at"`
+	MaxStalenessHours int       `json:"max_staleness_hours"`
+}
+
+// readETagState loads the persisted state. Anything unusable — missing
+// file, non-JSON (including the retired plain-text ETag format), or a
+// record missing any field the 304 path needs — yields nil: the run sends
+// an unconditional GET and verifies from scratch.
+func readETagState(path string) *etagState {
 	if path == "" {
-		return ""
+		return nil
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(data))
-}
-
-func persistETag(path, etag string) error {
-	if path == "" || etag == "" {
 		return nil
 	}
-	if err := os.WriteFile(path, []byte(etag+"\n"), 0o644); err != nil {
-		return fmt.Errorf("capfeed run: persisting ETag: %w", err)
+	var s etagState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil
+	}
+	if s.ETag == "" || s.GeneratedAt.IsZero() || s.MaxStalenessHours <= 0 {
+		return nil
+	}
+	return &s
+}
+
+func persistETagState(path, etag string, idx *Index) error {
+	if path == "" {
+		return nil
+	}
+	if etag == "" {
+		// A verified 200 without an ETag supersedes whatever is on disk;
+		// leaving the old record would let a later 304 validate against an
+		// index we no longer hold.
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("capfeed run: clearing superseded ETag state: %w", err)
+		}
+		return nil
+	}
+	data, err := json.Marshal(etagState{
+		ETag:              etag,
+		GeneratedAt:       idx.GeneratedAt,
+		MaxStalenessHours: idx.MaxStalenessHours,
+	})
+	if err != nil {
+		return fmt.Errorf("capfeed run: encoding ETag state: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("capfeed run: persisting ETag state: %w", err)
 	}
 	return nil
 }

--- a/cli/internal/capfeed/run_test.go
+++ b/cli/internal/capfeed/run_test.go
@@ -179,8 +179,15 @@ func TestRun_ETagRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ETag file not persisted: %v", err)
 	}
-	if strings.TrimSpace(string(persisted)) != fx.indexETag {
-		t.Errorf("persisted ETag = %q; want server ETag %q", persisted, fx.indexETag)
+	var st etagState
+	if err := json.Unmarshal(persisted, &st); err != nil {
+		t.Fatalf("ETag state is not JSON: %v (contents %q)", err, persisted)
+	}
+	if st.ETag != fx.indexETag {
+		t.Errorf("persisted ETag = %q; want server ETag %q", st.ETag, fx.indexETag)
+	}
+	if st.GeneratedAt.IsZero() || st.MaxStalenessHours <= 0 {
+		t.Errorf("persisted state missing freshness fields: %+v", st)
 	}
 
 	// Second run must send it back: the fixture's index handler answers 304
@@ -192,6 +199,112 @@ func TestRun_ETagRoundTrip(t *testing.T) {
 	}
 	if n := fx.attRequests.Load(); n != 0 {
 		t.Error("second run did not send If-None-Match (no 304 short-circuit happened)")
+	}
+}
+
+// TestRun_NotModified304StaleFails verifies the 304 path enforces the
+// freshness gate from the persisted state: a CDN replaying 304 forever must
+// turn the run red once the last verified generated_at exceeds the feed's
+// max staleness, not stay a green no-op (syllago-u9s3l).
+func TestRun_NotModified304StaleFails(t *testing.T) {
+	indexBytes, _ := loadSnapshot(t)
+	fx := newRunFixture(t, indexBytes)
+
+	if _, err := Run(context.Background(), fx.opts); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	fx.attRequests.Store(0)
+	fx.fileRequests.Store(0)
+
+	var meta struct {
+		GeneratedAt       time.Time `json:"generated_at"`
+		MaxStalenessHours int       `json:"max_staleness_hours"`
+	}
+	if err := json.Unmarshal(indexBytes, &meta); err != nil {
+		t.Fatal(err)
+	}
+	fx.opts.Now = func() time.Time {
+		return meta.GeneratedAt.Add(time.Duration(meta.MaxStalenessHours+1) * time.Hour)
+	}
+
+	_, err := Run(context.Background(), fx.opts)
+	if err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("stale 304 run error = %v; want freshness failure", err)
+	}
+	if n := fx.attRequests.Load(); n != 0 {
+		t.Errorf("stale 304 run fetched %d attestations; want 0", n)
+	}
+	if n := fx.fileRequests.Load(); n != 0 {
+		t.Errorf("stale 304 run made %d per-file requests; want 0", n)
+	}
+}
+
+// TestRun_Unsolicited304Fails verifies a 304 answered to a request that sent
+// no If-None-Match (protocol-illegal, e.g. a misbehaving CDN) is an error,
+// not a silent no-op — there is no persisted state to vouch for it.
+func TestRun_Unsolicited304Fails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := Run(context.Background(), Options{FeedURL: srv.URL + "/index.json"})
+	if err == nil || !strings.Contains(err.Error(), "304") {
+		t.Fatalf("unsolicited 304 error = %v; want 304 rejection", err)
+	}
+}
+
+// TestPersistETagState_EmptyETagClearsState verifies a verified 200 that
+// carries no ETag removes the superseded state file instead of leaving an
+// old validator (and its freshness fields) on disk.
+func TestPersistETagState_EmptyETagClearsState(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "etag")
+	idx := &Index{GeneratedAt: time.Now(), MaxStalenessHours: 48}
+	if err := persistETagState(path, `"e1"`, idx); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	if err := persistETagState(path, "", idx); err != nil {
+		t.Fatalf("persist with empty etag: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("state file still present after empty-ETag persist (stat err = %v)", err)
+	}
+}
+
+// TestRun_LegacyETagFileIgnored verifies the retired plain-text ETag format
+// is treated as absent: the run sends an unconditional GET, re-verifies from
+// scratch, and upgrades the file to the JSON state format.
+func TestRun_LegacyETagFileIgnored(t *testing.T) {
+	indexBytes, _ := loadSnapshot(t)
+	fx := newRunFixture(t, indexBytes)
+
+	if _, err := Run(context.Background(), fx.opts); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if err := os.WriteFile(fx.opts.ETagFile, []byte(fx.indexETag+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fx.attRequests.Store(0)
+
+	sum, err := Run(context.Background(), fx.opts)
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if sum.Changed {
+		t.Error("marker-match run Summary.Changed = true; want false")
+	}
+	if n := fx.attRequests.Load(); n == 0 {
+		t.Error("legacy ETag file was trusted: no re-verification happened (want full 200 + verify)")
+	}
+	var st etagState
+	data, err := os.ReadFile(fx.opts.ETagFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &st); err != nil {
+		t.Fatalf("ETag file not upgraded to JSON state: %v (contents %q)", err, data)
 	}
 }
 


### PR DESCRIPTION
Closes the endless-304 staleness gap found during the syllago-6zxsi live verification (bead syllago-u9s3l): the 304 short-circuit in `capfeed.Run` returned before any freshness check, so a CDN replaying 304 indefinitely kept the daily capmon-pull cron green while the feed went stale — silently defeating the workflow's "stale feed exits non-zero" alarm.

Changes:
- The `.capmon-pull-etag` file is now a JSON state envelope: `etag`, `generated_at`, `max_staleness_hours` (captured from the last verified index).
- The 304 path re-runs `CheckFreshness` against that persisted state — a frozen feed now goes red once it exceeds its own max staleness, same as on the 200 path.
- A 304 answered to a request that sent no `If-None-Match` (protocol-illegal, e.g. a misbehaving CDN) is now an error instead of a silent green no-op.
- A verified 200 without an ETag clears superseded state instead of leaving an old validator on disk (Codex review finding, fixed pre-PR).
- Legacy plain-text ETag files are ignored (treated as absent → one unconditional refetch + full re-verify). No migration; the production Actions caches were already purged tonight.

New tests: stale-304 goes red, unsolicited-304 errors, legacy file ignored + upgraded, empty-ETag clears state. Full `go test ./...` + build pass.

Codex-reviewed (GPT-5.5): 1 P2 finding (superseded-state clearing), fixed and covered by test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWYKtPV2Ruh3MF11fWppQe