### PR TITLE
feat(provider): accepted-drift list for the Coverage Drift gate

### DIFF
--- a/cli/internal/provider/coverage.go
+++ b/cli/internal/provider/coverage.go
@@ -17,6 +17,10 @@ type CoverageDrift struct {
 	ContentType catalog.ContentType
 	Assertion   string
 	Message     string
+	// AcceptedReason is non-empty when this drift is a recorded, permanent
+	// disagreement (see acceptedFeedDrift): both sides are correct and the
+	// CI gate reports it as accepted instead of failing.
+	AcceptedReason string
 }
 
 func (d CoverageDrift) String() string {

--- a/cli/internal/provider/coverage_feed.go
+++ b/cli/internal/provider/coverage_feed.go
@@ -15,6 +15,23 @@ import (
 	"path/filepath"
 )
 
+// acceptedFeedDrift records provider/content-type pairs where the feed's
+// concept-level `supported` and Go's install-level SupportsType disagree and
+// BOTH are correct: the provider has the capability concept, but offers no
+// installable form. The feed answers "does the provider have this concept?";
+// SupportsType answers "can syllago install this content type there?" — for
+// these pairs the answers legitimately diverge, so the CI gate reports them
+// as accepted instead of failing. Every entry MUST carry a reason. Delete
+// the entry (and implement install support) if the provider ships an
+// installable form.
+var acceptedFeedDrift = map[string]string{
+	// Zed Agent Profiles carry tool restrictions and per-profile MCP scoping
+	// (so the feed's auto-flipped agents.supported is true), but profiles are
+	// settings.json entries with no prompt and no definition file — there is
+	// nothing an agent content item could be installed into (syllago-s1zou).
+	"zed/agents": "Zed Agent Profiles have no prompt or definition file; agent items cannot be installed",
+}
+
 // capabilityDocument mirrors the subset of capabilities/<slug>.json the
 // feed assertion needs. Unknown fields at every level are ignored (default
 // encoding/json semantics — never DisallowUnknownFields).
@@ -57,17 +74,21 @@ func checkFeedCoverage(repoRoot string, p Provider) ([]CoverageDrift, error) {
 		if goSupported == feedSupported {
 			continue
 		}
-		var msg string
+		var msg, accepted string
 		if goSupported {
 			msg = "Go SupportsType claims support but the Capability Feed asserts supported: false"
+			// Never accepted: Go claiming support the feed denies is always
+			// a real finding, whatever acceptedFeedDrift says.
 		} else {
 			msg = "Capability Feed asserts supported: true but Go SupportsType returns false (missed capability)"
+			accepted = acceptedFeedDrift[p.Slug+"/"+string(ct)]
 		}
 		drifts = append(drifts, CoverageDrift{
-			Provider:    p.Slug,
-			ContentType: ct,
-			Assertion:   AssertionGoVsCapabilityFeed,
-			Message:     msg,
+			Provider:       p.Slug,
+			ContentType:    ct,
+			Assertion:      AssertionGoVsCapabilityFeed,
+			Message:        msg,
+			AcceptedReason: accepted,
 		})
 	}
 	return drifts, nil

--- a/cli/internal/provider/coverage_feed_test.go
+++ b/cli/internal/provider/coverage_feed_test.go
@@ -152,6 +152,49 @@ func TestCheckCoverage_FeedAssertionIntegrated(t *testing.T) {
 	}
 }
 
+// TestCheckFeedCoverage_AcceptedDrift verifies a contradiction listed in
+// acceptedFeedDrift is still reported but carries its AcceptedReason, and
+// that the same shape on an unlisted provider does not.
+func TestCheckFeedCoverage_AcceptedDrift(t *testing.T) {
+	root := feedFixtureRoot(t, "zed", `{"slug":"zed","content_types":{"agents":{"supported":true}}}`)
+	drifts, err := checkFeedCoverage(root, fakeProvider("zed" /* no agents */))
+	if err != nil {
+		t.Fatalf("checkFeedCoverage: %v", err)
+	}
+	if len(drifts) != 1 {
+		t.Fatalf("got %d drifts; want 1", len(drifts))
+	}
+	if drifts[0].AcceptedReason == "" {
+		t.Error("zed/agents drift should carry an AcceptedReason")
+	}
+
+	root = feedFixtureRoot(t, "fake", `{"slug":"fake","content_types":{"agents":{"supported":true}}}`)
+	drifts, err = checkFeedCoverage(root, fakeProvider("fake"))
+	if err != nil {
+		t.Fatalf("checkFeedCoverage: %v", err)
+	}
+	if len(drifts) != 1 {
+		t.Fatalf("got %d drifts; want 1", len(drifts))
+	}
+	if drifts[0].AcceptedReason != "" {
+		t.Errorf("fake/agents drift must not be accepted; got reason %q", drifts[0].AcceptedReason)
+	}
+
+	// The reverse direction — Go claims support the feed denies — is always
+	// a real finding, even for a listed pair (Codex review finding).
+	root = feedFixtureRoot(t, "zed", `{"slug":"zed","content_types":{"agents":{"supported":false}}}`)
+	drifts, err = checkFeedCoverage(root, fakeProvider("zed", catalog.Agents))
+	if err != nil {
+		t.Fatalf("checkFeedCoverage: %v", err)
+	}
+	if len(drifts) != 1 {
+		t.Fatalf("got %d drifts; want 1", len(drifts))
+	}
+	if drifts[0].AcceptedReason != "" {
+		t.Errorf("reverse-direction zed/agents drift must not be accepted; got reason %q", drifts[0].AcceptedReason)
+	}
+}
+
 // TestCoverageFeedDrift is the CI Coverage Drift gate: red (non-required)
 // when Go's SupportsType contradicts the committed Capability Documents.
 // Reproduce locally with: SYLLAGO_COVERAGE_FEED=1 go test ./internal/provider/ -run TestCoverageFeedDrift
@@ -166,10 +209,15 @@ func TestCoverageFeedDrift(t *testing.T) {
 	}
 	var failed bool
 	for _, d := range drifts {
-		if d.Assertion == AssertionGoVsCapabilityFeed {
-			failed = true
-			t.Errorf("Coverage Drift: %s", d)
+		if d.Assertion != AssertionGoVsCapabilityFeed {
+			continue
 		}
+		if d.AcceptedReason != "" {
+			t.Logf("Coverage Drift (accepted): %s — %s", d, d.AcceptedReason)
+			continue
+		}
+		failed = true
+		t.Errorf("Coverage Drift: %s", d)
 	}
 	if failed {
 		t.Log("Go SupportsType claims contradict the mirrored Capability Feed data; reconcile the provider's SupportsType or await a feed correction")


### PR DESCRIPTION
Resolves syllago-s1zou (Holden picked option A): the zed/agents Coverage Drift finding is a permanent, correct disagreement — the Capability Feed's `agents.supported: true` (auto-flipped from Zed's profile tool-restriction/MCP-scoping capabilities) vs Go's `SupportsType(agents) = false` (profiles have no prompt or definition file; nothing to install into). Without an exemption the non-required gate stays red on every roll of the mirror PR, hiding future real findings.

- `acceptedFeedDrift` records provider/content-type pairs with a **mandatory reason**; delete the entry and implement install support if the provider ever ships an installable form.
- `CoverageDrift` gains `AcceptedReason`; the CI gate (`TestCoverageFeedDrift`) logs accepted entries (`Coverage Drift (accepted): …`) instead of failing.
- Direction-guarded per Codex review: only feed-true/Go-false can be accepted. Go claiming support the feed denies is always a real finding, even for a listed pair — regression-tested.

After merge, re-running the rolling PR's failed Coverage Drift job should go green with an "accepted" log line.

Codex-reviewed (GPT-5.5): 1 finding (direction guard), fixed with regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWYKtPV2Ruh3MF11fWppQe