### PR TITLE
ACIF Stage 1: hook-scope conformance adapter (28/30)

### DIFF
--- a/cli/cmd/acif-adapter/handlers.go
+++ b/cli/cmd/acif-adapter/handlers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 
@@ -47,10 +48,18 @@ func dispatch(req request) any {
 			"implementation":   "syllago",
 			"version":          adapterVersion,
 			"adapter_protocol": 1,
-			"scopes":           []string{"core"},
+			"scopes":           []string{"core", "hook"},
 		})
 	case "ingest":
 		return handleIngest(req.Input)
+	case "project":
+		return handleProject(req.Input)
+	case "render":
+		return handleRender(req.Input)
+	case "evaluate_install":
+		return handleEvaluateInstall(req.Input)
+	case "evaluate_requires":
+		return handleEvaluateRequires(req.Input)
 	case "derive_pack_id":
 		return handleDerivePackID(req.Input)
 	case "resolve_pack":
@@ -68,6 +77,10 @@ func errorResponse(message string) errorEnvelope {
 	return errorEnvelope{OK: false, Error: message}
 }
 
+func rejectResponse(reject *acif.RejectError) errorEnvelope {
+	return errorEnvelope{OK: false, Error: reject.ID, Diagnostics: reject.Diagnostics}
+}
+
 func unsupportedResponse() unsupportedEnvelope {
 	return unsupportedEnvelope{Unsupported: true}
 }
@@ -81,6 +94,10 @@ func handleIngest(raw json.RawMessage) any {
 	var input ingestInput
 	if err := json.Unmarshal(raw, &input); err != nil {
 		return errorResponse("adapter: " + err.Error())
+	}
+
+	if input.Kind == "hook" {
+		return handleHookIngest(rawInput, input)
 	}
 
 	if _, ok := rawInput["provider_config"]; ok {
@@ -106,6 +123,64 @@ func handleIngest(raw json.RawMessage) any {
 	return unsupportedResponse()
 }
 
+func handleHookIngest(rawInput map[string]json.RawMessage, input ingestInput) any {
+	opts := acif.HookOpts{BodyRoot: input.BodyRoot}
+	var result *acif.HookResult
+	var err error
+	if rawProviderConfig, ok := rawInput["provider_config"]; ok {
+		var config map[string]any
+		if err := decodeJSONUseNumber(rawProviderConfig, &config); err != nil {
+			return errorResponse("adapter: " + err.Error())
+		}
+		result, err = acif.CanonicalizeProviderConfig(config, opts)
+	} else if rawSidecar, ok := rawInput["sidecar"]; ok {
+		var block map[string]any
+		if err := decodeJSONUseNumber(rawSidecar, &block); err != nil {
+			return errorResponse("adapter: " + err.Error())
+		}
+		result, err = acif.CanonicalizeHook(block, opts)
+	} else {
+		return unsupportedResponse()
+	}
+	if err != nil {
+		return hookErrorResponse(err)
+	}
+	if result.Verdict != nil {
+		return okResponse(map[string]any{
+			"conformant": false,
+			"reason":     result.Verdict.Reason,
+		})
+	}
+
+	rawCanonical, err := json.Marshal(result.Canonical)
+	if err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	canonicalBytes, err := acif.CanonicalJSON(rawCanonical)
+	if err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	bodyHash, computed, err := acif.HookBodyHash(result.Canonical, input.BodyRoot)
+	if err != nil {
+		return hookErrorResponse(err)
+	}
+
+	response := map[string]any{
+		"conformant":      true,
+		"installable":     true,
+		"canonical":       result.Canonical,
+		"canonical_bytes": string(canonicalBytes),
+		"provenance":      result.Provenance,
+	}
+	if computed {
+		response["body_hash"] = bodyHash
+	}
+	if len(result.Diagnostics) > 0 {
+		response["diagnostics"] = result.Diagnostics
+	}
+	return okResponse(response)
+}
+
 func isFrontmatterKind(kind string) bool {
 	switch kind {
 	case "skill", "rule", "agent", "command":
@@ -120,7 +195,7 @@ func handleBodyIngest(bodyRoot, entryFile string) any {
 	if err != nil {
 		var reject *acif.RejectError
 		if errors.As(err, &reject) {
-			return errorResponse(reject.ID)
+			return rejectResponse(reject)
 		}
 		return errorResponse("adapter: " + err.Error())
 	}
@@ -129,6 +204,127 @@ func handleBodyIngest(bodyRoot, entryFile string) any {
 		"classification": result.Classification,
 		"conformant":     true,
 	})
+}
+
+type projectInput struct {
+	Projection string          `json:"projection"`
+	Targets    []string        `json:"targets"`
+	Item       json.RawMessage `json:"item"`
+	Canonical  json.RawMessage `json:"canonical"`
+	Hook       json.RawMessage `json:"hook"`
+	Sidecar    json.RawMessage `json:"sidecar"`
+}
+
+func handleProject(raw json.RawMessage) any {
+	var input projectInput
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	switch input.Projection {
+	case "script_selection", "derived_capabilities", "os_coverage":
+	default:
+		return unsupportedResponse()
+	}
+	block, err := decodeHookBlockInput(input.Item, input.Canonical, input.Hook, input.Sidecar)
+	if err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	switch input.Projection {
+	case "script_selection":
+		selection, diagnostics, err := acif.ScriptSelection(block, input.Targets)
+		if err != nil {
+			return hookErrorResponse(err)
+		}
+		result := map[string]any{"selection": selection}
+		if len(diagnostics) > 0 {
+			result["diagnostics"] = diagnostics
+		}
+		return okResponse(result)
+	case "derived_capabilities":
+		caps, err := acif.DerivedCapabilities(block)
+		if err != nil {
+			return hookErrorResponse(err)
+		}
+		return okResponse(map[string]any{"derived_capabilities": caps})
+	case "os_coverage":
+		projection, err := acif.OSCoverage(block)
+		if err != nil {
+			return hookErrorResponse(err)
+		}
+		return okResponse(map[string]any{"projection": projection})
+	default:
+		return unsupportedResponse()
+	}
+}
+
+type renderInput struct {
+	Canonical  json.RawMessage `json:"canonical"`
+	Target     string          `json:"target"`
+	Invocation map[string]any  `json:"invocation"`
+}
+
+func handleRender(raw json.RawMessage) any {
+	var input renderInput
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	block, err := decodeHookBlockInput(nil, input.Canonical, nil, nil)
+	if err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	result, err := acif.RenderHook(block, input.Target, input.Invocation)
+	if err != nil {
+		return hookErrorResponse(err)
+	}
+	if result.Unsupported {
+		return unsupportedResponse()
+	}
+	response := map[string]any{"output": result.Output}
+	if len(result.Diagnostics) > 0 {
+		response["diagnostics"] = result.Diagnostics
+	}
+	return okResponse(response)
+}
+
+type evaluateInstallInput struct {
+	Item            json.RawMessage `json:"item"`
+	InstallTargetOS string          `json:"install_target_os"`
+}
+
+func handleEvaluateInstall(raw json.RawMessage) any {
+	var input evaluateInstallInput
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	block, err := decodeHookBlockInput(input.Item, nil, nil, nil)
+	if err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	result, err := acif.EvaluateInstall(block, input.InstallTargetOS)
+	if err != nil {
+		return hookErrorResponse(err)
+	}
+	return okResponse(result)
+}
+
+func handleEvaluateRequires(raw json.RawMessage) any {
+	var rawInput map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &rawInput); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	itemRequires := make(map[string]any)
+	if rawRequires, ok := rawInput["item_requires"]; ok {
+		if err := decodeJSONUseNumber(rawRequires, &itemRequires); err != nil {
+			return errorResponse("adapter: " + err.Error())
+		}
+	}
+	var recognizes []string
+	if rawRecognizes, ok := rawInput["consumer_recognizes"]; ok {
+		if err := json.Unmarshal(rawRecognizes, &recognizes); err != nil {
+			return errorResponse("adapter: " + err.Error())
+		}
+	}
+	return okResponse(acif.EvaluateRequires(itemRequires, recognizes))
 }
 
 type sidecarResult struct {
@@ -192,6 +388,34 @@ func parseJSONObject(raw json.RawMessage) (map[string]json.RawMessage, bool) {
 		return nil, false
 	}
 	return obj, true
+}
+
+func decodeHookBlockInput(candidates ...json.RawMessage) (map[string]any, error) {
+	for _, raw := range candidates {
+		if len(raw) == 0 || string(raw) == "null" {
+			continue
+		}
+		var block map[string]any
+		if err := decodeJSONUseNumber(raw, &block); err != nil {
+			return nil, err
+		}
+		return block, nil
+	}
+	return nil, errors.New("missing hook block")
+}
+
+func decodeJSONUseNumber(raw json.RawMessage, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	return dec.Decode(v)
+}
+
+func hookErrorResponse(err error) any {
+	var reject *acif.RejectError
+	if errors.As(err, &reject) {
+		return rejectResponse(reject)
+	}
+	return errorResponse("adapter: " + err.Error())
 }
 
 type derivePackIDInput struct {

--- a/cli/cmd/acif-adapter/main_test.go
+++ b/cli/cmd/acif-adapter/main_test.go
@@ -57,7 +57,7 @@ func TestHello(t *testing.T) {
 			"implementation":   "syllago",
 			"version":          "0.0.0-dev",
 			"adapter_protocol": float64(1),
-			"scopes":           []any{"core"},
+			"scopes":           []any{"core", "hook"},
 		},
 	}
 	if !reflect.DeepEqual(responses[0], want) {
@@ -134,6 +134,126 @@ func TestIngestBodyRejectError(t *testing.T) {
 	}
 	if responses[0]["ok"] != false || responses[0]["error"] != "acif.body.symlink" {
 		t.Fatalf("response = %#v, want acif.body.symlink error", responses[0])
+	}
+}
+
+func TestHookIngestSidecar(t *testing.T) {
+	t.Parallel()
+	request := `{"op":"ingest","input":{"kind":"hook","sidecar":{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"inline","content":"#!/bin/sh\r\nexit 0\r\n"}]}]}}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 1 {
+		t.Fatalf("responses = %d, want 1", len(responses))
+	}
+	if responses[0]["ok"] != true {
+		t.Fatalf("response = %#v, want ok true", responses[0])
+	}
+	result, ok := responses[0]["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("result missing: %#v", responses[0])
+	}
+	if result["conformant"] != true || result["installable"] != true {
+		t.Fatalf("conformant/installable = %#v/%#v", result["conformant"], result["installable"])
+	}
+	if got, want := result["body_hash"], "9c8ab2d7f2465728140264d725011daad97054aceaaedfa9dd0a03d68d06b629"; got != want {
+		t.Fatalf("body_hash = %#v, want %q", got, want)
+	}
+	if got, want := result["canonical_bytes"], `{"blocking":false,"event":"before_tool_execute","handlers":[{"async":false,"scripts":[{"content":"#!/bin/sh\nexit 0\n","type":"inline"}],"type":"command"}]}`; got != want {
+		t.Fatalf("canonical_bytes = %#v, want %q", got, want)
+	}
+}
+
+func TestHookIngestProviderConfig(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeAdapterFixture(t, dir, map[string]string{
+		"hooks/base.sh": "#!/bin/sh\necho base\n",
+		"hooks/win.cmd": "@echo off\r\necho win\r\n",
+		"hooks/lin.sh":  "#!/bin/sh\necho lin\n",
+		"hooks/mac.sh":  "#!/bin/sh\necho mac\n",
+	})
+	request := `{"op":"ingest","input":{"kind":"hook","body_root":` + mustJSON(t, dir) + `,"provider_config":{"provider":"per-os-key-map","path":"settings.json","content":{"command":"hooks/base.sh","windows":"hooks/win.cmd","linux":"hooks/lin.sh","osx":"hooks/mac.sh"}}}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 1 {
+		t.Fatalf("responses = %d, want 1", len(responses))
+	}
+	if responses[0]["ok"] != true {
+		t.Fatalf("response = %#v, want ok true", responses[0])
+	}
+	result := responses[0]["result"].(map[string]any)
+	if got, want := result["body_hash"], "11f1e91480d2fdfd247311cc52240bf0fb2293febeccaeeadafacd74707cb32d"; got != want {
+		t.Fatalf("body_hash = %#v, want %q", got, want)
+	}
+	if result["provenance"] != "declared" {
+		t.Fatalf("provenance = %#v, want declared", result["provenance"])
+	}
+}
+
+func TestHookIngestReject(t *testing.T) {
+	t.Parallel()
+	request := `{"op":"ingest","input":{"kind":"hook","sidecar":{"event":"before_tool_execute"}}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 1 {
+		t.Fatalf("responses = %d, want 1", len(responses))
+	}
+	if responses[0]["ok"] != false || responses[0]["error"] != "acif.hook.handlers_missing" {
+		t.Fatalf("response = %#v, want handlers_missing error", responses[0])
+	}
+}
+
+func TestHookProjectOps(t *testing.T) {
+	t.Parallel()
+	request := `{"op":"project","input":{"projection":"script_selection","targets":["linux","windows"],"item":{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"file","path":"hooks/unix.sh","os":["darwin","linux"]}]}]}}}` + "\n" +
+		`{"op":"project","input":{"projection":"derived_capabilities","item":{"event":"before_tool_execute","matcher":"shell","handlers":[{"async":true,"scripts":[{"type":"inline","content":"x"}]}]}}}` + "\n" +
+		`{"op":"project","input":{"projection":"not-real","item":{}}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 3 {
+		t.Fatalf("responses = %d, want 3", len(responses))
+	}
+	result := responses[0]["result"].(map[string]any)
+	selection := result["selection"].(map[string]any)
+	if selection["linux"] != "hooks/unix.sh" || selection["windows"] != "none" {
+		t.Fatalf("selection = %#v", selection)
+	}
+	diags := result["diagnostics"].([]any)
+	if len(diags) != 1 || diags[0].(map[string]any)["id"] != "acif.hook.script_no_platform_match" {
+		t.Fatalf("diagnostics = %#v", diags)
+	}
+	caps := responses[1]["result"].(map[string]any)["derived_capabilities"].(map[string]any)
+	if caps["handler_types"] != true || caps["matcher_patterns"] != true || caps["async_execution"] != true {
+		t.Fatalf("derived_capabilities = %#v", caps)
+	}
+	if !reflect.DeepEqual(responses[2], map[string]any{"unsupported": true}) {
+		t.Fatalf("unknown projection = %#v, want unsupported", responses[2])
+	}
+}
+
+func TestHookRenderOp(t *testing.T) {
+	t.Parallel()
+	request := `{"op":"render","input":{"target":"no-mechanism-provider","invocation":{"target_os":"linux"},"canonical":{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"file","path":"hooks/unix.sh","os":["darwin","linux"]}]}]}}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 1 {
+		t.Fatalf("responses = %d, want 1", len(responses))
+	}
+	result := responses[0]["result"].(map[string]any)
+	if !strings.Contains(result["output"].(string), `"command":"hooks/unix.sh"`) {
+		t.Fatalf("render output = %#v", result["output"])
+	}
+}
+
+func TestHookEvaluateOps(t *testing.T) {
+	t.Parallel()
+	request := `{"op":"evaluate_install","input":{"install_target_os":"windows","item":{"event":"before_tool_execute","blocking":true,"handlers":[{"scripts":[{"type":"file","path":"hooks/unix.sh","os":["darwin","linux"]}]}]}}}` + "\n" +
+		`{"op":"evaluate_requires","input":{"item_requires":{"handler_types":["command"]},"consumer_recognizes":["matcher_patterns"]}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 2 {
+		t.Fatalf("responses = %d, want 2", len(responses))
+	}
+	if got := responses[0]["result"].(map[string]any)["install"]; got != "refuse-unless-operator-opt-in" {
+		t.Fatalf("evaluate_install = %#v", responses[0])
+	}
+	result := responses[1]["result"].(map[string]any)
+	if result["evaluation"] != "unknown" || result["install"] != "refuse-unless-operator-opt-in" {
+		t.Fatalf("evaluate_requires = %#v", result)
 	}
 }
 

--- a/cli/internal/acif/diagnostics.go
+++ b/cli/internal/acif/diagnostics.go
@@ -8,8 +8,9 @@ type Diagnostic struct {
 
 // RejectError carries a spec-minted acif.* error identifier.
 type RejectError struct {
-	ID     string
-	Detail string
+	ID          string
+	Detail      string
+	Diagnostics []Diagnostic
 }
 
 func (e *RejectError) Error() string {
@@ -26,4 +27,26 @@ const (
 	ErrBodySymlink       = "acif.body.symlink"
 	ErrBodyPathCollision = "acif.body.path_collision"
 	ErrBodyEmpty         = "acif.body.empty"
+
+	ErrHookEventUnrecognized          = "acif.hook.event_unrecognized"
+	ErrHookHandlersMissing            = "acif.hook.handlers_missing"
+	ErrHookHandlerTypeUnrecognized    = "acif.hook.handler_type_unrecognized"
+	ErrHookScriptOSInvalid            = "acif.hook.script_os_invalid"
+	ErrHookScriptOSEmpty              = "acif.hook.script_os_empty"
+	ErrHookScriptArchEmpty            = "acif.hook.script_arch_empty"
+	ErrHookScriptDefaultAmbiguous     = "acif.hook.script_default_ambiguous"
+	ErrHookScriptPlatformAmbiguous    = "acif.hook.script_platform_ambiguous"
+	ErrHookScriptFileMissing          = "acif.hook.script_file_missing"
+	ErrHookScriptPathInvalid          = "acif.hook.script_path_invalid"
+	ErrHookPlatformUnmappable         = "acif.hook.platform_unmappable"
+	ErrHookNoDefaultForDegradedRender = "acif.hook.no_default_for_degraded_render"
+
+	DiagHookPlatformOverrideDropped     = "acif.hook.platform_override_dropped"
+	DiagHookPlatformShellOSProxy        = "acif.hook.platform_shell_os_proxy"
+	DiagHookPlatformFilenameInferred    = "acif.hook.platform_filename_inferred"
+	DiagHookPlatformFilenameUninferable = "acif.hook.platform_filename_uninferable"
+	DiagHookScriptNoPlatformMatch       = "acif.hook.script_no_platform_match"
+
+	ReasonRequiresOrphanKey            = "acif.requires.orphan_key"
+	ReasonCommandHandlerScriptsMissing = "command-handler-scripts-missing"
 )

--- a/cli/internal/acif/hook.go
+++ b/cli/internal/acif/hook.go
@@ -1,0 +1,493 @@
+package acif
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/OpenScribbler/syllago/cli/internal/converter"
+	"github.com/OpenScribbler/syllago/cli/internal/moat"
+)
+
+type HookOpts struct {
+	Provider string
+	BodyRoot string
+}
+
+type HookVerdict struct {
+	Reason string `json:"reason"`
+}
+
+type HookResult struct {
+	Canonical   map[string]any
+	Diagnostics []Diagnostic
+	Provenance  string
+	Verdict     *HookVerdict
+}
+
+var validHookHandlerTypes = map[string]bool{
+	"command": true,
+	"http":    true,
+	"prompt":  true,
+	"agent":   true,
+}
+
+var validHookOS = map[string]bool{
+	"darwin":  true,
+	"linux":   true,
+	"windows": true,
+}
+
+var hookOSOrder = []string{"darwin", "linux", "windows"}
+
+func CanonicalizeHook(block map[string]any, opts HookOpts) (*HookResult, error) {
+	block = unwrapHookBlock(block)
+	out := make(map[string]any, len(block)+2)
+	for k, v := range block {
+		if isHookTopLevelCanonicalKey(k) {
+			continue
+		}
+		out[k] = cloneJSONValue(v)
+	}
+
+	event, _ := block["event"].(string)
+	canonicalEvent, ok := canonicalHookEvent(event, opts.Provider)
+	if !ok {
+		return nil, hookReject(ErrHookEventUnrecognized, event)
+	}
+	out["event"] = canonicalEvent
+
+	if matcher, ok := block["matcher"]; ok {
+		if s, ok := matcher.(string); ok {
+			if s != "" {
+				if opts.Provider != "" {
+					s = converter.ReverseTranslateMatcher(s, opts.Provider)
+				}
+				out["matcher"] = s
+			}
+		} else {
+			out["matcher"] = cloneJSONValue(matcher)
+		}
+	}
+
+	rawHandlers, ok := block["handlers"].([]any)
+	if !ok || len(rawHandlers) == 0 {
+		return nil, hookReject(ErrHookHandlersMissing, "")
+	}
+	handlers := make([]any, 0, len(rawHandlers))
+	result := &HookResult{Canonical: out, Provenance: "declared"}
+	for _, rawHandler := range rawHandlers {
+		handler, ok := rawHandler.(map[string]any)
+		if !ok {
+			return nil, hookReject(ErrHookHandlersMissing, "")
+		}
+		canonicalHandler, verdict, err := canonicalizeHookHandler(handler)
+		if err != nil {
+			return nil, err
+		}
+		handlers = append(handlers, canonicalHandler)
+		if verdict != nil && result.Verdict == nil {
+			result.Verdict = verdict
+		}
+	}
+	out["handlers"] = handlers
+
+	if aux, ok := block["auxiliary_files"]; ok {
+		canonicalAux, err := canonicalizeAuxiliaryFiles(aux)
+		if err != nil {
+			return nil, err
+		}
+		if len(canonicalAux) > 0 {
+			out["auxiliary_files"] = canonicalAux
+		}
+	}
+
+	if blocking, ok := block["blocking"]; ok {
+		out["blocking"] = cloneJSONValue(blocking)
+	} else {
+		out["blocking"] = false
+	}
+
+	if requires, ok := block["requires"]; ok {
+		if reqMap, ok := requires.(map[string]any); ok {
+			if len(reqMap) > 0 {
+				out["requires"] = cloneJSONValue(reqMap)
+				result.Verdict = &HookVerdict{Reason: ReasonRequiresOrphanKey}
+			}
+		} else {
+			out["requires"] = cloneJSONValue(requires)
+			result.Verdict = &HookVerdict{Reason: ReasonRequiresOrphanKey}
+		}
+	}
+
+	return result, nil
+}
+
+func canonicalHookEvent(event, provider string) (string, bool) {
+	if !converter.IsValidHookEvent(event) {
+		return "", false
+	}
+	if _, ok := converter.HookEvents[event]; ok {
+		return event, true
+	}
+	if provider != "" {
+		translated := converter.ReverseTranslateHookEvent(event, provider)
+		if _, ok := converter.HookEvents[translated]; ok {
+			return translated, true
+		}
+	}
+	matches := make([]string, 0, 2)
+	for canonical, providerMap := range converter.HookEvents {
+		for _, native := range providerMap {
+			if native == event {
+				matches = append(matches, canonical)
+				break
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return "", false
+	}
+	for _, match := range matches {
+		if match == "error_occurred" {
+			return match, true
+		}
+	}
+	sort.Strings(matches)
+	return matches[0], true
+}
+
+func canonicalizeHookHandler(handler map[string]any) (map[string]any, *HookVerdict, error) {
+	out := make(map[string]any, len(handler)+2)
+	for k, v := range handler {
+		if k == "type" || k == "scripts" || k == "async" {
+			continue
+		}
+		out[k] = cloneJSONValue(v)
+	}
+
+	rawHandlerType, hasHandlerType := handler["type"]
+	handlerType := "command"
+	if hasHandlerType {
+		typedHandlerType, ok := rawHandlerType.(string)
+		if !ok {
+			return nil, nil, hookReject(ErrHookHandlerTypeUnrecognized, "")
+		}
+		handlerType = typedHandlerType
+	}
+	if handlerType == "" {
+		handlerType = "command"
+	}
+	if !validHookHandlerTypes[handlerType] {
+		return nil, nil, hookReject(ErrHookHandlerTypeUnrecognized, handlerType)
+	}
+	out["type"] = handlerType
+
+	if handlerType != "command" {
+		if scripts, ok := handler["scripts"]; ok {
+			out["scripts"] = cloneJSONValue(scripts)
+		}
+		if async, ok := handler["async"]; ok {
+			out["async"] = cloneJSONValue(async)
+		}
+		return out, nil, nil
+	}
+
+	if async, ok := handler["async"]; ok {
+		out["async"] = cloneJSONValue(async)
+	} else {
+		out["async"] = false
+	}
+
+	rawScripts, ok := handler["scripts"].([]any)
+	if !ok || len(rawScripts) == 0 {
+		return out, &HookVerdict{Reason: ReasonCommandHandlerScriptsMissing}, nil
+	}
+	scripts, err := canonicalizeHookScripts(rawScripts)
+	if err != nil {
+		return nil, nil, err
+	}
+	out["scripts"] = scripts
+	return out, nil, nil
+}
+
+func canonicalizeHookScripts(rawScripts []any) ([]any, error) {
+	processed := make([]map[string]any, 0, len(rawScripts))
+	for _, rawScript := range rawScripts {
+		script, ok := rawScript.(map[string]any)
+		if !ok {
+			return nil, hookReject(ErrHookScriptPathInvalid, "")
+		}
+		canonical, err := canonicalizeHookScript(script)
+		if err != nil {
+			return nil, err
+		}
+		processed = append(processed, canonical)
+	}
+
+	if err := checkScriptDisjointness(processed); err != nil {
+		return nil, err
+	}
+
+	sort.SliceStable(processed, func(i, j int) bool {
+		return bytes.Compare(scriptSortKey(processed[i]), scriptSortKey(processed[j])) < 0
+	})
+
+	out := make([]any, len(processed))
+	for i := range processed {
+		out[i] = processed[i]
+	}
+	return out, nil
+}
+
+func canonicalizeHookScript(script map[string]any) (map[string]any, error) {
+	out := make(map[string]any, len(script))
+	for k, v := range script {
+		switch k {
+		case "type", "path", "content", "os", "arch":
+			continue
+		default:
+			out[k] = cloneJSONValue(v)
+		}
+	}
+
+	scriptType, _ := script["type"].(string)
+	switch scriptType {
+	case "file":
+		path, ok := script["path"].(string)
+		if !ok || !isValidHookPath(path) {
+			return nil, hookReject(ErrHookScriptPathInvalid, path)
+		}
+		out["path"] = path
+	case "inline":
+		content, ok := script["content"].(string)
+		if !ok {
+			return nil, hookReject(ErrHookScriptPathInvalid, "")
+		}
+		out["content"] = string(moat.CanonicalText([]byte(content)))
+	default:
+		return nil, hookReject(ErrHookScriptPathInvalid, scriptType)
+	}
+	out["type"] = scriptType
+
+	if rawOS, ok := script["os"]; ok {
+		osTags, err := canonicalStringArray(rawOS, true, validHookOS, ErrHookScriptOSEmpty, ErrHookScriptOSInvalid)
+		if err != nil {
+			return nil, err
+		}
+		out["os"] = stringsToAnySlice(osTags)
+	}
+
+	if rawArch, ok := script["arch"]; ok {
+		archTags, err := canonicalStringArray(rawArch, true, nil, ErrHookScriptArchEmpty, "")
+		if err != nil {
+			return nil, err
+		}
+		out["arch"] = stringsToAnySlice(archTags)
+	}
+
+	return out, nil
+}
+
+func canonicalStringArray(raw any, rejectEmpty bool, allowed map[string]bool, emptyID, invalidID string) ([]string, error) {
+	rawItems, ok := raw.([]any)
+	if !ok {
+		if invalidID != "" {
+			return nil, hookReject(invalidID, "")
+		}
+		return nil, hookReject(emptyID, "")
+	}
+	if rejectEmpty && len(rawItems) == 0 {
+		return nil, hookReject(emptyID, "")
+	}
+	seen := make(map[string]bool, len(rawItems))
+	items := make([]string, 0, len(rawItems))
+	for _, rawItem := range rawItems {
+		item, ok := rawItem.(string)
+		if !ok {
+			if invalidID != "" {
+				return nil, hookReject(invalidID, "")
+			}
+			return nil, hookReject(emptyID, "")
+		}
+		if allowed != nil && !allowed[item] {
+			return nil, hookReject(invalidID, item)
+		}
+		if !seen[item] {
+			seen[item] = true
+			items = append(items, item)
+		}
+	}
+	sort.Strings(items)
+	return items, nil
+}
+
+func checkScriptDisjointness(scripts []map[string]any) error {
+	defaultEntries := 0
+	collisions := make([]Diagnostic, 0)
+	for _, script := range scripts {
+		if _, ok := script["os"]; !ok {
+			defaultEntries++
+		}
+	}
+	if defaultEntries > 1 {
+		return hookReject(ErrHookScriptDefaultAmbiguous, "")
+	}
+
+	for _, osTag := range hookOSOrder {
+		indices := make([]any, 0, 2)
+		for i, script := range scripts {
+			for _, declared := range anyStringSlice(script["os"]) {
+				if declared == osTag {
+					indices = append(indices, i)
+					break
+				}
+			}
+		}
+		if len(indices) >= 2 {
+			collisions = append(collisions, Diagnostic{
+				ID:     ErrHookScriptPlatformAmbiguous,
+				Params: map[string]any{"os": osTag, "entries": indices},
+			})
+		}
+	}
+	if len(collisions) > 0 {
+		return hookRejectWithDiagnostics(ErrHookScriptPlatformAmbiguous, "", collisions)
+	}
+	return nil
+}
+
+func canonicalizeAuxiliaryFiles(raw any) ([]any, error) {
+	rawItems, ok := raw.([]any)
+	if !ok {
+		return nil, nil
+	}
+	byPath := make(map[string]map[string]any, len(rawItems))
+	paths := make([]string, 0, len(rawItems))
+	for _, rawItem := range rawItems {
+		item, ok := rawItem.(map[string]any)
+		if !ok {
+			return nil, hookReject(ErrHookScriptPathInvalid, "")
+		}
+		path, ok := item["path"].(string)
+		if !ok || !isValidHookPath(path) {
+			return nil, hookReject(ErrHookScriptPathInvalid, path)
+		}
+		if _, seen := byPath[path]; !seen {
+			byPath[path] = cloneJSONValue(item).(map[string]any)
+			paths = append(paths, path)
+		}
+	}
+	sort.Strings(paths)
+	out := make([]any, 0, len(paths))
+	for _, path := range paths {
+		out = append(out, byPath[path])
+	}
+	return out, nil
+}
+
+func scriptSortKey(script map[string]any) []byte {
+	raw, err := json.Marshal(script)
+	if err != nil {
+		return nil
+	}
+	canonical, err := CanonicalJSON(raw)
+	if err != nil {
+		return raw
+	}
+	return canonical
+}
+
+func isValidHookPath(path string) bool {
+	if path == "" {
+		return false
+	}
+	if strings.Contains(path, `\`) || strings.HasPrefix(path, "/") {
+		return false
+	}
+	if len(path) >= 2 && path[1] == ':' && isASCIIAlpha(path[0]) {
+		return false
+	}
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIIAlpha(b byte) bool {
+	return ('a' <= b && b <= 'z') || ('A' <= b && b <= 'Z')
+}
+
+func unwrapHookBlock(block map[string]any) map[string]any {
+	if block == nil {
+		return map[string]any{}
+	}
+	if hook, ok := block["hook"].(map[string]any); ok {
+		return hook
+	}
+	return block
+}
+
+func isHookTopLevelCanonicalKey(key string) bool {
+	switch key {
+	case "event", "matcher", "handlers", "auxiliary_files", "blocking", "requires":
+		return true
+	default:
+		return false
+	}
+}
+
+func stringsToAnySlice(items []string) []any {
+	out := make([]any, len(items))
+	for i, item := range items {
+		out[i] = item
+	}
+	return out
+}
+
+func anyStringSlice(raw any) []string {
+	switch items := raw.(type) {
+	case []any:
+		out := make([]string, 0, len(items))
+		for _, item := range items {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		return append([]string(nil), items...)
+	default:
+		return nil
+	}
+}
+
+func cloneJSONValue(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, v := range x {
+			out[k] = cloneJSONValue(v)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, v := range x {
+			out[i] = cloneJSONValue(v)
+		}
+		return out
+	default:
+		return x
+	}
+}
+
+func hookReject(id, detail string) *RejectError {
+	return &RejectError{ID: id, Detail: detail}
+}
+
+func hookRejectWithDiagnostics(id, detail string, diagnostics []Diagnostic) *RejectError {
+	return &RejectError{ID: id, Detail: detail, Diagnostics: diagnostics}
+}

--- a/cli/internal/acif/hook_test.go
+++ b/cli/internal/acif/hook_test.go
@@ -1,0 +1,650 @@
+package acif
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const (
+	tvHookG = "9c8ab2d7f2465728140264d725011daad97054aceaaedfa9dd0a03d68d06b629"
+
+	tvPlatformQBase = "194225ce5a7ec641253e47b6abd7f07b22fdf8ac4845cba159bef8ffe7f8783f"
+	tvPlatformQFlip = "f5c964cdeddb304e801431f21c2c6c29f0e1e51cf99c63af78d2be58057c7dfc"
+
+	tvPlatformQ2 = "bdee51e032051d9fc88d39f9196e47b4742d51fe4673cb020ba82c47903bee3a"
+
+	tvPlatformI = "11f1e91480d2fdfd247311cc52240bf0fb2293febeccaeeadafacd74707cb32d"
+)
+
+func hookBlock(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.UseNumber()
+	var block map[string]any
+	if err := dec.Decode(&block); err != nil {
+		t.Fatalf("decode hook block: %v", err)
+	}
+	return block
+}
+
+func hookCanonicalBytes(t *testing.T, block map[string]any) string {
+	t.Helper()
+	raw, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal canonical block: %v", err)
+	}
+	canonical, err := CanonicalJSON(raw)
+	if err != nil {
+		t.Fatalf("canonical JSON: %v", err)
+	}
+	return string(canonical)
+}
+
+func hookHash(t *testing.T, block map[string]any, bodyRoot string) string {
+	t.Helper()
+	hash, computed, err := HookBodyHash(block, bodyRoot)
+	if err != nil {
+		t.Fatalf("HookBodyHash() error: %v", err)
+	}
+	if !computed {
+		t.Fatalf("HookBodyHash() computed = false, want true")
+	}
+	return hash
+}
+
+func expectHookReject(t *testing.T, err error, id string) {
+	t.Helper()
+	var reject *RejectError
+	if !errors.As(err, &reject) {
+		t.Fatalf("error = %T %v, want *RejectError %s", err, err, id)
+	}
+	if reject.ID != id {
+		t.Fatalf("RejectError.ID = %q, want %q", reject.ID, id)
+	}
+}
+
+func writeHookFiles(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+}
+
+func TestHookPinnedBodyHashes(t *testing.T) {
+	t.Run("TV-HOOK-g inline only", func(t *testing.T) {
+		result, err := CanonicalizeHook(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"type":"command","scripts":[{"type":"inline","content":"#!/bin/sh\r\nexit 0\r\n"}]}]
+		}`), HookOpts{})
+		if err != nil {
+			t.Fatalf("CanonicalizeHook() error: %v", err)
+		}
+		if result.Verdict != nil {
+			t.Fatalf("Verdict = %#v, want nil", result.Verdict)
+		}
+		if got := hookHash(t, result.Canonical, ""); got != tvHookG {
+			t.Fatalf("body_hash = %s, want %s", got, tvHookG)
+		}
+		wantBytes := `{"blocking":false,"event":"before_tool_execute","handlers":[{"async":false,"scripts":[{"content":"#!/bin/sh\nexit 0\n","type":"inline"}],"type":"command"}]}`
+		if got := hookCanonicalBytes(t, result.Canonical); got != wantBytes {
+			t.Fatalf("canonical_bytes = %s, want %s", got, wantBytes)
+		}
+	})
+
+	t.Run("TV-PLATFORM-q file os flip changes hash", func(t *testing.T) {
+		dir := t.TempDir()
+		writeHookFiles(t, dir, map[string]string{"hooks/run.sh": "#!/bin/sh\necho ok\n"})
+
+		base, err := CanonicalizeHook(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"type":"command","scripts":[{"type":"file","path":"hooks/run.sh","os":["linux"]}]}]
+		}`), HookOpts{})
+		if err != nil {
+			t.Fatalf("CanonicalizeHook(base) error: %v", err)
+		}
+		if got := hookHash(t, base.Canonical, dir); got != tvPlatformQBase {
+			t.Fatalf("base body_hash = %s, want %s", got, tvPlatformQBase)
+		}
+
+		flip, err := CanonicalizeHook(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"type":"command","scripts":[{"type":"file","path":"hooks/run.sh","os":["windows"]}]}]
+		}`), HookOpts{})
+		if err != nil {
+			t.Fatalf("CanonicalizeHook(flip) error: %v", err)
+		}
+		if got := hookHash(t, flip.Canonical, dir); got != tvPlatformQFlip {
+			t.Fatalf("flip body_hash = %s, want %s", got, tvPlatformQFlip)
+		}
+	})
+
+	t.Run("TV-PLATFORM-q2 deterministic inline and file mix", func(t *testing.T) {
+		dir := t.TempDir()
+		writeHookFiles(t, dir, map[string]string{"hooks/win.cmd": "@echo off\r\necho hi\r\n"})
+
+		a, err := CanonicalizeHook(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"type":"command","scripts":[
+				{"type":"inline","content":"#!/bin/sh\necho hi\n","os":["darwin","linux"]},
+				{"type":"file","path":"hooks/win.cmd","os":["windows"]}
+			]}]
+		}`), HookOpts{})
+		if err != nil {
+			t.Fatalf("CanonicalizeHook(a) error: %v", err)
+		}
+		b, err := CanonicalizeHook(hookBlock(t, `{
+			"handlers":[{"scripts":[
+				{"os":["windows"],"path":"hooks/win.cmd","type":"file"},
+				{"os":["linux","darwin"],"content":"#!/bin/sh\r\necho hi\r\n","type":"inline"}
+			]}],
+			"event":"before_tool_execute"
+		}`), HookOpts{})
+		if err != nil {
+			t.Fatalf("CanonicalizeHook(b) error: %v", err)
+		}
+
+		if gotA, gotB := hookCanonicalBytes(t, a.Canonical), hookCanonicalBytes(t, b.Canonical); gotA != gotB {
+			t.Fatalf("canonical_bytes differ:\nA %s\nB %s", gotA, gotB)
+		}
+		if got := hookHash(t, a.Canonical, dir); got != tvPlatformQ2 {
+			t.Fatalf("body_hash(a) = %s, want %s", got, tvPlatformQ2)
+		}
+		if got := hookHash(t, b.Canonical, dir); got != tvPlatformQ2 {
+			t.Fatalf("body_hash(b) = %s, want %s", got, tvPlatformQ2)
+		}
+	})
+
+	t.Run("TV-PLATFORM-i per-os-key-map", func(t *testing.T) {
+		dir := t.TempDir()
+		writeHookFiles(t, dir, map[string]string{
+			"hooks/base.sh": "#!/bin/sh\necho base\n",
+			"hooks/win.cmd": "@echo off\r\necho win\r\n",
+			"hooks/lin.sh":  "#!/bin/sh\necho lin\n",
+			"hooks/mac.sh":  "#!/bin/sh\necho mac\n",
+		})
+		result, err := CanonicalizeProviderConfig(hookBlock(t, `{
+			"provider":"per-os-key-map",
+			"path":"unused.json",
+			"content":{"command":"hooks/base.sh","windows":"hooks/win.cmd","linux":"hooks/lin.sh","osx":"hooks/mac.sh"}
+		}`), HookOpts{BodyRoot: dir})
+		if err != nil {
+			t.Fatalf("CanonicalizeProviderConfig() error: %v", err)
+		}
+		if result.Provenance != "declared" {
+			t.Fatalf("Provenance = %q, want declared", result.Provenance)
+		}
+		if got := hookHash(t, result.Canonical, dir); got != tvPlatformI {
+			t.Fatalf("body_hash = %s, want %s", got, tvPlatformI)
+		}
+		wantScripts := []map[string]any{
+			{"type": "file", "path": "hooks/mac.sh", "os": []any{"darwin"}},
+			{"type": "file", "path": "hooks/lin.sh", "os": []any{"linux"}},
+			{"type": "file", "path": "hooks/win.cmd", "os": []any{"windows"}},
+			{"type": "file", "path": "hooks/base.sh"},
+		}
+		gotScripts := result.Canonical["handlers"].([]any)[0].(map[string]any)["scripts"]
+		if !reflect.DeepEqual(gotScripts, anySliceFromMaps(wantScripts)) {
+			t.Fatalf("scripts = %#v, want %#v", gotScripts, wantScripts)
+		}
+	})
+}
+
+func TestHookRejectsAndVerdicts(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		id   string
+	}{
+		{"handlers absent", `{"event":"before_tool_execute"}`, ErrHookHandlersMissing},
+		{"handlers empty", `{"event":"before_tool_execute","handlers":[]}`, ErrHookHandlersMissing},
+		{"handlers wrong type", `{"event":"before_tool_execute","handlers":{}}`, ErrHookHandlersMissing},
+		{"bad handler type", `{"event":"before_tool_execute","handlers":[{"type":"webhook2"}]}`, ErrHookHandlerTypeUnrecognized},
+		{"os empty", `{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"file","path":"hooks/run.sh","os":[]}]}]}`, ErrHookScriptOSEmpty},
+		{"arch empty", `{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"file","path":"hooks/run.sh","arch":[]}]}]}`, ErrHookScriptArchEmpty},
+		{"os freebsd", `{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"file","path":"hooks/run.sh","os":["linux","freebsd"]}]}]}`, ErrHookScriptOSInvalid},
+		{"os case", `{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"file","path":"hooks/run.sh","os":["Linux"]}]}]}`, ErrHookScriptOSInvalid},
+		{"two defaults", `{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"file","path":"hooks/a.sh"},{"type":"file","path":"hooks/b.sh"}]}]}`, ErrHookScriptDefaultAmbiguous},
+		{"absolute path", `{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"file","path":"/etc/hooks/run.sh"}]}]}`, ErrHookScriptPathInvalid},
+		{"parent path", `{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"file","path":"../outside/run.sh"}]}]}`, ErrHookScriptPathInvalid},
+		{"backslash path", `{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"file","path":"a\\b"}]}]}`, ErrHookScriptPathInvalid},
+		{"windows drive path", `{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"file","path":"C:x"}]}]}`, ErrHookScriptPathInvalid},
+		{"dot segment path", `{"event":"before_tool_execute","handlers":[{"scripts":[{"type":"file","path":"a/./b"}]}]}`, ErrHookScriptPathInvalid},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := CanonicalizeHook(hookBlock(t, tt.raw), HookOpts{})
+			expectHookReject(t, err, tt.id)
+		})
+	}
+
+	t.Run("platform ambiguity diagnostic uses input order", func(t *testing.T) {
+		_, err := CanonicalizeHook(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"scripts":[
+				{"type":"file","path":"hooks/unix.sh","os":["darwin","linux"]},
+				{"type":"file","path":"hooks/linux.sh","os":["linux"]}
+			]}]
+		}`), HookOpts{})
+		var reject *RejectError
+		if !errors.As(err, &reject) {
+			t.Fatalf("error = %T %v, want RejectError", err, err)
+		}
+		if reject.ID != ErrHookScriptPlatformAmbiguous {
+			t.Fatalf("RejectError.ID = %q, want %q", reject.ID, ErrHookScriptPlatformAmbiguous)
+		}
+		if len(reject.Diagnostics) != 1 {
+			t.Fatalf("diagnostics = %#v, want one", reject.Diagnostics)
+		}
+		want := Diagnostic{ID: ErrHookScriptPlatformAmbiguous, Params: map[string]any{"os": "linux", "entries": []any{0, 1}}}
+		if !reflect.DeepEqual(reject.Diagnostics[0], want) {
+			t.Fatalf("diagnostic = %#v, want %#v", reject.Diagnostics[0], want)
+		}
+	})
+
+	t.Run("missing referenced file", func(t *testing.T) {
+		result, err := CanonicalizeHook(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"scripts":[{"type":"file","path":"hooks/missing.sh"}]}]
+		}`), HookOpts{})
+		if err != nil {
+			t.Fatalf("CanonicalizeHook() error: %v", err)
+		}
+		_, _, err = HookBodyHash(result.Canonical, t.TempDir())
+		expectHookReject(t, err, ErrHookScriptFileMissing)
+	})
+
+	t.Run("requires empty omitted and non-empty verdict", func(t *testing.T) {
+		empty, err := CanonicalizeHook(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"requires":{},
+			"handlers":[{"scripts":[{"type":"inline","content":"x"}]}]
+		}`), HookOpts{})
+		if err != nil {
+			t.Fatalf("CanonicalizeHook(empty requires) error: %v", err)
+		}
+		if _, ok := empty.Canonical["requires"]; ok {
+			t.Fatalf("requires present in canonical: %#v", empty.Canonical)
+		}
+		nonEmpty, err := CanonicalizeHook(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"requires":{"handler_types":["command"]},
+			"handlers":[{"scripts":[{"type":"inline","content":"x"}]}]
+		}`), HookOpts{})
+		if err != nil {
+			t.Fatalf("CanonicalizeHook(non-empty requires) error: %v", err)
+		}
+		if nonEmpty.Verdict == nil || nonEmpty.Verdict.Reason != ReasonRequiresOrphanKey {
+			t.Fatalf("Verdict = %#v, want %s", nonEmpty.Verdict, ReasonRequiresOrphanKey)
+		}
+	})
+}
+
+func TestHookHandlerDefaultsAndEventTranslation(t *testing.T) {
+	explicit, err := CanonicalizeHook(hookBlock(t, `{
+		"event":"before_tool_execute",
+		"handlers":[{"type":"command","scripts":[{"type":"inline","content":"#!/bin/sh\nexit 0\n"}]}]
+	}`), HookOpts{})
+	if err != nil {
+		t.Fatalf("explicit CanonicalizeHook() error: %v", err)
+	}
+	implicit, err := CanonicalizeHook(hookBlock(t, `{
+		"event":"before_tool_execute",
+		"handlers":[{"scripts":[{"type":"inline","content":"#!/bin/sh\nexit 0\n"}]}]
+	}`), HookOpts{})
+	if err != nil {
+		t.Fatalf("implicit CanonicalizeHook() error: %v", err)
+	}
+	if got, want := hookHash(t, implicit.Canonical, ""), hookHash(t, explicit.Canonical, ""); got != want {
+		t.Fatalf("implicit hash = %s, explicit hash = %s", got, want)
+	}
+	handler := implicit.Canonical["handlers"].([]any)[0].(map[string]any)
+	if handler["type"] != "command" || handler["async"] != false {
+		t.Fatalf("handler defaults = %#v", handler)
+	}
+
+	for _, tc := range []struct {
+		provider string
+		event    string
+	}{
+		{"claude-code", "PreToolUse"},
+		{"gemini-cli", "BeforeTool"},
+		{"opencode", "tool.execute.before"},
+		{"unknown-provider", "PreToolUse"},
+		{"", "before_tool_execute"},
+	} {
+		tc := tc
+		t.Run(tc.provider+"/"+tc.event, func(t *testing.T) {
+			result, err := CanonicalizeHook(hookBlock(t, `{
+				"event":`+mustJSONString(t, tc.event)+`,
+				"handlers":[{"scripts":[{"type":"inline","content":"#!/bin/sh\nexit 0\n"}]}]
+			}`), HookOpts{Provider: tc.provider})
+			if err != nil {
+				t.Fatalf("CanonicalizeHook() error: %v", err)
+			}
+			if result.Canonical["event"] != "before_tool_execute" {
+				t.Fatalf("event = %#v, want before_tool_execute", result.Canonical["event"])
+			}
+			if got := hookHash(t, result.Canonical, ""); got != tvHookG {
+				t.Fatalf("body_hash = %s, want %s", got, tvHookG)
+			}
+		})
+	}
+
+	_, err = CanonicalizeHook(hookBlock(t, `{
+		"event":"onToolStart",
+		"handlers":[{"scripts":[{"type":"inline","content":"x"}]}]
+	}`), HookOpts{})
+	expectHookReject(t, err, ErrHookEventUnrecognized)
+}
+
+func TestHookProjection(t *testing.T) {
+	t.Run("script selection with none diagnostic", func(t *testing.T) {
+		block := hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"scripts":[
+				{"type":"file","path":"hooks/unix.sh","os":["darwin","linux"]}
+			]}]
+		}`)
+		selection, diags, err := ScriptSelection(block, []string{"darwin", "linux", "windows"})
+		if err != nil {
+			t.Fatalf("ScriptSelection() error: %v", err)
+		}
+		want := map[string]string{"darwin": "hooks/unix.sh", "linux": "hooks/unix.sh", "windows": "none"}
+		if !reflect.DeepEqual(selection, want) {
+			t.Fatalf("selection = %#v, want %#v", selection, want)
+		}
+		if len(diags) != 1 || diags[0].ID != DiagHookScriptNoPlatformMatch {
+			t.Fatalf("diagnostics = %#v, want no-platform-match", diags)
+		}
+	})
+
+	t.Run("derived capabilities", func(t *testing.T) {
+		caps, err := DerivedCapabilities(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"matcher":"shell",
+			"handlers":[{"async":true,"scripts":[{"type":"inline","content":"x"}]}]
+		}`))
+		if err != nil {
+			t.Fatalf("DerivedCapabilities() error: %v", err)
+		}
+		want := map[string]bool{"handler_types": true, "matcher_patterns": true, "async_execution": true}
+		if !reflect.DeepEqual(caps, want) {
+			t.Fatalf("caps = %#v, want %#v", caps, want)
+		}
+	})
+
+	t.Run("os coverage divergence cases", func(t *testing.T) {
+		portable, err := OSCoverage(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"scripts":[{"type":"file","path":"hooks/run.sh","os":["darwin","linux","windows"]}]}]
+		}`))
+		if err != nil {
+			t.Fatalf("OSCoverage(portable) error: %v", err)
+		}
+		if portable["os_divergent"] != false {
+			t.Fatalf("portable os_divergent = %#v, want false", portable["os_divergent"])
+		}
+
+		perOS, err := OSCoverage(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"scripts":[
+				{"type":"file","path":"hooks/mac.sh","os":["darwin"]},
+				{"type":"file","path":"hooks/lin.sh","os":["linux"]},
+				{"type":"file","path":"hooks/win.cmd","os":["windows"]}
+			]}]
+		}`))
+		if err != nil {
+			t.Fatalf("OSCoverage(perOS) error: %v", err)
+		}
+		if perOS["os_divergent"] != true {
+			t.Fatalf("perOS os_divergent = %#v, want true", perOS["os_divergent"])
+		}
+
+		decoy, err := OSCoverage(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"scripts":[
+				{"type":"file","path":"hooks/unix.sh"},
+				{"type":"file","path":"hooks/win.cmd","os":["windows"]}
+			]}]
+		}`))
+		if err != nil {
+			t.Fatalf("OSCoverage(decoy) error: %v", err)
+		}
+		if decoy["os_divergent"] != true || decoy["unconstrained"] != true {
+			t.Fatalf("decoy coverage = %#v, want divergent unconstrained", decoy)
+		}
+	})
+}
+
+func TestHookMechanisms(t *testing.T) {
+	t.Run("dual shell fields", func(t *testing.T) {
+		result, err := CanonicalizeProviderConfig(hookBlock(t, `{
+			"provider":"dual-shell-fields",
+			"path":"unused.json",
+			"content":{"bash":"hooks/unix.sh","powershell":"hooks/win.ps1"}
+		}`), HookOpts{})
+		if err != nil {
+			t.Fatalf("CanonicalizeProviderConfig() error: %v", err)
+		}
+		if result.Provenance != "inferred-from-convention" {
+			t.Fatalf("Provenance = %q", result.Provenance)
+		}
+		if len(result.Diagnostics) != 1 || result.Diagnostics[0].ID != DiagHookPlatformShellOSProxy {
+			t.Fatalf("diagnostics = %#v, want shell os proxy", result.Diagnostics)
+		}
+	})
+
+	t.Run("filename extension convention table", func(t *testing.T) {
+		cases := []struct {
+			file       string
+			wantOS     []any
+			wantDiag   string
+			provenance string
+		}{
+			{"hooks/run.ps1", []any{"windows"}, DiagHookPlatformFilenameInferred, "inferred-from-convention"},
+			{"hooks/run.cmd", []any{"windows"}, DiagHookPlatformFilenameInferred, "inferred-from-convention"},
+			{"hooks/run.bat", []any{"windows"}, DiagHookPlatformFilenameInferred, "inferred-from-convention"},
+			{"hooks/run.sh", []any{"darwin", "linux"}, DiagHookPlatformFilenameInferred, "inferred-from-convention"},
+			{"hooks/run", []any{"darwin", "linux"}, DiagHookPlatformFilenameInferred, "inferred-from-convention"},
+			{"hooks/run.py", nil, DiagHookPlatformFilenameUninferable, "declared"},
+		}
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.file, func(t *testing.T) {
+				result, err := CanonicalizeProviderConfig(hookBlock(t, `{
+					"provider":"filename-extension-convention",
+					"path":"unused.json",
+					"content":{"file":`+mustJSONString(t, tc.file)+`}
+				}`), HookOpts{})
+				if err != nil {
+					t.Fatalf("CanonicalizeProviderConfig() error: %v", err)
+				}
+				script := result.Canonical["handlers"].([]any)[0].(map[string]any)["scripts"].([]any)[0].(map[string]any)
+				if tc.wantOS == nil {
+					if _, ok := script["os"]; ok {
+						t.Fatalf("os present = %#v, want absent", script["os"])
+					}
+				} else if !reflect.DeepEqual(script["os"], tc.wantOS) {
+					t.Fatalf("os = %#v, want %#v", script["os"], tc.wantOS)
+				}
+				if len(result.Diagnostics) != 1 || result.Diagnostics[0].ID != tc.wantDiag {
+					t.Fatalf("diagnostics = %#v, want %s", result.Diagnostics, tc.wantDiag)
+				}
+				if result.Provenance != tc.provenance {
+					t.Fatalf("provenance = %q, want %q", result.Provenance, tc.provenance)
+				}
+			})
+		}
+	})
+
+	t.Run("interpreter flag passthrough", func(t *testing.T) {
+		result, err := CanonicalizeProviderConfig(hookBlock(t, `{
+			"provider":"per-os-key-map",
+			"path":"unused.json",
+			"content":{"command":"hooks/run","shell":"pwsh -NoProfile -Command \"Write-Host hi\""}
+		}`), HookOpts{})
+		if err != nil {
+			t.Fatalf("CanonicalizeProviderConfig() error: %v", err)
+		}
+		script := result.Canonical["handlers"].([]any)[0].(map[string]any)["scripts"].([]any)[0].(map[string]any)
+		if script["shell"] != `pwsh -NoProfile -Command "Write-Host hi"` {
+			t.Fatalf("shell passthrough = %#v", script["shell"])
+		}
+		if _, ok := script["os"]; ok {
+			t.Fatalf("os synthesized unexpectedly: %#v", script)
+		}
+	})
+
+	t.Run("unknown table key without command rejects", func(t *testing.T) {
+		_, err := CanonicalizeProviderConfig(hookBlock(t, `{
+			"provider":"per-os-key-map",
+			"path":"unused.json",
+			"content":{"shell":"bash"}
+		}`), HookOpts{})
+		expectHookReject(t, err, ErrHookPlatformUnmappable)
+	})
+
+	t.Run("identity merge", func(t *testing.T) {
+		result, err := CanonicalizeProviderConfig(hookBlock(t, `{
+			"provider":"per-os-key-map",
+			"path":"unused.json",
+			"content":{"command":"base.sh","linux":"unix.sh","osx":"unix.sh","windows":"win.cmd"}
+		}`), HookOpts{})
+		if err != nil {
+			t.Fatalf("CanonicalizeProviderConfig() error: %v", err)
+		}
+		scripts := result.Canonical["handlers"].([]any)[0].(map[string]any)["scripts"].([]any)
+		if len(scripts) != 3 {
+			t.Fatalf("scripts length = %d, want 3: %#v", len(scripts), scripts)
+		}
+		for _, s := range scripts {
+			script := s.(map[string]any)
+			if script["path"] == "unix.sh" && !reflect.DeepEqual(script["os"], []any{"darwin", "linux"}) {
+				t.Fatalf("unix.sh os = %#v, want darwin/linux", script["os"])
+			}
+		}
+	})
+}
+
+func TestHookRender(t *testing.T) {
+	t.Run("default degraded render drops overrides", func(t *testing.T) {
+		out, err := RenderHook(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"scripts":[
+				{"type":"file","path":"hooks/unix.sh","os":["darwin","linux"]},
+				{"type":"file","path":"hooks/base.sh"}
+			]}]
+		}`), "no-mechanism-provider", nil)
+		if err != nil {
+			t.Fatalf("RenderHook() error: %v", err)
+		}
+		if !strings.Contains(out.Output, `"command":"hooks/base.sh"`) {
+			t.Fatalf("output = %s, want base command", out.Output)
+		}
+		if strings.Contains(out.Output, "hooks/unix.sh") {
+			t.Fatalf("output contains dropped override path: %s", out.Output)
+		}
+		if len(out.Diagnostics) != 1 || out.Diagnostics[0].ID != DiagHookPlatformOverrideDropped {
+			t.Fatalf("diagnostics = %#v, want override dropped", out.Diagnostics)
+		}
+	})
+
+	t.Run("target os selection required without default", func(t *testing.T) {
+		block := hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"scripts":[{"type":"file","path":"hooks/unix.sh","os":["darwin","linux"]}]}]
+		}`)
+		out, err := RenderHook(block, "no-mechanism-provider", map[string]any{"target_os": "linux"})
+		if err != nil {
+			t.Fatalf("RenderHook(linux) error: %v", err)
+		}
+		if !strings.Contains(out.Output, `"command":"hooks/unix.sh"`) {
+			t.Fatalf("output = %s, want unix command", out.Output)
+		}
+		_, err = RenderHook(block, "no-mechanism-provider", nil)
+		expectHookReject(t, err, ErrHookNoDefaultForDegradedRender)
+		_, err = RenderHook(block, "no-mechanism-provider", map[string]any{"target_os": "windows"})
+		expectHookReject(t, err, ErrHookNoDefaultForDegradedRender)
+	})
+
+	t.Run("render back preserves shell string field", func(t *testing.T) {
+		out, err := RenderHook(hookBlock(t, `{
+			"event":"before_tool_execute",
+			"handlers":[{"scripts":[{"type":"file","path":"hooks/run","shell":"pwsh -NoProfile -Command \"Write-Host hi\""}]}]
+		}`), "no-mechanism-provider", nil)
+		if err != nil {
+			t.Fatalf("RenderHook() error: %v", err)
+		}
+		var rendered map[string]any
+		if err := json.Unmarshal([]byte(out.Output), &rendered); err != nil {
+			t.Fatalf("rendered output not JSON: %v", err)
+		}
+		if rendered["shell"] != `pwsh -NoProfile -Command "Write-Host hi"` {
+			t.Fatalf("shell = %#v", rendered["shell"])
+		}
+	})
+}
+
+func TestHookInstallAndRequires(t *testing.T) {
+	t.Run("evaluate install", func(t *testing.T) {
+		item := hookBlock(t, `{
+			"event":"before_tool_execute",
+			"blocking":true,
+			"handlers":[{"scripts":[{"type":"file","path":"hooks/unix.sh","os":["darwin","linux"]}]}]
+		}`)
+		refuse, err := EvaluateInstall(item, "windows")
+		if err != nil {
+			t.Fatalf("EvaluateInstall(windows) error: %v", err)
+		}
+		if refuse["install"] != "refuse-unless-operator-opt-in" {
+			t.Fatalf("windows install = %#v", refuse)
+		}
+		proceed, err := EvaluateInstall(item, "linux")
+		if err != nil {
+			t.Fatalf("EvaluateInstall(linux) error: %v", err)
+		}
+		if proceed["install"] != "proceed" {
+			t.Fatalf("linux install = %#v", proceed)
+		}
+	})
+
+	t.Run("evaluate requires", func(t *testing.T) {
+		unknown := EvaluateRequires(map[string]any{"handler_types": []any{"command"}}, []string{"matcher_patterns"})
+		if unknown["evaluation"] != "unknown" || unknown["install"] != "refuse-unless-operator-opt-in" {
+			t.Fatalf("unknown requires = %#v", unknown)
+		}
+		satisfied := EvaluateRequires(map[string]any{"handler_types": []any{"command"}}, []string{"handler_types"})
+		if satisfied["evaluation"] != "satisfied" || satisfied["install"] != "proceed" {
+			t.Fatalf("satisfied requires = %#v", satisfied)
+		}
+	})
+}
+
+func anySliceFromMaps(in []map[string]any) []any {
+	out := make([]any, len(in))
+	for i := range in {
+		out[i] = in[i]
+	}
+	return out
+}
+
+func mustJSONString(t *testing.T, s string) string {
+	t.Helper()
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal string: %v", err)
+	}
+	return string(data)
+}

--- a/cli/internal/acif/hookhash.go
+++ b/cli/internal/acif/hookhash.go
@@ -1,0 +1,152 @@
+package acif
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"golang.org/x/text/unicode/norm"
+)
+
+const hookSHA256Prefix = "sha256:"
+
+func HookBodyHash(canonical map[string]any, bodyRoot string) (string, bool, error) {
+	paths := referencedHookFiles(canonical)
+	if bodyRoot == "" && len(paths) > 0 {
+		return "", false, nil
+	}
+
+	manifest, err := hookReferencedFileManifest(paths, bodyRoot)
+	if err != nil {
+		return "", false, err
+	}
+
+	raw, err := json.Marshal(unwrapHookBlock(canonical))
+	if err != nil {
+		return "", false, err
+	}
+	wire, err := CanonicalJSON(raw)
+	if err != nil {
+		return "", false, err
+	}
+
+	digestHeader := hookSHA256Prefix + sha256HexLocal(manifest)
+	preimage := make([]byte, 0, len(digestHeader)+1+len(wire)+1)
+	preimage = append(preimage, digestHeader...)
+	preimage = append(preimage, '\n')
+	preimage = append(preimage, wire...)
+	preimage = append(preimage, '\n')
+	return sha256HexLocal(preimage), true, nil
+}
+
+func referencedHookFiles(canonical map[string]any) []string {
+	seen := make(map[string]bool)
+	var paths []string
+	for _, handler := range hookHandlers(canonical) {
+		if handler["type"] != "command" {
+			continue
+		}
+		for _, script := range hookScripts(handler) {
+			if script["type"] == "file" {
+				if path, ok := script["path"].(string); ok && !seen[path] {
+					seen[path] = true
+					paths = append(paths, path)
+				}
+			}
+		}
+	}
+	for _, item := range anySlice(unwrapHookBlock(canonical)["auxiliary_files"]) {
+		aux, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if path, ok := aux["path"].(string); ok && !seen[path] {
+			seen[path] = true
+			paths = append(paths, path)
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func hookReferencedFileManifest(paths []string, bodyRoot string) ([]byte, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	type entry struct {
+		key  string
+		hash string
+	}
+	entries := make([]entry, 0, len(paths))
+	seenKeys := make(map[string]string, len(paths))
+	for _, path := range paths {
+		if bodyRoot == "" {
+			return nil, hookReject(ErrHookScriptFileMissing, path)
+		}
+		abs := filepath.Join(bodyRoot, filepath.FromSlash(path))
+		info, err := os.Stat(abs)
+		if err != nil || !info.Mode().IsRegular() {
+			return nil, hookReject(ErrHookScriptFileMissing, path)
+		}
+		key := norm.NFC.String(path)
+		if prior, ok := seenKeys[key]; ok && prior != path {
+			return nil, fmt.Errorf("hook path collision: %q and %q normalize to %q", prior, path, key)
+		}
+		seenKeys[key] = path
+		fileHash, err := moat.FileHash(abs)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry{key: key, hash: fileHash})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].key < entries[j].key
+	})
+
+	var manifest strings.Builder
+	for _, entry := range entries {
+		manifest.WriteString(entry.hash)
+		manifest.WriteString("  ")
+		manifest.WriteString(entry.key)
+		manifest.WriteByte('\n')
+	}
+	return []byte(manifest.String()), nil
+}
+
+func sha256HexLocal(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func hookHandlers(block map[string]any) []map[string]any {
+	var out []map[string]any
+	for _, raw := range anySlice(unwrapHookBlock(block)["handlers"]) {
+		if handler, ok := raw.(map[string]any); ok {
+			out = append(out, handler)
+		}
+	}
+	return out
+}
+
+func hookScripts(handler map[string]any) []map[string]any {
+	var out []map[string]any
+	for _, raw := range anySlice(handler["scripts"]) {
+		if script, ok := raw.(map[string]any); ok {
+			out = append(out, script)
+		}
+	}
+	return out
+}
+
+func anySlice(raw any) []any {
+	if items, ok := raw.([]any); ok {
+		return items
+	}
+	return nil
+}

--- a/cli/internal/acif/hookinstall.go
+++ b/cli/internal/acif/hookinstall.go
@@ -1,0 +1,51 @@
+package acif
+
+func EvaluateInstall(item map[string]any, installTargetOS string) (map[string]any, error) {
+	result, err := CanonicalizeHook(item, HookOpts{})
+	if err != nil {
+		return nil, err
+	}
+	if installTargetOS == "" {
+		return map[string]any{"install": "proceed"}, nil
+	}
+
+	blocking, _ := result.Canonical["blocking"].(bool)
+	var diagnostics []Diagnostic
+	for _, handler := range hookHandlers(result.Canonical) {
+		if handler["type"] != "command" {
+			continue
+		}
+		if _, ok := selectScriptForOS(handler, installTargetOS); ok {
+			continue
+		}
+		if blocking {
+			return map[string]any{"install": "refuse-unless-operator-opt-in"}, nil
+		}
+		diagnostics = append(diagnostics, Diagnostic{ID: DiagHookScriptNoPlatformMatch})
+	}
+
+	out := map[string]any{"install": "proceed"}
+	if len(diagnostics) > 0 {
+		out["diagnostics"] = diagnostics
+	}
+	return out, nil
+}
+
+func EvaluateRequires(itemRequires map[string]any, consumerRecognizes []string) map[string]string {
+	recognized := make(map[string]bool, len(consumerRecognizes))
+	for _, key := range consumerRecognizes {
+		recognized[key] = true
+	}
+	for key := range itemRequires {
+		if !recognized[key] {
+			return map[string]string{
+				"evaluation": "unknown",
+				"install":    "refuse-unless-operator-opt-in",
+			}
+		}
+	}
+	return map[string]string{
+		"evaluation": "satisfied",
+		"install":    "proceed",
+	}
+}

--- a/cli/internal/acif/hookmech.go
+++ b/cli/internal/acif/hookmech.go
@@ -1,0 +1,244 @@
+package acif
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+)
+
+func CanonicalizeProviderConfig(config map[string]any, opts HookOpts) (*HookResult, error) {
+	provider, _ := config["provider"].(string)
+	content, ok := config["content"]
+	if !ok {
+		return nil, hookReject(ErrHookPlatformUnmappable, "")
+	}
+
+	decoded, err := decodeProviderContent(content)
+	if err != nil {
+		return nil, err
+	}
+	if block, ok := decoded.(map[string]any); ok {
+		if _, hasEvent := block["event"]; hasEvent {
+			hookOpts := opts
+			hookOpts.Provider = provider
+			return CanonicalizeHook(block, hookOpts)
+		}
+	}
+
+	switch provider {
+	case "per-os-key-map", "per-os-key-map-provider":
+		return canonicalizePerOSKeyMap(decoded, opts)
+	case "dual-shell-fields":
+		return canonicalizeDualShellFields(decoded, opts)
+	case "filename-extension-convention":
+		return canonicalizeFilenameExtensionConvention(decoded, opts)
+	default:
+		return nil, hookReject(ErrHookPlatformUnmappable, provider)
+	}
+}
+
+func decodeProviderContent(content any) (any, error) {
+	if s, ok := content.(string); ok {
+		var decoded any
+		if err := decodeJSONUseNumberBytes([]byte(s), &decoded); err != nil {
+			return nil, hookReject(ErrHookPlatformUnmappable, err.Error())
+		}
+		return decoded, nil
+	}
+	return cloneJSONValue(content), nil
+}
+
+func canonicalizePerOSKeyMap(content any, opts HookOpts) (*HookResult, error) {
+	obj, ok := content.(map[string]any)
+	if !ok {
+		return nil, hookReject(ErrHookPlatformUnmappable, "")
+	}
+
+	var scripts []map[string]any
+	var defaultEntry map[string]any
+	passthrough := make(map[string]any)
+	for key, raw := range obj {
+		switch key {
+		case "command":
+			path, ok := raw.(string)
+			if !ok {
+				return nil, hookReject(ErrHookPlatformUnmappable, key)
+			}
+			defaultEntry = map[string]any{"type": "file", "path": path}
+		case "windows", "linux", "osx":
+			path, ok := raw.(string)
+			if !ok {
+				return nil, hookReject(ErrHookPlatformUnmappable, key)
+			}
+			osTag := key
+			if osTag == "osx" {
+				osTag = "darwin"
+			}
+			scripts = append(scripts, map[string]any{
+				"type": "file",
+				"path": path,
+				"os":   []any{osTag},
+			})
+		default:
+			passthrough[key] = cloneJSONValue(raw)
+		}
+	}
+
+	if len(passthrough) > 0 && defaultEntry == nil {
+		return nil, hookReject(ErrHookPlatformUnmappable, "")
+	}
+	if defaultEntry != nil {
+		for k, v := range passthrough {
+			defaultEntry[k] = v
+		}
+	}
+
+	scripts = mergeConstrainedScriptIdentities(scripts)
+	if defaultEntry != nil {
+		scripts = append(scripts, defaultEntry)
+	}
+	return canonicalizeSynthesizedScripts(scripts, "declared", nil, opts)
+}
+
+func mergeConstrainedScriptIdentities(scripts []map[string]any) []map[string]any {
+	type identity struct {
+		typ  string
+		path string
+	}
+	byID := make(map[identity]map[string]any, len(scripts))
+	var order []identity
+	for _, script := range scripts {
+		id := identity{typ: script["type"].(string), path: script["path"].(string)}
+		existing, ok := byID[id]
+		if !ok {
+			copied := cloneJSONValue(script).(map[string]any)
+			byID[id] = copied
+			order = append(order, id)
+			continue
+		}
+		union := make(map[string]bool)
+		for _, osTag := range anyStringSlice(existing["os"]) {
+			union[osTag] = true
+		}
+		for _, osTag := range anyStringSlice(script["os"]) {
+			union[osTag] = true
+		}
+		items := make([]string, 0, len(union))
+		for osTag := range union {
+			items = append(items, osTag)
+		}
+		sortStrings(items)
+		existing["os"] = stringsToAnySlice(items)
+	}
+
+	out := make([]map[string]any, 0, len(order))
+	for _, id := range order {
+		out = append(out, byID[id])
+	}
+	return out
+}
+
+func canonicalizeDualShellFields(content any, opts HookOpts) (*HookResult, error) {
+	obj, ok := content.(map[string]any)
+	if !ok {
+		return nil, hookReject(ErrHookPlatformUnmappable, "")
+	}
+	var scripts []map[string]any
+	for key, raw := range obj {
+		path, ok := raw.(string)
+		if !ok {
+			return nil, hookReject(ErrHookPlatformUnmappable, key)
+		}
+		switch key {
+		case "bash":
+			scripts = append(scripts, map[string]any{
+				"type": "file",
+				"path": path,
+				"os":   []any{"darwin", "linux"},
+			})
+		case "powershell":
+			scripts = append(scripts, map[string]any{
+				"type": "file",
+				"path": path,
+				"os":   []any{"windows"},
+			})
+		default:
+			return nil, hookReject(ErrHookPlatformUnmappable, key)
+		}
+	}
+	if len(scripts) == 0 {
+		return nil, hookReject(ErrHookPlatformUnmappable, "")
+	}
+	return canonicalizeSynthesizedScripts(scripts, "inferred-from-convention", []Diagnostic{{ID: DiagHookPlatformShellOSProxy}}, opts)
+}
+
+func canonicalizeFilenameExtensionConvention(content any, opts HookOpts) (*HookResult, error) {
+	obj, ok := content.(map[string]any)
+	if !ok {
+		return nil, hookReject(ErrHookPlatformUnmappable, "")
+	}
+	path, ok := obj["file"].(string)
+	if !ok {
+		return nil, hookReject(ErrHookPlatformUnmappable, "")
+	}
+
+	script := map[string]any{"type": "file", "path": path}
+	diagID := DiagHookPlatformFilenameUninferable
+	provenance := "declared"
+	switch finalHookExtension(filepath.Base(path)) {
+	case ".ps1", ".cmd", ".bat":
+		script["os"] = []any{"windows"}
+		diagID = DiagHookPlatformFilenameInferred
+		provenance = "inferred-from-convention"
+	case ".sh", "":
+		script["os"] = []any{"darwin", "linux"}
+		diagID = DiagHookPlatformFilenameInferred
+		provenance = "inferred-from-convention"
+	}
+	return canonicalizeSynthesizedScripts([]map[string]any{script}, provenance, []Diagnostic{{ID: diagID}}, opts)
+}
+
+func finalHookExtension(base string) string {
+	dot := strings.LastIndex(base, ".")
+	if dot <= 0 {
+		return ""
+	}
+	return strings.ToLower(base[dot:])
+}
+
+func canonicalizeSynthesizedScripts(scripts []map[string]any, provenance string, diagnostics []Diagnostic, opts HookOpts) (*HookResult, error) {
+	rawScripts := make([]any, len(scripts))
+	for i := range scripts {
+		rawScripts[i] = scripts[i]
+	}
+	block := map[string]any{
+		"event": "before_tool_execute",
+		"handlers": []any{
+			map[string]any{"type": "command", "scripts": rawScripts},
+		},
+	}
+	result, err := CanonicalizeHook(block, HookOpts{BodyRoot: opts.BodyRoot})
+	if err != nil {
+		return nil, err
+	}
+	result.Provenance = provenance
+	result.Diagnostics = append(result.Diagnostics, diagnostics...)
+	return result, nil
+}
+
+func decodeJSONUseNumberBytes(data []byte, v any) error {
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.UseNumber()
+	return dec.Decode(v)
+}
+
+func sortStrings(items []string) {
+	if len(items) < 2 {
+		return
+	}
+	for i := 1; i < len(items); i++ {
+		for j := i; j > 0 && items[j] < items[j-1]; j-- {
+			items[j], items[j-1] = items[j-1], items[j]
+		}
+	}
+}

--- a/cli/internal/acif/hookproject.go
+++ b/cli/internal/acif/hookproject.go
@@ -1,0 +1,183 @@
+package acif
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+
+	"github.com/OpenScribbler/syllago/cli/internal/moat"
+)
+
+func ScriptSelection(block map[string]any, targets []string) (map[string]string, []Diagnostic, error) {
+	result, err := CanonicalizeHook(block, HookOpts{})
+	if err != nil {
+		return nil, nil, err
+	}
+	handler := firstCommandHandler(result.Canonical)
+	selection := make(map[string]string, len(targets))
+	missed := make([]any, 0)
+	for _, target := range targets {
+		script, ok := selectScriptForOS(handler, target)
+		if !ok {
+			selection[target] = "none"
+			missed = append(missed, target)
+			continue
+		}
+		if script["type"] == "inline" {
+			selection[target] = "inline"
+		} else if path, ok := script["path"].(string); ok {
+			selection[target] = path
+		} else {
+			selection[target] = "none"
+			missed = append(missed, target)
+		}
+	}
+	var diagnostics []Diagnostic
+	if len(missed) > 0 {
+		diagnostics = append(diagnostics, Diagnostic{
+			ID:     DiagHookScriptNoPlatformMatch,
+			Params: map[string]any{"targets": missed},
+		})
+	}
+	return selection, diagnostics, nil
+}
+
+func DerivedCapabilities(block map[string]any) (map[string]bool, error) {
+	result, err := CanonicalizeHook(block, HookOpts{})
+	if err != nil {
+		return nil, err
+	}
+	caps := map[string]bool{
+		"handler_types":    false,
+		"matcher_patterns": false,
+		"async_execution":  false,
+	}
+	if _, ok := result.Canonical["matcher"]; ok {
+		caps["matcher_patterns"] = true
+	}
+	for _, handler := range hookHandlers(result.Canonical) {
+		if typ, ok := handler["type"].(string); ok && typ != "" {
+			caps["handler_types"] = true
+		}
+		if async, ok := handler["async"].(bool); ok && async {
+			caps["async_execution"] = true
+		}
+	}
+	return caps, nil
+}
+
+func OSCoverage(block map[string]any) (map[string]any, error) {
+	result, err := CanonicalizeHook(block, HookOpts{})
+	if err != nil {
+		return nil, err
+	}
+	osSet := make(map[string]bool)
+	archSet := make(map[string]bool)
+	derivable := false
+	unconstrained := false
+	divergent := false
+	for _, handler := range hookHandlers(result.Canonical) {
+		if handler["type"] != "command" {
+			continue
+		}
+		for _, script := range hookScripts(handler) {
+			osTags := anyStringSlice(script["os"])
+			if len(osTags) == 0 {
+				unconstrained = true
+			} else {
+				derivable = true
+				for _, osTag := range osTags {
+					osSet[osTag] = true
+				}
+			}
+			for _, arch := range anyStringSlice(script["arch"]) {
+				archSet[arch] = true
+			}
+		}
+		if commandHandlerDivergent(handler) {
+			divergent = true
+		}
+	}
+	return map[string]any{
+		"derivable":     derivable,
+		"os":            stringsFromSet(osSet),
+		"arch":          stringsFromSet(archSet),
+		"unconstrained": unconstrained,
+		"os_divergent":  divergent,
+		"provenance":    "declared",
+	}, nil
+}
+
+func firstCommandHandler(block map[string]any) map[string]any {
+	for _, handler := range hookHandlers(block) {
+		if handler["type"] == "command" {
+			return handler
+		}
+	}
+	return nil
+}
+
+func selectScriptForOS(handler map[string]any, osTag string) (map[string]any, bool) {
+	if handler == nil {
+		return nil, false
+	}
+	var defaultScript map[string]any
+	for _, script := range hookScripts(handler) {
+		osTags := anyStringSlice(script["os"])
+		if len(osTags) == 0 {
+			defaultScript = script
+			continue
+		}
+		for _, declared := range osTags {
+			if declared == osTag {
+				return script, true
+			}
+		}
+	}
+	if defaultScript != nil {
+		return defaultScript, true
+	}
+	return nil, false
+}
+
+func commandHandlerDivergent(handler map[string]any) bool {
+	seen := make(map[string]string)
+	for _, osTag := range hookOSOrder {
+		script, ok := selectScriptForOS(handler, osTag)
+		if !ok {
+			continue
+		}
+		seen[osTag] = executableIdentity(script)
+	}
+	identities := make(map[string]bool)
+	for _, identity := range seen {
+		if identity != "" {
+			identities[identity] = true
+		}
+	}
+	return len(identities) >= 2
+}
+
+func executableIdentity(script map[string]any) string {
+	typ, _ := script["type"].(string)
+	switch typ {
+	case "file":
+		path, _ := script["path"].(string)
+		return typ + "\x00" + path
+	case "inline":
+		content, _ := script["content"].(string)
+		sum := sha256.Sum256(moat.CanonicalText([]byte(content)))
+		return typ + "\x00" + hex.EncodeToString(sum[:])
+	default:
+		return typ
+	}
+}
+
+func stringsFromSet(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for item := range set {
+		out = append(out, item)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cli/internal/acif/hookrender.go
+++ b/cli/internal/acif/hookrender.go
@@ -1,0 +1,112 @@
+package acif
+
+import "encoding/json"
+
+type RenderResult struct {
+	Output      string
+	Diagnostics []Diagnostic
+	Unsupported bool
+}
+
+func RenderHook(block map[string]any, target string, invocation map[string]any) (*RenderResult, error) {
+	result, err := CanonicalizeHook(block, HookOpts{})
+	if err != nil {
+		return nil, err
+	}
+	handler := firstCommandHandler(result.Canonical)
+	switch target {
+	case "no-mechanism-provider":
+		return renderNoMechanism(result.Canonical, handler, invocation)
+	case "per-os-key-map-provider":
+		return renderPerOSKeyMapProvider(result.Canonical, handler)
+	default:
+		return &RenderResult{Unsupported: true}, nil
+	}
+}
+
+func renderNoMechanism(block map[string]any, handler map[string]any, invocation map[string]any) (*RenderResult, error) {
+	defaultScript, constrained := splitDefaultAndConstrained(handler)
+	var selected map[string]any
+	var diagnostics []Diagnostic
+	if defaultScript != nil {
+		selected = defaultScript
+		if constrained > 0 {
+			diagnostics = append(diagnostics, Diagnostic{ID: DiagHookPlatformOverrideDropped})
+		}
+	} else {
+		targetOS, _ := invocation["target_os"].(string)
+		if targetOS == "" {
+			return nil, hookReject(ErrHookNoDefaultForDegradedRender, "")
+		}
+		var ok bool
+		selected, ok = selectScriptForOS(handler, targetOS)
+		if !ok {
+			return nil, hookReject(ErrHookNoDefaultForDegradedRender, targetOS)
+		}
+	}
+	if selected == nil || selected["type"] != "file" {
+		return &RenderResult{Unsupported: true}, nil
+	}
+	output := map[string]any{
+		"event":   block["event"],
+		"command": selected["path"],
+	}
+	addScriptPassthrough(output, selected)
+	data, err := json.Marshal(output)
+	if err != nil {
+		return nil, err
+	}
+	return &RenderResult{Output: string(data), Diagnostics: diagnostics}, nil
+}
+
+func renderPerOSKeyMapProvider(_ map[string]any, handler map[string]any) (*RenderResult, error) {
+	output := make(map[string]any)
+	for _, script := range hookScripts(handler) {
+		if script["type"] == "inline" {
+			return &RenderResult{Unsupported: true}, nil
+		}
+		path, _ := script["path"].(string)
+		osTags := anyStringSlice(script["os"])
+		if len(osTags) == 0 {
+			output["command"] = path
+		} else {
+			for _, osTag := range osTags {
+				key := osTag
+				if osTag == "darwin" {
+					key = "osx"
+				}
+				output[key] = path
+			}
+		}
+		addScriptPassthrough(output, script)
+	}
+	data, err := json.Marshal(output)
+	if err != nil {
+		return nil, err
+	}
+	return &RenderResult{Output: string(data)}, nil
+}
+
+func splitDefaultAndConstrained(handler map[string]any) (map[string]any, int) {
+	var defaultScript map[string]any
+	constrained := 0
+	for _, script := range hookScripts(handler) {
+		if _, ok := script["os"]; ok {
+			constrained++
+		} else {
+			defaultScript = script
+		}
+	}
+	return defaultScript, constrained
+}
+
+func addScriptPassthrough(output map[string]any, script map[string]any) {
+	for key, value := range script {
+		switch key {
+		case "type", "path", "content", "os", "arch":
+			continue
+		default:
+			output[key] = cloneJSONValue(value)
+		}
+	}
+}


### PR DESCRIPTION
Stage 1 of syllago-as-ACIF-implementation-#1: the conformance adapter now claims the `hook` scope.

## What's here

- `cli/internal/acif`: [ACIF-HOOK] canonical hook model — canonicalization (§6–§8), per-OS script entries and selection (§7), sidecar-only `body_hash` preimage (§9), registry projections (§10.1, §13.1), render-back (§12), install coverage-gap rule (§11), CORE §9.5 requires evaluation.
- `cli/cmd/acif-adapter`: hook-aware `ingest` (sidecar + provider mechanism forms), new ops `project` / `render` / `evaluate_install` / `evaluate_requires`; handshake claims `["core", "hook"]`.

## Conformance

`--scope core --scope hook`: **core 13/13, hook 28/30.**

The two failures are published-suite bugs, not adapter defects — each fails on exactly one check while every other check in the vector passes:

- **TV-PLATFORM-l** `case_6`: the vector expects the string `"absent"` but the binding compares against its own `"<absent>"` sentinel — unpassable by any conforming adapter.
- **TV-PLATFORM-r** `roundtrip_identity`: the vector's expected canonical scripts are not in [ACIF-HOOK] §9.3 canonical order (os-bearing entries sort before path-first defaults under JCS byte order).

A detailed upstream report (including a proposed §7.4 identity-merge clarification that this implementation applies to make key-map round-trips well-defined) accompanies this work.

All five pinned vector hashes (TV-HOOK-g, TV-PLATFORM-i/q/q′/q2) were re-derived independently in Python before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7tRhi8WaVhr1iMMkNNgfN
