### PR TITLE
ACIF Stage 0: core-scope conformance adapter (13/13)

### DIFF
--- a/cli/cmd/acif-adapter/handlers.go
+++ b/cli/cmd/acif-adapter/handlers.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/OpenScribbler/syllago/cli/internal/acif"
+	"github.com/google/uuid"
+)
+
+const adapterVersion = "0.0.0-dev"
+
+type request struct {
+	Op             string          `json:"op"`
+	Input          json.RawMessage `json:"input"`
+	RunnerProtocol int             `json:"runner_protocol"`
+}
+
+type ingestInput struct {
+	Kind           string          `json:"kind"`
+	BodyRoot       string          `json:"body_root"`
+	EntryFile      string          `json:"entry_file"`
+	Sidecar        json.RawMessage `json:"sidecar"`
+	ProviderConfig json.RawMessage `json:"provider_config"`
+	Context        json.RawMessage `json:"context"`
+}
+
+type okEnvelope struct {
+	OK     bool `json:"ok"`
+	Result any  `json:"result"`
+}
+
+type errorEnvelope struct {
+	OK          bool              `json:"ok"`
+	Error       string            `json:"error"`
+	Diagnostics []acif.Diagnostic `json:"diagnostics,omitempty"`
+}
+
+type unsupportedEnvelope struct {
+	Unsupported bool `json:"unsupported"`
+}
+
+func dispatch(req request) any {
+	switch req.Op {
+	case "hello":
+		return okResponse(map[string]any{
+			"implementation":   "syllago",
+			"version":          adapterVersion,
+			"adapter_protocol": 1,
+			"scopes":           []string{"core"},
+		})
+	case "ingest":
+		return handleIngest(req.Input)
+	case "derive_pack_id":
+		return handleDerivePackID(req.Input)
+	case "resolve_pack":
+		return handleResolvePack(req.Input)
+	default:
+		return unsupportedResponse()
+	}
+}
+
+func okResponse(result any) okEnvelope {
+	return okEnvelope{OK: true, Result: result}
+}
+
+func errorResponse(message string) errorEnvelope {
+	return errorEnvelope{OK: false, Error: message}
+}
+
+func unsupportedResponse() unsupportedEnvelope {
+	return unsupportedEnvelope{Unsupported: true}
+}
+
+func handleIngest(raw json.RawMessage) any {
+	var rawInput map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &rawInput); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+
+	var input ingestInput
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+
+	if _, ok := rawInput["provider_config"]; ok {
+		return unsupportedResponse()
+	}
+	if input.Kind == "pack" {
+		if _, ok := rawInput["manifests"]; ok {
+			return unsupportedResponse()
+		}
+	}
+
+	if _, hasBodyRoot := rawInput["body_root"]; hasBodyRoot {
+		if isFrontmatterKind(input.Kind) {
+			return handleBodyIngest(input.BodyRoot, input.EntryFile)
+		}
+		return unsupportedResponse()
+	}
+
+	if _, hasSidecar := rawInput["sidecar"]; hasSidecar {
+		return handleSidecarIngest(input.Sidecar)
+	}
+
+	return unsupportedResponse()
+}
+
+func isFrontmatterKind(kind string) bool {
+	switch kind {
+	case "skill", "rule", "agent", "command":
+		return true
+	default:
+		return false
+	}
+}
+
+func handleBodyIngest(bodyRoot, entryFile string) any {
+	result, err := acif.BodyHash(bodyRoot, entryFile)
+	if err != nil {
+		var reject *acif.RejectError
+		if errors.As(err, &reject) {
+			return errorResponse(reject.ID)
+		}
+		return errorResponse("adapter: " + err.Error())
+	}
+	return okResponse(map[string]any{
+		"body_hash":      result.HashHex,
+		"classification": result.Classification,
+		"conformant":     true,
+	})
+}
+
+type sidecarResult struct {
+	PublisherSection json.RawMessage `json:"publisher_section"`
+	CanonicalBytes   string          `json:"canonical_bytes"`
+	MetadataHash     string          `json:"metadata_hash"`
+	Conformant       bool            `json:"conformant"`
+	Reason           string          `json:"reason,omitempty"`
+	Installable      bool            `json:"installable"`
+}
+
+func handleSidecarIngest(rawSidecar json.RawMessage) any {
+	sidecar, ok := parseJSONObject(rawSidecar)
+	if !ok {
+		return okResponse(map[string]any{
+			"conformant": false,
+			"reason":     "sidecar-not-object",
+		})
+	}
+
+	sectionRaw := rawSidecar
+	section := sidecar
+	allSections := []map[string]json.RawMessage{sidecar}
+	if publisherRaw, ok := sidecar["publisher_section"]; ok {
+		parsedPublisher, ok := parseJSONObject(publisherRaw)
+		if !ok {
+			return okResponse(map[string]any{
+				"conformant": false,
+				"reason":     "sidecar-not-object",
+			})
+		}
+		sectionRaw = publisherRaw
+		section = parsedPublisher
+		allSections = []map[string]json.RawMessage{sidecar, parsedPublisher}
+		if registryRaw, ok := sidecar["registry_section"]; ok {
+			if parsedRegistry, ok := parseJSONObject(registryRaw); ok {
+				allSections = append(allSections, parsedRegistry)
+			}
+		}
+	}
+
+	verdict := acif.ValidateEnvelope(section, allSections)
+	hashHex, canonicalBytes, err := acif.MetadataHash(sectionRaw)
+	if err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+
+	return okResponse(sidecarResult{
+		PublisherSection: sectionRaw,
+		CanonicalBytes:   string(canonicalBytes),
+		MetadataHash:     hashHex,
+		Conformant:       verdict.Conformant,
+		Reason:           verdict.Reason,
+		Installable:      verdict.Conformant,
+	})
+}
+
+func parseJSONObject(raw json.RawMessage) (map[string]json.RawMessage, bool) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil || obj == nil {
+		return nil, false
+	}
+	return obj, true
+}
+
+type derivePackIDInput struct {
+	Namespace     string `json:"namespace"`
+	RepositoryURL string `json:"repository_url"`
+	DisplayName   string `json:"display_name"`
+}
+
+func handleDerivePackID(raw json.RawMessage) any {
+	var input derivePackIDInput
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	namespace, err := uuid.Parse(input.Namespace)
+	if err != nil {
+		return errorResponse("adapter: bad namespace")
+	}
+	return okResponse(map[string]any{
+		"inferred_pack_id": acif.DerivePackID(namespace, input.RepositoryURL, input.DisplayName).String(),
+	})
+}
+
+type resolvePackInput struct {
+	Item struct {
+		PublisherSection struct {
+			PackID string `json:"pack_id"`
+		} `json:"publisher_section"`
+		RegistrySection struct {
+			InferredPackID string `json:"inferred_pack_id"`
+		} `json:"registry_section"`
+	} `json:"item"`
+	KnownPacks []struct {
+		ID string `json:"id"`
+	} `json:"known_packs"`
+}
+
+type resolvePackResult struct {
+	PackResolution string `json:"pack_resolution"`
+	MemberOf       string `json:"member_of,omitempty"`
+	Install        string `json:"install"`
+}
+
+func handleResolvePack(raw json.RawMessage) any {
+	var input resolvePackInput
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	known := make([]string, 0, len(input.KnownPacks))
+	for _, pack := range input.KnownPacks {
+		known = append(known, pack.ID)
+	}
+	resolution := acif.ResolvePack(
+		input.Item.PublisherSection.PackID,
+		input.Item.RegistrySection.InferredPackID,
+		known,
+	)
+	return okResponse(resolvePackResult{
+		PackResolution: resolution.Resolution,
+		MemberOf:       resolution.MemberOf,
+		Install:        resolution.Install,
+	})
+}

--- a/cli/cmd/acif-adapter/main.go
+++ b/cli/cmd/acif-adapter/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	if err := run(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(r io.Reader, w io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 17*1024*1024)
+
+	writer := bufio.NewWriter(w)
+	for scanner.Scan() {
+		response := handleLine(scanner.Bytes())
+		data, err := json.Marshal(response)
+		if err != nil {
+			return err
+		}
+		if _, err := writer.Write(data); err != nil {
+			return err
+		}
+		if err := writer.WriteByte('\n'); err != nil {
+			return err
+		}
+		if err := writer.Flush(); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func handleLine(line []byte) (response any) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			response = errorResponse("adapter: " + fmt.Sprint(recovered))
+		}
+	}()
+
+	var req request
+	if err := json.Unmarshal(line, &req); err != nil {
+		return errorResponse("adapter: malformed request line")
+	}
+	return dispatch(req)
+}

--- a/cli/cmd/acif-adapter/main_test.go
+++ b/cli/cmd/acif-adapter/main_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func runLines(t *testing.T, input string) []map[string]any {
+	t.Helper()
+	var out strings.Builder
+	if err := run(strings.NewReader(input), &out); err != nil {
+		t.Fatalf("run() error: %v", err)
+	}
+
+	var responses []map[string]any
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	for scanner.Scan() {
+		var response map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &response); err != nil {
+			t.Fatalf("response is not JSON: %q: %v", scanner.Text(), err)
+		}
+		responses = append(responses, response)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan responses: %v", err)
+	}
+	return responses
+}
+
+func writeAdapterFixture(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, data := range files {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
+		}
+		if err := os.WriteFile(p, []byte(data), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+}
+
+func TestHello(t *testing.T) {
+	t.Parallel()
+	responses := runLines(t, `{"op":"hello","runner_protocol":1}`+"\n")
+	if len(responses) != 1 {
+		t.Fatalf("responses = %d, want 1", len(responses))
+	}
+	want := map[string]any{
+		"ok": true,
+		"result": map[string]any{
+			"implementation":   "syllago",
+			"version":          "0.0.0-dev",
+			"adapter_protocol": float64(1),
+			"scopes":           []any{"core"},
+		},
+	}
+	if !reflect.DeepEqual(responses[0], want) {
+		t.Fatalf("hello response = %#v, want %#v", responses[0], want)
+	}
+}
+
+func TestIngestSidecarTV9(t *testing.T) {
+	t.Parallel()
+	request := `{"op":"ingest","input":{"kind":"command","sidecar":{"kind":"command","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","display_name":"Review PR","version":"1.2.0"}}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 1 {
+		t.Fatalf("responses = %d, want 1", len(responses))
+	}
+	result, ok := responses[0]["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("result missing or wrong type: %#v", responses[0])
+	}
+	if responses[0]["ok"] != true {
+		t.Fatalf("ok = %#v, want true", responses[0]["ok"])
+	}
+	if got, want := result["canonical_bytes"], `{"display_name":"Review PR","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","kind":"command","version":"1.2.0"}`; got != want {
+		t.Fatalf("canonical_bytes = %#v, want %q", got, want)
+	}
+	if got, want := result["metadata_hash"], "ceb0cf9212c530e85444020aeb3cbae8865fdc16d91ee63fe6f5cb374d67b5c6"; got != want {
+		t.Fatalf("metadata_hash = %#v, want %q", got, want)
+	}
+	if result["conformant"] != true || result["installable"] != true {
+		t.Fatalf("conformant/installable = %#v/%#v, want true/true", result["conformant"], result["installable"])
+	}
+	publisherSection, ok := result["publisher_section"].(map[string]any)
+	if !ok {
+		t.Fatalf("publisher_section missing or wrong type: %#v", result["publisher_section"])
+	}
+	if publisherSection["display_name"] != "Review PR" || publisherSection["kind"] != "command" {
+		t.Fatalf("publisher_section echo = %#v", publisherSection)
+	}
+}
+
+func TestIngestBodyTV1(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeAdapterFixture(t, dir, map[string]string{
+		"SKILL.md": "---\ndescription: demo\n---\nUse this skill to demo hashing.\n",
+	})
+	request := `{"op":"ingest","input":{"kind":"skill","body_root":` + mustJSON(t, dir) + `,"entry_file":"SKILL.md"}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 1 {
+		t.Fatalf("responses = %d, want 1", len(responses))
+	}
+	result, ok := responses[0]["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("result missing or wrong type: %#v", responses[0])
+	}
+	if got, want := result["body_hash"], "916e570331167c16f8112573d1b6020c134cc3d4019e8011693676d019b88ffe"; got != want {
+		t.Fatalf("body_hash = %#v, want %q", got, want)
+	}
+	if got := result["classification"]; got != "single-file" {
+		t.Fatalf("classification = %#v, want single-file", got)
+	}
+}
+
+func TestIngestBodyRejectError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeAdapterFixture(t, dir, map[string]string{"SKILL.md": "Body prose.\n"})
+	if err := os.Symlink("SKILL.md", filepath.Join(dir, "link.md")); err != nil {
+		t.Skipf("creating symlink: %v", err)
+	}
+	request := `{"op":"ingest","input":{"kind":"skill","body_root":` + mustJSON(t, dir) + `,"entry_file":"SKILL.md"}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 1 {
+		t.Fatalf("responses = %d, want 1", len(responses))
+	}
+	if responses[0]["ok"] != false || responses[0]["error"] != "acif.body.symlink" {
+		t.Fatalf("response = %#v, want acif.body.symlink error", responses[0])
+	}
+}
+
+func TestUnknownOpUnsupported(t *testing.T) {
+	t.Parallel()
+	responses := runLines(t, `{"op":"not_real","input":{}}`+"\n")
+	if len(responses) != 1 {
+		t.Fatalf("responses = %d, want 1", len(responses))
+	}
+	if !reflect.DeepEqual(responses[0], map[string]any{"unsupported": true}) {
+		t.Fatalf("response = %#v, want unsupported", responses[0])
+	}
+}
+
+func TestMalformedJSONLineContinues(t *testing.T) {
+	t.Parallel()
+	responses := runLines(t, "{bad json\n"+`{"op":"hello","runner_protocol":1}`+"\n")
+	if len(responses) != 2 {
+		t.Fatalf("responses = %d, want 2", len(responses))
+	}
+	if responses[0]["ok"] != false {
+		t.Fatalf("first response = %#v, want ok=false", responses[0])
+	}
+	errText, _ := responses[0]["error"].(string)
+	if !strings.HasPrefix(errText, "adapter: ") {
+		t.Fatalf("malformed error = %q, want adapter prefix", errText)
+	}
+	if responses[1]["ok"] != true {
+		t.Fatalf("second response = %#v, want hello success", responses[1])
+	}
+}
+
+func TestStatelessnessSmoke(t *testing.T) {
+	t.Parallel()
+	request := `{"op":"ingest","input":{"kind":"command","sidecar":{"kind":"command","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","display_name":"Review PR","version":"1.2.0"}}}` + "\n"
+	var out strings.Builder
+	if err := run(strings.NewReader(request+request), &out); err != nil {
+		t.Fatalf("run() error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSuffix(out.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("response lines = %d, want 2: %q", len(lines), out.String())
+	}
+	if lines[0] != lines[1] {
+		t.Fatalf("identical requests produced different responses:\n%s\n%s", lines[0], lines[1])
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+	return string(data)
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,7 +9,9 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467
 	github.com/evanw/esbuild v0.28.0
+	github.com/google/uuid v1.6.0
 	github.com/in-toto/attestation v1.2.0
 	github.com/lrstanley/bubblezone v1.0.0
 	github.com/muesli/termenv v0.16.0
@@ -39,7 +41,6 @@ require (
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
-	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 // indirect
 	github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 // indirect
 	github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -71,7 +72,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/google/certificate-transparency-go v1.3.3 // indirect
 	github.com/google/go-containerregistry v0.21.6 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/in-toto/in-toto-golang v0.11.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/cli/internal/acif/bodyhash.go
+++ b/cli/internal/acif/bodyhash.go
@@ -1,0 +1,186 @@
+package acif
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"golang.org/x/text/unicode/norm"
+)
+
+type BodyResult struct {
+	Classification string
+	HashHex        string
+}
+
+type bodyFile struct {
+	abs                 string
+	rel                 string
+	rootLicenseOrReadme bool
+}
+
+var acifVCSDirs = map[string]bool{
+	".git": true, ".svn": true, ".hg": true, ".bzr": true,
+	"_darcs": true, ".fossil": true,
+}
+
+// BodyHash computes body_hash for a frontmatter-bearing content type.
+func BodyHash(bodyRoot, entryFile string) (*BodyResult, error) {
+	absRoot, err := filepath.Abs(bodyRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolving body root: %w", err)
+	}
+	entryRel := filepath.ToSlash(filepath.Clean(entryFile))
+
+	var files []bodyFile
+	walkErr := filepath.WalkDir(absRoot, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		rel, err := filepath.Rel(absRoot, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		posixRel := filepath.ToSlash(rel)
+
+		if d.Type()&fs.ModeSymlink != 0 {
+			return &RejectError{ID: ErrBodySymlink, Detail: posixRel}
+		}
+		if d.IsDir() {
+			if acifVCSDirs[d.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		rootFile := filepath.Dir(rel) == "."
+		if rootFile && d.Name() == "acif-sidecar.yaml" {
+			return nil
+		}
+
+		files = append(files, bodyFile{
+			abs:                 path,
+			rel:                 posixRel,
+			rootLicenseOrReadme: rootFile && isRootLicenseOrReadme(d.Name()),
+		})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	var contentCandidates []bodyFile
+	for _, f := range files {
+		if !f.rootLicenseOrReadme {
+			contentCandidates = append(contentCandidates, f)
+		}
+	}
+	if len(contentCandidates) == 0 {
+		return nil, &RejectError{ID: ErrBodyEmpty, Detail: bodyRoot}
+	}
+
+	if len(contentCandidates) == 1 && contentCandidates[0].rel == entryRel {
+		hash, err := hashEntryFile(contentCandidates[0].abs)
+		if err != nil {
+			return nil, err
+		}
+		return &BodyResult{Classification: "single-file", HashHex: hash}, nil
+	}
+
+	hash, err := multiFileBodyHash(files, entryRel)
+	if err != nil {
+		return nil, err
+	}
+	return &BodyResult{Classification: "multi-file", HashHex: hash}, nil
+}
+
+func isRootLicenseOrReadme(name string) bool {
+	upper := strings.ToUpper(name)
+	return strings.HasPrefix(upper, "LICENSE") || strings.HasPrefix(upper, "README")
+}
+
+func hashEntryFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading entry file: %w", err)
+	}
+	return sha256Hex(stripFrontmatter(moat.CanonicalText(data))), nil
+}
+
+func multiFileBodyHash(files []bodyFile, entryRel string) (string, error) {
+	type manifestEntry struct {
+		rel  string
+		hash string
+	}
+	entries := make([]manifestEntry, 0, len(files))
+	seen := make(map[string]string, len(files))
+
+	for _, f := range files {
+		nfcRel := norm.NFC.String(f.rel)
+		if prior, ok := seen[nfcRel]; ok && prior != f.rel {
+			return "", &RejectError{
+				ID:     ErrBodyPathCollision,
+				Detail: fmt.Sprintf("%q and %q normalize to %q", prior, f.rel, nfcRel),
+			}
+		}
+		seen[nfcRel] = f.rel
+
+		var fileHash string
+		var err error
+		if f.rel == entryRel {
+			fileHash, err = hashEntryFile(f.abs)
+		} else {
+			fileHash, err = moat.FileHash(f.abs)
+		}
+		if err != nil {
+			return "", fmt.Errorf("hashing %s: %w", f.rel, err)
+		}
+		entries = append(entries, manifestEntry{rel: nfcRel, hash: fileHash})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].rel < entries[j].rel
+	})
+
+	var manifest strings.Builder
+	for _, e := range entries {
+		manifest.WriteString(e.hash)
+		manifest.WriteString("  ")
+		manifest.WriteString(e.rel)
+		manifest.WriteByte('\n')
+	}
+	return sha256Hex([]byte(manifest.String())), nil
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func stripFrontmatter(text []byte) []byte {
+	if !bytes.HasPrefix(text, []byte("---\n")) {
+		return text
+	}
+	const closing = "\n---\n"
+	if idx := bytes.Index(text[3:], []byte(closing)); idx >= 0 {
+		start := idx + 3
+		return text[start+len(closing):]
+	}
+	if bytes.HasSuffix(text, []byte("\n---")) {
+		return nil
+	}
+	return text
+}

--- a/cli/internal/acif/bodyhash_test.go
+++ b/cli/internal/acif/bodyhash_test.go
@@ -1,0 +1,226 @@
+package acif
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func writeBodyFixture(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, data := range files {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
+		}
+		if err := os.WriteFile(p, []byte(data), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+}
+
+func assertReject(t *testing.T, err error, id string) {
+	t.Helper()
+	var reject *RejectError
+	if !errors.As(err, &reject) {
+		t.Fatalf("error = %T %v, want *RejectError %s", err, err, id)
+	}
+	if reject.ID != id {
+		t.Fatalf("RejectError.ID = %q, want %q", reject.ID, id)
+	}
+}
+
+func TestBodyHashVectors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		files          map[string]string
+		entry          string
+		classification string
+		hash           string
+	}{
+		{
+			name: "TV-1 single file strips frontmatter",
+			files: map[string]string{
+				"SKILL.md": "---\ndescription: demo\n---\nUse this skill to demo hashing.\n",
+			},
+			entry:          "SKILL.md",
+			classification: "single-file",
+			hash:           "916e570331167c16f8112573d1b6020c134cc3d4019e8011693676d019b88ffe",
+		},
+		{
+			name: "TV-12 nested sidecar included",
+			files: map[string]string{
+				"SKILL.md":              "Body prose.\n",
+				"sub/acif-sidecar.yaml": "kind: skill\n",
+			},
+			entry:          "SKILL.md",
+			classification: "multi-file",
+			hash:           "581e9b6b2dbd5a5947758f8ecdf67896c2a1225936ab5bd744a3973460b85169",
+		},
+		{
+			name: "TV-12 root sidecar excluded",
+			files: map[string]string{
+				"SKILL.md":              "Body prose.\n",
+				"acif-sidecar.yaml":     "kind: skill\n",
+				"sub/acif-sidecar.yaml": "kind: skill\n",
+			},
+			entry:          "SKILL.md",
+			classification: "multi-file",
+			hash:           "581e9b6b2dbd5a5947758f8ecdf67896c2a1225936ab5bd744a3973460b85169",
+		},
+		{
+			name: "TV-12 nested sidecar edit changes hash",
+			files: map[string]string{
+				"SKILL.md":              "Body prose.\n",
+				"sub/acif-sidecar.yaml": "kind: skill\nid: f47ac10b\n",
+			},
+			entry:          "SKILL.md",
+			classification: "multi-file",
+			hash:           "b4e9079283b7852f98fc2a9f9719699a1c5e3b48101695f8f7567314d3a2eae4",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			writeBodyFixture(t, dir, tc.files)
+			got, err := BodyHash(dir, tc.entry)
+			if err != nil {
+				t.Fatalf("BodyHash() error: %v", err)
+			}
+			if got.Classification != tc.classification {
+				t.Fatalf("classification = %q, want %q", got.Classification, tc.classification)
+			}
+			if got.HashHex != tc.hash {
+				t.Fatalf("hash = %s, want %s", got.HashHex, tc.hash)
+			}
+		})
+	}
+}
+
+func TestBodyHashRejectsSymlink(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions vary on Windows")
+	}
+	dir := t.TempDir()
+	writeBodyFixture(t, dir, map[string]string{"SKILL.md": "Body prose.\n"})
+	if err := os.Symlink("SKILL.md", filepath.Join(dir, "link.md")); err != nil {
+		t.Skipf("creating symlink: %v", err)
+	}
+
+	_, err := BodyHash(dir, "SKILL.md")
+	assertReject(t, err, ErrBodySymlink)
+}
+
+func TestBodyHashRejectsNFCPathCollision(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeBodyFixture(t, dir, map[string]string{
+		"SKILL.md": "Body prose.\n",
+		"café.md":  "nfc\n",
+		"café.md": "nfd\n",
+	})
+
+	_, err := BodyHash(dir, "SKILL.md")
+	assertReject(t, err, ErrBodyPathCollision)
+}
+
+func TestBodyHashRejectsEmptyAfterRootLicenseAndReadmeExclusions(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeBodyFixture(t, dir, map[string]string{
+		"LICENSE":   "MIT\n",
+		"README.md": "# Demo\n",
+	})
+
+	_, err := BodyHash(dir, "SKILL.md")
+	assertReject(t, err, ErrBodyEmpty)
+}
+
+func TestBodyHashRootReadmeExcludedFromClassification(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeBodyFixture(t, dir, map[string]string{
+		"SKILL.md":  "Body prose.\n",
+		"Readme.md": "# Demo\n",
+	})
+
+	got, err := BodyHash(dir, "SKILL.md")
+	if err != nil {
+		t.Fatalf("BodyHash() error: %v", err)
+	}
+	if got.Classification != "single-file" {
+		t.Fatalf("classification = %q, want single-file", got.Classification)
+	}
+}
+
+func TestBodyHashRootLicenseIncludedInMultiFileManifest(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	writeBodyFixture(t, base, map[string]string{
+		"SKILL.md": "Body prose.\n",
+		"extra.md": "Extra prose.\n",
+	})
+	withLicense := t.TempDir()
+	writeBodyFixture(t, withLicense, map[string]string{
+		"SKILL.md": "Body prose.\n",
+		"extra.md": "Extra prose.\n",
+		"LICENSE":  "MIT\n",
+	})
+
+	baseHash, err := BodyHash(base, "SKILL.md")
+	if err != nil {
+		t.Fatalf("BodyHash(base): %v", err)
+	}
+	licenseHash, err := BodyHash(withLicense, "SKILL.md")
+	if err != nil {
+		t.Fatalf("BodyHash(withLicense): %v", err)
+	}
+	if baseHash.Classification != "multi-file" || licenseHash.Classification != "multi-file" {
+		t.Fatalf("classifications = %q/%q, want multi-file/multi-file", baseHash.Classification, licenseHash.Classification)
+	}
+	if baseHash.HashHex == licenseHash.HashHex {
+		t.Fatalf("adding root LICENSE did not change multi-file body hash: %s", baseHash.HashHex)
+	}
+}
+
+func TestStripFrontmatterEdges(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "no frontmatter", in: "Body prose.\n", want: "Body prose.\n"},
+		{name: "unterminated block", in: "---\ncrud\n", want: "---\ncrud\n"},
+		{name: "closed by delimiter line", in: "---\nkind: x\n---\nBody\n", want: "Body\n"},
+		{name: "closed by eof", in: "---\nkind: x\n---", want: ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := string(stripFrontmatter([]byte(tc.in))); got != tc.want {
+				t.Fatalf("stripFrontmatter() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripFrontmatterClosedByEOFHashesEmptyInput(t *testing.T) {
+	t.Parallel()
+	sum := sha256.Sum256(stripFrontmatter([]byte("---\nkind: x\n---")))
+	if got, want := hex.EncodeToString(sum[:]), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"; got != want {
+		t.Fatalf("hash of stripped EOF frontmatter = %s, want %s", got, want)
+	}
+}

--- a/cli/internal/acif/diagnostics.go
+++ b/cli/internal/acif/diagnostics.go
@@ -1,0 +1,29 @@
+package acif
+
+// Diagnostic is the ACIF structured diagnostic (adapter protocol §3.1).
+type Diagnostic struct {
+	ID     string         `json:"id"`
+	Params map[string]any `json:"params,omitempty"`
+}
+
+// RejectError carries a spec-minted acif.* error identifier.
+type RejectError struct {
+	ID     string
+	Detail string
+}
+
+func (e *RejectError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Detail == "" {
+		return e.ID
+	}
+	return e.ID + ": " + e.Detail
+}
+
+const (
+	ErrBodySymlink       = "acif.body.symlink"
+	ErrBodyPathCollision = "acif.body.path_collision"
+	ErrBodyEmpty         = "acif.body.empty"
+)

--- a/cli/internal/acif/envelope.go
+++ b/cli/internal/acif/envelope.go
@@ -1,0 +1,97 @@
+package acif
+
+import (
+	"encoding/json"
+	"regexp"
+
+	"github.com/google/uuid"
+)
+
+type EnvelopeVerdict struct {
+	Conformant bool
+	Reason     string
+}
+
+var (
+	semverRe = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$`)
+	spdxIDRe = regexp.MustCompile(`^[A-Za-z0-9.+-]+$`)
+)
+
+// ValidateEnvelope validates a publisher_section / flat sidecar declaration
+// (a parsed JSON object) plus the enclosing item record's sections.
+func ValidateEnvelope(section map[string]json.RawMessage, allSections []map[string]json.RawMessage) EnvelopeVerdict {
+	forbidden := []string{"effective_version", "derived_version", "pack_inherited_version", "resolved_version"}
+	if len(allSections) == 0 {
+		allSections = []map[string]json.RawMessage{section}
+	}
+	for _, name := range forbidden {
+		for _, s := range allSections {
+			if _, ok := s[name]; ok {
+				return EnvelopeVerdict{Reason: "forbidden-field " + name}
+			}
+		}
+	}
+
+	kind, ok := stringField(section, "kind")
+	if !ok {
+		return EnvelopeVerdict{Reason: "missing-required-field kind"}
+	}
+	if !validKind(kind) {
+		return EnvelopeVerdict{Reason: "kind-not-in-closed-enum"}
+	}
+
+	id, ok := stringField(section, "id")
+	if !ok {
+		return EnvelopeVerdict{Reason: "missing-required-field id"}
+	}
+	parsedID, err := uuid.Parse(id)
+	if err != nil || parsedID.Version() != 4 || parsedID.Variant() != uuid.RFC4122 {
+		return EnvelopeVerdict{Reason: "id-not-uuid-v4"}
+	}
+
+	displayName, ok := stringField(section, "display_name")
+	if !ok || displayName == "" {
+		return EnvelopeVerdict{Reason: "missing-required-field display_name"}
+	}
+
+	if rawVersion, ok := section["version"]; ok {
+		var version string
+		if err := json.Unmarshal(rawVersion, &version); err != nil || !semverRe.MatchString(version) {
+			return EnvelopeVerdict{Reason: "version-not-semver"}
+		}
+	}
+
+	if rawLicense, ok := section["license"]; ok {
+		var license map[string]json.RawMessage
+		if err := json.Unmarshal(rawLicense, &license); err != nil {
+			return EnvelopeVerdict{Reason: "license-spdx-not-identifier"}
+		}
+		spdx, ok := stringField(license, "spdx")
+		if !ok || !spdxIDRe.MatchString(spdx) {
+			return EnvelopeVerdict{Reason: "license-spdx-not-identifier"}
+		}
+	}
+
+	return EnvelopeVerdict{Conformant: true}
+}
+
+func stringField(section map[string]json.RawMessage, name string) (string, bool) {
+	raw, ok := section[name]
+	if !ok {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func validKind(kind string) bool {
+	switch kind {
+	case "hook", "skill", "rule", "command", "agent", "mcp_config", "pack":
+		return true
+	default:
+		return false
+	}
+}

--- a/cli/internal/acif/envelope_test.go
+++ b/cli/internal/acif/envelope_test.go
@@ -1,0 +1,151 @@
+package acif
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func rawObject(t *testing.T, raw string) map[string]json.RawMessage {
+	t.Helper()
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &obj); err != nil {
+		t.Fatalf("unmarshal object: %v", err)
+	}
+	return obj
+}
+
+func TestValidateEnvelopeTV11InvalidCases(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		raw    string
+		reason string
+	}{
+		{
+			name:   "kind case mismatch",
+			raw:    `{"kind":"Skill","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","display_name":"Demo"}`,
+			reason: "kind-not-in-closed-enum",
+		},
+		{
+			name:   "id not uuid",
+			raw:    `{"kind":"skill","id":"not-a-uuid","display_name":"Demo"}`,
+			reason: "id-not-uuid-v4",
+		},
+		{
+			name:   "version not semver",
+			raw:    `{"kind":"skill","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","display_name":"Demo","version":"1.0"}`,
+			reason: "version-not-semver",
+		},
+		{
+			name:   "license spdx not identifier",
+			raw:    `{"kind":"skill","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","display_name":"Demo","license":{"spdx":"MIT License"}}`,
+			reason: "license-spdx-not-identifier",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			section := rawObject(t, tc.raw)
+			got := ValidateEnvelope(section, []map[string]json.RawMessage{section})
+			if got.Conformant {
+				t.Fatalf("ValidateEnvelope() conformant, want rejection")
+			}
+			if got.Reason != tc.reason {
+				t.Fatalf("reason = %q, want %q", got.Reason, tc.reason)
+			}
+		})
+	}
+}
+
+func TestValidateEnvelopeTV6ForbiddenEffectiveVersion(t *testing.T) {
+	t.Parallel()
+	section := rawObject(t, `{"kind":"skill","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","display_name":"Demo","effective_version":"1.0.0"}`)
+	got := ValidateEnvelope(section, []map[string]json.RawMessage{section})
+	if got.Conformant {
+		t.Fatalf("ValidateEnvelope() conformant, want forbidden-field rejection")
+	}
+	if got.Reason != "forbidden-field effective_version" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+}
+
+func TestValidateEnvelopeValid(t *testing.T) {
+	t.Parallel()
+	section := rawObject(t, `{"kind":"agent","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","display_name":"Demo Agent","version":"1.2.3-alpha+build","license":{"spdx":"MIT"}}`)
+	got := ValidateEnvelope(section, []map[string]json.RawMessage{section})
+	if !got.Conformant {
+		t.Fatalf("ValidateEnvelope() rejected valid envelope: %q", got.Reason)
+	}
+	if got.Reason != "" {
+		t.Fatalf("reason = %q, want empty", got.Reason)
+	}
+}
+
+func TestValidateEnvelopeForbiddenFieldsInEachSection(t *testing.T) {
+	t.Parallel()
+
+	forbidden := []string{"effective_version", "derived_version", "pack_inherited_version", "resolved_version"}
+	locations := []string{"top-level", "publisher-section", "registry-section"}
+
+	for _, field := range forbidden {
+		field := field
+		for _, location := range locations {
+			location := location
+			t.Run(location+"/"+field, func(t *testing.T) {
+				t.Parallel()
+				valid := `{"kind":"skill","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","display_name":"Demo"}`
+				top := rawObject(t, `{}`)
+				publisher := rawObject(t, valid)
+				registry := rawObject(t, `{}`)
+
+				switch location {
+				case "top-level":
+					top[field] = json.RawMessage(`"x"`)
+				case "publisher-section":
+					publisher[field] = json.RawMessage(`"x"`)
+				case "registry-section":
+					registry[field] = json.RawMessage(`"x"`)
+				}
+
+				got := ValidateEnvelope(publisher, []map[string]json.RawMessage{top, publisher, registry})
+				if got.Conformant {
+					t.Fatalf("ValidateEnvelope() conformant with forbidden %s in %s", field, location)
+				}
+				if want := "forbidden-field " + field; got.Reason != want {
+					t.Fatalf("reason = %q, want %q", got.Reason, want)
+				}
+			})
+		}
+	}
+}
+
+func TestValidateEnvelopeMissingRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		raw    string
+		reason string
+	}{
+		{name: "kind", raw: `{"id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","display_name":"Demo"}`, reason: "missing-required-field kind"},
+		{name: "id", raw: `{"kind":"skill","display_name":"Demo"}`, reason: "missing-required-field id"},
+		{name: "display_name", raw: `{"kind":"skill","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479"}`, reason: "missing-required-field display_name"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			section := rawObject(t, tc.raw)
+			got := ValidateEnvelope(section, []map[string]json.RawMessage{section})
+			if got.Conformant {
+				t.Fatalf("ValidateEnvelope() conformant, want rejection")
+			}
+			if got.Reason != tc.reason {
+				t.Fatalf("reason = %q, want %q", got.Reason, tc.reason)
+			}
+		})
+	}
+}

--- a/cli/internal/acif/jcs.go
+++ b/cli/internal/acif/jcs.go
@@ -1,0 +1,27 @@
+package acif
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	jsoncanonicalizer "github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+)
+
+// CanonicalJSON returns the RFC 8785 (JCS) serialization of the JSON text in raw.
+func CanonicalJSON(raw json.RawMessage) ([]byte, error) {
+	return jsoncanonicalizer.Transform([]byte(raw))
+}
+
+// MetadataHash computes [ACIF-PUBLISHER] §6: lowercase-hex SHA-256 over
+// JCS(publisher_section) followed by one LF (0x0A).
+func MetadataHash(publisherSection json.RawMessage) (hashHex string, canonicalBytes []byte, err error) {
+	canonicalBytes, err = CanonicalJSON(publisherSection)
+	if err != nil {
+		return "", nil, err
+	}
+	h := sha256.New()
+	_, _ = h.Write(canonicalBytes)
+	_, _ = h.Write([]byte{'\n'})
+	return hex.EncodeToString(h.Sum(nil)), canonicalBytes, nil
+}

--- a/cli/internal/acif/jcs_test.go
+++ b/cli/internal/acif/jcs_test.go
@@ -1,0 +1,59 @@
+package acif
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMetadataHashVectors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		section   string
+		canonical string
+		hash      string
+	}{
+		{
+			name:      "TV-9 command",
+			section:   `{"kind":"command","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","display_name":"Review PR","version":"1.2.0"}`,
+			canonical: `{"display_name":"Review PR","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","kind":"command","version":"1.2.0"}`,
+			hash:      "ceb0cf9212c530e85444020aeb3cbae8865fdc16d91ee63fe6f5cb374d67b5c6",
+		},
+		{
+			name:      "TV-2 skill",
+			section:   `{"kind":"skill","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","display_name":"Demo Skill"}`,
+			canonical: `{"display_name":"Demo Skill","id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","kind":"skill"}`,
+			hash:      "b68bf2e4cbd6b9123d23de684498157adeaf4915e65435a95a556ac27ec50316",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			hash, canonical, err := MetadataHash(json.RawMessage(tc.section))
+			if err != nil {
+				t.Fatalf("MetadataHash() error: %v", err)
+			}
+			if string(canonical) != tc.canonical {
+				t.Fatalf("canonical = %s, want %s", canonical, tc.canonical)
+			}
+			if hash != tc.hash {
+				t.Fatalf("hash = %s, want %s", hash, tc.hash)
+			}
+		})
+	}
+}
+
+func TestCanonicalJSONUsesRawBytes(t *testing.T) {
+	t.Parallel()
+	raw := json.RawMessage([]byte("{\n  \"b\":2,\n  \"a\":1\n}"))
+	got, err := CanonicalJSON(raw)
+	if err != nil {
+		t.Fatalf("CanonicalJSON() error: %v", err)
+	}
+	if want := `{"a":1,"b":2}`; string(got) != want {
+		t.Fatalf("CanonicalJSON() = %s, want %s", got, want)
+	}
+}

--- a/cli/internal/acif/pack.go
+++ b/cli/internal/acif/pack.go
@@ -1,0 +1,44 @@
+package acif
+
+import "github.com/google/uuid"
+
+// DerivePackID implements [ACIF-PUBLISHER] §9.4 over already-canonical inputs:
+// UUIDv5(namespace, canonicalRepositoryURL + "\n" + canonicalDisplayName).
+func DerivePackID(namespace uuid.UUID, repositoryURL, displayName string) uuid.UUID {
+	return uuid.NewSHA1(namespace, []byte(repositoryURL+"\n"+displayName))
+}
+
+type PackResolution struct {
+	Resolution string
+	MemberOf   string
+	Install    string
+}
+
+func ResolvePack(declaredPackID, inferredPackID string, knownPackIDs []string) PackResolution {
+	if declaredPackID != "" {
+		for _, known := range knownPackIDs {
+			if declaredPackID == known {
+				return PackResolution{
+					Resolution: "declared",
+					MemberOf:   declaredPackID,
+					Install:    "proceed",
+				}
+			}
+		}
+		return PackResolution{
+			Resolution: "unresolved",
+			Install:    "refuse-unless-operator-opt-in",
+		}
+	}
+	if inferredPackID != "" {
+		return PackResolution{
+			Resolution: "inferred",
+			MemberOf:   inferredPackID,
+			Install:    "proceed",
+		}
+	}
+	return PackResolution{
+		Resolution: "none",
+		Install:    "proceed",
+	}
+}

--- a/cli/internal/acif/pack_test.go
+++ b/cli/internal/acif/pack_test.go
@@ -1,0 +1,78 @@
+package acif
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestDerivePackIDTV3(t *testing.T) {
+	t.Parallel()
+	namespace := uuid.MustParse("93516344-00e5-419b-a230-6e8b1d02f87d")
+	got := DerivePackID(namespace, "https://github.com/obra/superpowers", "superpowers")
+	if want := "d932cd6d-1c14-527d-b2e7-185c717b7a0d"; got.String() != want {
+		t.Fatalf("DerivePackID() = %s, want %s", got.String(), want)
+	}
+}
+
+func TestResolvePack(t *testing.T) {
+	t.Parallel()
+
+	const (
+		declared = "11111111-1111-4111-8111-111111111111"
+		inferred = "22222222-2222-4222-8222-222222222222"
+		unknown  = "99999999-9999-4999-8999-999999999999"
+	)
+	cases := []struct {
+		name       string
+		declared   string
+		inferred   string
+		known      []string
+		resolution string
+		memberOf   string
+		install    string
+	}{
+		{
+			name:       "TV-4 declared wins when both known",
+			declared:   declared,
+			inferred:   inferred,
+			known:      []string{declared, inferred},
+			resolution: "declared",
+			memberOf:   declared,
+			install:    "proceed",
+		},
+		{
+			name:       "TV-5 unknown declared refuses",
+			declared:   unknown,
+			known:      nil,
+			resolution: "unresolved",
+			memberOf:   "",
+			install:    "refuse-unless-operator-opt-in",
+		},
+		{
+			name:       "inferred only resolves without consulting known",
+			inferred:   inferred,
+			known:      nil,
+			resolution: "inferred",
+			memberOf:   inferred,
+			install:    "proceed",
+		},
+		{
+			name:       "neither",
+			resolution: "none",
+			install:    "proceed",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ResolvePack(tc.declared, tc.inferred, tc.known)
+			if got.Resolution != tc.resolution || got.MemberOf != tc.memberOf || got.Install != tc.install {
+				t.Fatalf("ResolvePack() = %+v, want resolution=%q member_of=%q install=%q",
+					got, tc.resolution, tc.memberOf, tc.install)
+			}
+		})
+	}
+}

--- a/cli/internal/capfeed/run_test.go
+++ b/cli/internal/capfeed/run_test.go
@@ -237,7 +237,8 @@ func TestRun_VerifyPrecedesMarkerCompare(t *testing.T) {
 func tamperOneSHA256(t *testing.T, indexBytes []byte) []byte {
 	t.Helper()
 	var meta struct {
-		Files map[string]struct {
+		DataRevision string `json:"data_revision"`
+		Files        map[string]struct {
 			SHA256 string `json:"sha256"`
 		} `json:"files"`
 	}
@@ -245,6 +246,12 @@ func tamperOneSHA256(t *testing.T, indexBytes []byte) []byte {
 		t.Fatal(err)
 	}
 	for _, f := range meta.Files {
+		// data_revision is the sha256 of one of the files, and it appears in
+		// the raw JSON before the files map — flipping that file's digest via
+		// first-occurrence Replace would tamper data_revision instead.
+		if f.SHA256 == meta.DataRevision {
+			continue
+		}
 		old := []byte(`"` + f.SHA256 + `"`)
 		flipped := []byte(f.SHA256)
 		if flipped[0] == 'a' {

--- a/cli/internal/moat/export.go
+++ b/cli/internal/moat/export.go
@@ -1,0 +1,32 @@
+package moat
+
+import "bytes"
+
+// FileHash returns the file-level MOAT hash as lowercase hex without an
+// algorithm prefix, classifying the file with the same text/binary heuristic
+// used by ContentHash.
+func FileHash(path string) (string, error) {
+	text, err := isText(path)
+	if err != nil {
+		return "", err
+	}
+	if text {
+		return hashText(path)
+	}
+	return hashBinary(path)
+}
+
+// CanonicalText returns the bytes-level canonical text form used by MOAT:
+// strip a leading UTF-8 BOM, then normalize CRLF and lone CR to LF.
+func CanonicalText(data []byte) []byte {
+	chunk := bytes.TrimPrefix(data, utf8BOM)
+	var out bytes.Buffer
+	pendingCR := false
+	if len(chunk) > 0 {
+		normalizeChunk(&out, chunk, &pendingCR)
+	}
+	if pendingCR {
+		_ = out.WriteByte(0x0A)
+	}
+	return out.Bytes()
+}

--- a/cli/internal/moat/export_test.go
+++ b/cli/internal/moat/export_test.go
@@ -1,0 +1,86 @@
+package moat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCanonicalText(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{
+			name: "strips bom",
+			in:   append(append([]byte{}, utf8BOM...), []byte("hello\n")...),
+			want: "hello\n",
+		},
+		{
+			name: "normalizes crlf and cr mix",
+			in:   []byte("a\r\nb\rc\n"),
+			want: "a\nb\nc\n",
+		},
+		{
+			name: "lone cr at eof",
+			in:   []byte("a\r"),
+			want: "a\n",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := string(CanonicalText(tc.in)); got != tc.want {
+				t.Fatalf("CanonicalText() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFileHashClassifiesTextAndBinary(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	raw := append(append([]byte{}, utf8BOM...), []byte("a\r\nb\r")...)
+
+	textPath := filepath.Join(dir, "note.md")
+	if err := os.WriteFile(textPath, raw, 0o644); err != nil {
+		t.Fatalf("write text: %v", err)
+	}
+	textHash, err := FileHash(textPath)
+	if err != nil {
+		t.Fatalf("FileHash(text): %v", err)
+	}
+	if want := sha256HexOf([]byte("a\nb\n")); textHash != want {
+		t.Fatalf("FileHash(text) = %s, want %s", textHash, want)
+	}
+
+	binaryPath := filepath.Join(dir, "note.bin")
+	if err := os.WriteFile(binaryPath, raw, 0o644); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	binaryHash, err := FileHash(binaryPath)
+	if err != nil {
+		t.Fatalf("FileHash(binary): %v", err)
+	}
+	if want := sha256HexOf(raw); binaryHash != want {
+		t.Fatalf("FileHash(binary) = %s, want %s", binaryHash, want)
+	}
+
+	nulJSON := filepath.Join(dir, "data.json")
+	nulRaw := []byte("{\"k\":\"v\x00\"}\r\n")
+	if err := os.WriteFile(nulJSON, nulRaw, 0o644); err != nil {
+		t.Fatalf("write nul json: %v", err)
+	}
+	nulHash, err := FileHash(nulJSON)
+	if err != nil {
+		t.Fatalf("FileHash(nul json): %v", err)
+	}
+	if want := sha256HexOf(nulRaw); nulHash != want {
+		t.Fatalf("FileHash(nul json) = %s, want raw binary hash %s", nulHash, want)
+	}
+}


### PR DESCRIPTION
## Summary

Syllago is ACIF conformance implementation #1. Stage 0 lands the `internal/acif` semantics package and the `cmd/acif-adapter` dev-only NDJSON shim; the ACIF conformance runner passes **all 13 core-scope vectors (TV-1..TV-13)** against the built adapter.

- **`internal/acif`** — body_hash ([ACIF-CORE] §7: single/multi-file classification, entry-file frontmatter strip, root-only `acif-sidecar.yaml` exclusion, typed `acif.body.*` rejects), RFC 8785 canonical JSON + metadata_hash ([ACIF-PUBLISHER] §6), envelope validation ([ACIF-CORE] §5), UUIDv5 pack-id derivation + pack-membership resolution ([ACIF-PUBLISHER] §8.3/§9.4)
- **`cmd/acif-adapter`** — transport-only shim (adapter_protocol 1), not in ship targets; unimplemented request forms answer `{"unsupported": true}`
- **`internal/moat`** — two additive exports (`FileHash`, `CanonicalText`) so acif composes moat's text canonicalization; `ContentHash` untouched
- **`go.mod`** — promotes `google/uuid` and `cyberphone/json-canonicalization` indirect→direct

Also fixes a map-iteration-order bug in capfeed's `tamperOneSHA256` test helper: when Go's randomized map iteration picked the file whose sha256 doubles as the index's `data_revision`, the first-occurrence byte replace tampered `data_revision` instead of the file entry (4/128 runs). Now 128/128.

## Verification

- ACIF runner, core scope: 13/13 pass (`python3 -m conformance.runner --scope core`)
- `go test ./...` green (capfeed helper verified at `-count=128`)
- `make build` + adapter build green; gofmt clean
- All published vector hash/UUID constants pinned as Go unit tests; TV-1/TV-9/TV-3 constants additionally verified independently with sha256sum/Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7tRhi8WaVhr1iMMkNNgfN
