### PR TITLE
ACIF Stage 2: content-type scopes (63/65)

### DIFF
--- a/cli/cmd/acif-adapter/handlers.go
+++ b/cli/cmd/acif-adapter/handlers.go
@@ -48,7 +48,7 @@ func dispatch(req request) any {
 			"implementation":   "syllago",
 			"version":          adapterVersion,
 			"adapter_protocol": 1,
-			"scopes":           []string{"core", "hook"},
+			"scopes":           []string{"core", "hook", "skill", "rule", "command", "agent", "mcp"},
 		})
 	case "ingest":
 		return handleIngest(req.Input)
@@ -64,6 +64,8 @@ func dispatch(req request) any {
 		return handleDerivePackID(req.Input)
 	case "resolve_pack":
 		return handleResolvePack(req.Input)
+	case "resolve_reference":
+		return handleResolveReference(req.Input)
 	default:
 		return unsupportedResponse()
 	}
@@ -101,7 +103,7 @@ func handleIngest(raw json.RawMessage) any {
 	}
 
 	if _, ok := rawInput["provider_config"]; ok {
-		return unsupportedResponse()
+		return handleProviderConfigIngest(input.Kind, input.ProviderConfig)
 	}
 	if input.Kind == "pack" {
 		if _, ok := rawInput["manifests"]; ok {
@@ -111,16 +113,90 @@ func handleIngest(raw json.RawMessage) any {
 
 	if _, hasBodyRoot := rawInput["body_root"]; hasBodyRoot {
 		if isFrontmatterKind(input.Kind) {
-			return handleBodyIngest(input.BodyRoot, input.EntryFile)
+			return handleBodyIngest(input.Kind, input.BodyRoot, input.EntryFile)
 		}
 		return unsupportedResponse()
 	}
 
 	if _, hasSidecar := rawInput["sidecar"]; hasSidecar {
+		if input.Kind == "mcp_config" {
+			var block map[string]any
+			if err := decodeJSONUseNumber(input.Sidecar, &block); err != nil {
+				return errorResponse("adapter: " + err.Error())
+			}
+			result, err := acif.CanonicalizeMCP(block)
+			if err != nil {
+				return hookErrorResponse(err)
+			}
+			return okResponse(recordResponse(result))
+		}
+		if isFrontmatterKind(input.Kind) {
+			sidecar, ok := parseJSONObject(input.Sidecar)
+			if !ok {
+				return okResponse(map[string]any{
+					"conformant": false,
+					"reason":     "sidecar-not-object",
+				})
+			}
+			if _, ok := sidecar[input.Kind]; !ok {
+				return handleSidecarIngest(input.Sidecar)
+			}
+			var block map[string]any
+			if err := decodeJSONUseNumber(input.Sidecar, &block); err != nil {
+				return errorResponse("adapter: " + err.Error())
+			}
+			result, err := acif.IngestExtensionBlock(input.Kind, block)
+			if err != nil {
+				return hookErrorResponse(err)
+			}
+			return okResponse(recordResponse(result))
+		}
 		return handleSidecarIngest(input.Sidecar)
 	}
 
 	return unsupportedResponse()
+}
+
+func handleProviderConfigIngest(kind string, rawProviderConfig json.RawMessage) any {
+	var config map[string]any
+	if err := decodeJSONUseNumber(rawProviderConfig, &config); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	switch kind {
+	case "rule":
+		result, err := acif.CanonicalizeRuleProviderConfig(config)
+		if err != nil {
+			return hookErrorResponse(err)
+		}
+		return okResponse(map[string]any{
+			"conformant": true,
+			"canonical": map[string]any{
+				"kind": "rule",
+				"rule": result.Canonical,
+			},
+		})
+	case "agent":
+		result, err := acif.CanonicalizeAgentProviderConfig(config)
+		if err != nil {
+			return hookErrorResponse(err)
+		}
+		return okResponse(map[string]any{
+			"conformant":  true,
+			"installable": true,
+			"canonical": map[string]any{
+				"kind":  "agent",
+				"agent": result.Canonical,
+			},
+		})
+	case "mcp_config":
+		result, err := acif.CanonicalizeMCPProviderConfig(config)
+		if err != nil {
+			return hookErrorResponse(err)
+		}
+		return okResponse(recordResponse(result))
+	default:
+		return unsupportedResponse()
+	}
 }
 
 func handleHookIngest(rawInput map[string]json.RawMessage, input ingestInput) any {
@@ -190,8 +266,8 @@ func isFrontmatterKind(kind string) bool {
 	}
 }
 
-func handleBodyIngest(bodyRoot, entryFile string) any {
-	result, err := acif.BodyHash(bodyRoot, entryFile)
+func handleBodyIngest(kind, bodyRoot, entryFile string) any {
+	result, err := acif.IngestFrontmatterFile(kind, bodyRoot, entryFile)
 	if err != nil {
 		var reject *acif.RejectError
 		if errors.As(err, &reject) {
@@ -199,11 +275,39 @@ func handleBodyIngest(bodyRoot, entryFile string) any {
 		}
 		return errorResponse("adapter: " + err.Error())
 	}
-	return okResponse(map[string]any{
-		"body_hash":      result.HashHex,
-		"classification": result.Classification,
-		"conformant":     true,
-	})
+	return okResponse(recordResponse(result))
+}
+
+func recordResponse(result *acif.RecordResult) map[string]any {
+	response := map[string]any{
+		"conformant":  result.Conformant,
+		"installable": result.Installable,
+	}
+	if result.Reason != "" {
+		response["reason"] = result.Reason
+	}
+	if result.Classification != "" {
+		response["classification"] = result.Classification
+	}
+	if result.BodyHash != "" {
+		response["body_hash"] = result.BodyHash
+	}
+	if result.Canonical != nil {
+		response["canonical"] = result.Canonical
+	}
+	if result.CanonicalBytes != "" {
+		response["canonical_bytes"] = result.CanonicalBytes
+	}
+	if result.PublisherSection != nil {
+		response["publisher_section"] = result.PublisherSection
+	}
+	if result.MetadataHash != "" {
+		response["metadata_hash"] = result.MetadataHash
+	}
+	if len(result.Diagnostics) > 0 {
+		response["diagnostics"] = result.Diagnostics
+	}
+	return response
 }
 
 type projectInput struct {
@@ -221,7 +325,7 @@ func handleProject(raw json.RawMessage) any {
 		return errorResponse("adapter: " + err.Error())
 	}
 	switch input.Projection {
-	case "script_selection", "derived_capabilities", "os_coverage":
+	case "script_selection", "derived_capabilities", "os_coverage", "rule_activation", "advisory", "builtin_shadowing_advisory":
 	default:
 		return unsupportedResponse()
 	}
@@ -241,7 +345,7 @@ func handleProject(raw json.RawMessage) any {
 		}
 		return okResponse(result)
 	case "derived_capabilities":
-		caps, err := acif.DerivedCapabilities(block)
+		caps, err := acif.DerivedCapabilitiesForItem(block)
 		if err != nil {
 			return hookErrorResponse(err)
 		}
@@ -252,6 +356,20 @@ func handleProject(raw json.RawMessage) any {
 			return hookErrorResponse(err)
 		}
 		return okResponse(map[string]any{"projection": projection})
+	case "rule_activation":
+		projection, err := acif.RuleActivationProjection(block)
+		if err != nil {
+			return hookErrorResponse(err)
+		}
+		return okResponse(map[string]any{"projection": projection})
+	case "advisory":
+		projection, err := acif.CommandAdvisoryProjection(block)
+		if err != nil {
+			return hookErrorResponse(err)
+		}
+		return okResponse(map[string]any{"projection": projection})
+	case "builtin_shadowing_advisory":
+		return okResponse(map[string]any{})
 	default:
 		return unsupportedResponse()
 	}
@@ -259,6 +377,8 @@ func handleProject(raw json.RawMessage) any {
 
 type renderInput struct {
 	Canonical  json.RawMessage `json:"canonical"`
+	Item       json.RawMessage `json:"item"`
+	Sidecar    json.RawMessage `json:"sidecar"`
 	Target     string          `json:"target"`
 	Invocation map[string]any  `json:"invocation"`
 }
@@ -268,11 +388,11 @@ func handleRender(raw json.RawMessage) any {
 	if err := json.Unmarshal(raw, &input); err != nil {
 		return errorResponse("adapter: " + err.Error())
 	}
-	block, err := decodeHookBlockInput(nil, input.Canonical, nil, nil)
+	block, err := decodeHookBlockInput(input.Canonical, input.Item, nil, input.Sidecar)
 	if err != nil {
 		return errorResponse("adapter: " + err.Error())
 	}
-	result, err := acif.RenderHook(block, input.Target, input.Invocation)
+	result, err := renderItem(block, input.Target, input.Invocation)
 	if err != nil {
 		return hookErrorResponse(err)
 	}
@@ -283,7 +403,29 @@ func handleRender(raw json.RawMessage) any {
 	if len(result.Diagnostics) > 0 {
 		response["diagnostics"] = result.Diagnostics
 	}
+	if len(result.Lossy) > 0 {
+		response["lossy"] = result.Lossy
+	}
 	return okResponse(response)
+}
+
+func renderItem(block map[string]any, target string, invocation map[string]any) (*acif.RenderResult, error) {
+	renderers := []func(map[string]any, string) (*acif.RenderResult, error){
+		acif.RenderCommand,
+		acif.RenderRule,
+		acif.RenderAgent,
+		acif.RenderMCP,
+	}
+	for _, render := range renderers {
+		result, err := render(block, target)
+		if err != nil {
+			return nil, err
+		}
+		if !result.Unsupported {
+			return result, nil
+		}
+	}
+	return acif.RenderHook(block, target, invocation)
 }
 
 type evaluateInstallInput struct {
@@ -325,6 +467,18 @@ func handleEvaluateRequires(raw json.RawMessage) any {
 		}
 	}
 	return okResponse(acif.EvaluateRequires(itemRequires, recognizes))
+}
+
+func handleResolveReference(raw json.RawMessage) any {
+	var input map[string]any
+	if err := decodeJSONUseNumber(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	result, err := acif.ResolveReference(input)
+	if err != nil {
+		return hookErrorResponse(err)
+	}
+	return okResponse(result)
 }
 
 type sidecarResult struct {

--- a/cli/cmd/acif-adapter/main_test.go
+++ b/cli/cmd/acif-adapter/main_test.go
@@ -57,7 +57,7 @@ func TestHello(t *testing.T) {
 			"implementation":   "syllago",
 			"version":          "0.0.0-dev",
 			"adapter_protocol": float64(1),
-			"scopes":           []any{"core", "hook"},
+			"scopes":           []any{"core", "hook", "skill", "rule", "command", "agent", "mcp"},
 		},
 	}
 	if !reflect.DeepEqual(responses[0], want) {
@@ -254,6 +254,70 @@ func TestHookEvaluateOps(t *testing.T) {
 	result := responses[1]["result"].(map[string]any)
 	if result["evaluation"] != "unknown" || result["install"] != "refuse-unless-operator-opt-in" {
 		t.Fatalf("evaluate_requires = %#v", result)
+	}
+}
+
+func TestStage2IngestProjectRenderAndResolveOps(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeAdapterFixture(t, dir, map[string]string{
+		"COMMAND.md": "---\ndescription: review\n---\nReview PR {{args}} carefully.\n",
+	})
+	request := `{"op":"ingest","input":{"kind":"command","body_root":` + mustJSON(t, dir) + `,"entry_file":"COMMAND.md"}}` + "\n" +
+		`{"op":"ingest","input":{"kind":"skill","sidecar":{"skill":{"activation":{"type":"manual"}}}}}` + "\n" +
+		`{"op":"ingest","input":{"kind":"mcp_config","sidecar":{"servers":{"demo":{"command":"npx","args":["-y","@demo/mcp-server"]}}}}}` + "\n" +
+		`{"op":"project","input":{"projection":"derived_capabilities","item":{"agent":{"tools":["spawn_agent"],"model":"gpt-5-codex","mcp_servers":["demo"]}}}}` + "\n" +
+		`{"op":"project","input":{"projection":"rule_activation","item":{"rule":{"activation":{"mode":"glob","globs":["*.go","cmd/**","internal/**"]}}}}}` + "\n" +
+		`{"op":"project","input":{"projection":"advisory","item":{"command":{"body":"Review $ARGUMENTS."}}}}` + "\n" +
+		`{"op":"project","input":{"projection":"builtin_shadowing_advisory","item":{"command":{"body":"x"}}}}` + "\n" +
+		`{"op":"render","input":{"target":"input-form","canonical":{"command":{"body":"Review $ARGUMENTS."}}}}` + "\n" +
+		`{"op":"resolve_reference","input":{"item":{"skill":{"activation":{"type":"hook","hook_ref":{"id":"550e8400-e29b-41d4-a716-446655440000"}}}},"registry_state":{"known_hooks":["550e8400-e29b-41d4-a716-446655440000"]}}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 9 {
+		t.Fatalf("responses = %d, want 9", len(responses))
+	}
+
+	commandIngest := responses[0]["result"].(map[string]any)
+	if commandIngest["body_hash"] != "eb6f4eb9bc130773a45fb39b20e9ad8e8a05fdabc011d85eeaf47dec08fa5cea" {
+		t.Fatalf("command ingest = %#v", commandIngest)
+	}
+	skillIngest := responses[1]["result"].(map[string]any)
+	if skillIngest["conformant"] != true || skillIngest["installable"] != true {
+		t.Fatalf("skill sidecar = %#v", skillIngest)
+	}
+	mcpIngest := responses[2]["result"].(map[string]any)
+	if mcpIngest["body_hash"] != "26387bc7f0b779925f2d6e704f3dfe590fd381893aa301bc28d2ae399f5e3b52" {
+		t.Fatalf("mcp ingest = %#v", mcpIngest)
+	}
+
+	agentCaps := responses[3]["result"].(map[string]any)["derived_capabilities"].(map[string]any)
+	if agentCaps["subagent_spawning"] != true || agentCaps["per_agent_mcp"] != true {
+		t.Fatalf("agent caps = %#v", agentCaps)
+	}
+	ruleProjection := responses[4]["result"].(map[string]any)["projection"].(map[string]any)
+	if ruleProjection["mode"] != "glob" {
+		t.Fatalf("rule projection = %#v", ruleProjection)
+	}
+	advisory := responses[5]["result"].(map[string]any)["projection"].(map[string]any)
+	token := advisory["argument_substitution_token"].(map[string]any)
+	if token["present"] != true || token["method"] != "substring-canonical-v1" {
+		t.Fatalf("advisory = %#v", advisory)
+	}
+	if _, ok := responses[6]["result"].(map[string]any)["projection"]; ok {
+		t.Fatalf("builtin shadowing advisory should be vacuous-pass: %#v", responses[6])
+	}
+	rendered := responses[7]["result"].(map[string]any)
+	if rendered["output"] != "Review ${input:args}." {
+		t.Fatalf("render output = %#v", rendered)
+	}
+	cross := responses[8]["result"].(map[string]any)["cross_reference"].(map[string]any)
+	if !reflect.DeepEqual(cross, map[string]any{
+		"source_path": "skill.activation.hook_ref",
+		"target_kind": "hook",
+		"resolution":  "resolved",
+	}) {
+		t.Fatalf("skill cross reference = %#v", cross)
 	}
 }
 

--- a/cli/internal/acif/agentitem.go
+++ b/cli/internal/acif/agentitem.go
@@ -1,0 +1,241 @@
+package acif
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/OpenScribbler/syllago/cli/internal/converter"
+	"gopkg.in/yaml.v3"
+)
+
+func CanonicalizeAgent(block map[string]any, provider string) (*ItemResult, error) {
+	block = unwrapKindBlock(block, "agent")
+	out := make(map[string]any, len(block))
+	for k, v := range block {
+		switch k {
+		case "tools", "disallowed_tools":
+			out[k] = translateAgentToolList(v, provider)
+		default:
+			out[k] = cloneJSONValue(v)
+		}
+	}
+	verdict := applyRequiresVerdict(out)
+	return &ItemResult{Canonical: out, Verdict: verdict}, nil
+}
+
+func translateAgentToolList(raw any, provider string) any {
+	items, ok := raw.([]any)
+	if !ok {
+		return cloneJSONValue(raw)
+	}
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		name, ok := item.(string)
+		if !ok || name == "" {
+			out = append(out, cloneJSONValue(item))
+			continue
+		}
+		out = append(out, canonicalAgentToolName(name, provider))
+	}
+	return out
+}
+
+func canonicalAgentToolName(name, provider string) string {
+	if _, ok := converter.ToolNames[name]; ok {
+		return name
+	}
+	if provider != "" {
+		if provider == "collapsing-provider" {
+			if name == "edit_file" {
+				return "file_edit"
+			}
+		} else {
+			reversed := converter.ReverseTranslateTool(name, provider)
+			if reversed != name {
+				return reversed
+			}
+			if _, ok := converter.ToolNames[reversed]; ok {
+				return reversed
+			}
+		}
+	}
+	matches := matchingCanonicalToolsAnyProvider(name)
+	for _, match := range matches {
+		if match == "file_edit" {
+			return "file_edit"
+		}
+	}
+	if len(matches) == 0 && strings.EqualFold(name, "task") {
+		return "agent"
+	}
+	if len(matches) > 0 {
+		sort.Strings(matches)
+		return matches[0]
+	}
+	return name
+}
+
+func matchingCanonicalToolsAnyProvider(name string) []string {
+	var matches []string
+	for canonical, providers := range converter.ToolNames {
+		for _, native := range providers {
+			if native == name {
+				matches = append(matches, canonical)
+				break
+			}
+		}
+	}
+	return matches
+}
+
+func agentDerivedCapabilities(item map[string]any) (map[string]bool, error) {
+	block, _ := unwrapItemBlock(item, "agent")
+	result, err := CanonicalizeAgent(block, "")
+	if err != nil {
+		return nil, err
+	}
+	tools := anyStringSlice(result.Canonical["tools"])
+	return map[string]bool{
+		"tool_restrictions": len(tools) > 0 || len(anyStringSlice(result.Canonical["disallowed_tools"])) > 0,
+		"model_selection":   nonEmptyString(result.Canonical["model"]),
+		"per_agent_mcp":     len(anyStringSlice(result.Canonical["mcp_servers"])) > 0,
+		"subagent_spawning": stringSliceContains(tools, "agent"),
+	}, nil
+}
+
+func RenderAgent(item map[string]any, target string) (*RenderResult, error) {
+	block, _ := unwrapItemBlock(item, "agent")
+	result, err := CanonicalizeAgent(block, "")
+	if err != nil {
+		return nil, err
+	}
+	if !isAgentRenderTarget(target) {
+		return &RenderResult{Unsupported: true}, nil
+	}
+
+	frontmatter := make(map[string]any)
+	for k, v := range result.Canonical {
+		if k == "body" || k == "requires" {
+			continue
+		}
+		switch k {
+		case "tools", "disallowed_tools":
+			frontmatter[k] = translateAgentToolsForProvider(anyStringSlice(v), target)
+		default:
+			frontmatter[k] = cloneJSONValue(v)
+		}
+	}
+	body, _ := result.Canonical["body"].(string)
+	yamlBytes, err := yaml.Marshal(frontmatter)
+	if err != nil {
+		return nil, err
+	}
+	rendered := "---\n" + string(yamlBytes) + "---\n" + body
+	out := &RenderResult{Output: rendered}
+	if hasWriteEditLoss(result.Canonical, target) {
+		out.Lossy = []string{"write-edit-distinction"}
+	}
+	return out, nil
+}
+
+func translateAgentToolsForProvider(tools []string, target string) []any {
+	out := make([]any, len(tools))
+	for i, tool := range tools {
+		if target == "collapsing-provider" {
+			switch tool {
+			case "file_edit", "file_write":
+				out[i] = "edit_file"
+			default:
+				out[i] = tool
+			}
+			continue
+		}
+		out[i] = converter.TranslateTool(tool, target)
+	}
+	return out
+}
+
+func hasWriteEditLoss(block map[string]any, target string) bool {
+	tools := anyStringSlice(block["tools"])
+	seenNative := make(map[string]string)
+	for _, tool := range tools {
+		native := tool
+		if target == "collapsing-provider" {
+			if tool == "file_edit" || tool == "file_write" {
+				native = "edit_file"
+			}
+		} else {
+			native = converter.TranslateTool(tool, target)
+		}
+		if prior, ok := seenNative[native]; ok && prior != tool {
+			return true
+		}
+		seenNative[native] = tool
+	}
+	return false
+}
+
+func CanonicalizeAgentProviderConfig(config map[string]any) (*ItemResult, error) {
+	provider, _ := config["provider"].(string)
+	content, ok := config["content"].(string)
+	if !ok {
+		return nil, fmt.Errorf("agent provider_config content must be string")
+	}
+	doc, err := parseFrontmatterDocument([]byte(content))
+	if err != nil {
+		return nil, err
+	}
+	block := map[string]any{}
+	for k, v := range doc.Frontmatter {
+		block[k] = cloneJSONValue(v)
+	}
+	if doc.Present || doc.Body != "" {
+		block["body"] = doc.Body
+	}
+	return CanonicalizeAgent(block, provider)
+}
+
+func isAgentRenderTarget(target string) bool {
+	switch target {
+	case "claude-code", "copilot-cli", "opencode", "vs-code-copilot", "zed", "codex", "kiro", "factory-droid", "collapsing-provider":
+		return true
+	default:
+		return false
+	}
+}
+
+func unwrapKindBlock(block map[string]any, key string) map[string]any {
+	if block == nil {
+		return map[string]any{}
+	}
+	if inner, ok := block[key].(map[string]any); ok {
+		return inner
+	}
+	return block
+}
+
+func unwrapItemBlock(item map[string]any, key string) (map[string]any, string) {
+	if item == nil {
+		return map[string]any{}, ""
+	}
+	classification, _ := item["classification"].(string)
+	if inner, ok := item[key].(map[string]any); ok {
+		return inner, classification
+	}
+	return item, classification
+}
+
+func nonEmptyString(v any) bool {
+	s, ok := v.(string)
+	return ok && s != ""
+}
+
+func stringSliceContains(items []string, needle string) bool {
+	for _, item := range items {
+		if item == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/acif/agentitem_test.go
+++ b/cli/internal/acif/agentitem_test.go
@@ -1,0 +1,162 @@
+package acif
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/converter"
+)
+
+func TestAgentToolNamesAppendixARow(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]string{
+		"claude-code":     "Agent",
+		"copilot-cli":     "task",
+		"opencode":        "task",
+		"vs-code-copilot": "Agent",
+		"zed":             "spawn_agent",
+		"codex":           "spawn_agent",
+		"kiro":            "use_subagent",
+		"factory-droid":   "Task",
+	}
+	if !reflect.DeepEqual(converter.ToolNames["agent"], want) {
+		t.Fatalf("converter.ToolNames[agent] = %#v, want %#v", converter.ToolNames["agent"], want)
+	}
+}
+
+func TestAgentTranslationAndDerivedCapabilities(t *testing.T) {
+	t.Parallel()
+
+	spellings := []string{"Agent", "task", "spawn_agent", "use_subagent", "Task"}
+	for _, spelling := range spellings {
+		spelling := spelling
+		t.Run(spelling, func(t *testing.T) {
+			t.Parallel()
+			got, err := CanonicalizeAgent(map[string]any{"tools": []any{spelling}}, "")
+			if err != nil {
+				t.Fatalf("CanonicalizeAgent(%s): %v", spelling, err)
+			}
+			if !reflect.DeepEqual(got.Canonical["tools"], []any{"agent"}) {
+				t.Fatalf("tools = %#v, want [agent]", got.Canonical["tools"])
+			}
+		})
+	}
+
+	item := map[string]any{"agent": map[string]any{
+		"tools":            []any{"spawn_agent"},
+		"disallowed_tools": []any{"Bash"},
+		"model":            "gpt-5-codex",
+		"mcp_servers":      []any{"demo"},
+	}}
+	caps, err := DerivedCapabilitiesForItem(item)
+	if err != nil {
+		t.Fatalf("DerivedCapabilitiesForItem(agent): %v", err)
+	}
+	want := map[string]bool{
+		"tool_restrictions": true,
+		"model_selection":   true,
+		"per_agent_mcp":     true,
+		"subagent_spawning": true,
+	}
+	if !reflect.DeepEqual(caps, want) {
+		t.Fatalf("agent caps = %#v, want %#v", caps, want)
+	}
+
+	nulls, err := DerivedCapabilitiesForItem(map[string]any{"agent": map[string]any{
+		"tools":            nil,
+		"disallowed_tools": nil,
+	}})
+	if err != nil {
+		t.Fatalf("DerivedCapabilitiesForItem(agent nulls): %v", err)
+	}
+	if nulls["tool_restrictions"] {
+		t.Fatalf("null tool arrays counted as restrictions: %#v", nulls)
+	}
+}
+
+func TestAgentRenderReingestAndLossy(t *testing.T) {
+	t.Parallel()
+
+	item := map[string]any{"agent": map[string]any{"tools": []any{"agent"}, "body": "Help with the task.\n"}}
+	for _, provider := range []string{"claude-code", "copilot-cli", "opencode", "vs-code-copilot", "zed", "codex", "kiro", "factory-droid"} {
+		provider := provider
+		t.Run(provider, func(t *testing.T) {
+			t.Parallel()
+			rendered, err := RenderAgent(item, provider)
+			if err != nil {
+				t.Fatalf("RenderAgent(%s): %v", provider, err)
+			}
+			if !strings.Contains(rendered.Output, converter.TranslateTool("agent", provider)) {
+				t.Fatalf("render output for %s missing native name: %q", provider, rendered.Output)
+			}
+			roundtrip, err := CanonicalizeAgentProviderConfig(map[string]any{
+				"provider": provider,
+				"path":     "agent.rendered",
+				"content":  rendered.Output,
+			})
+			if err != nil {
+				t.Fatalf("CanonicalizeAgentProviderConfig(%s): %v", provider, err)
+			}
+			if !reflect.DeepEqual(roundtrip.Canonical["tools"], []any{"agent"}) {
+				t.Fatalf("roundtrip tools = %#v", roundtrip.Canonical["tools"])
+			}
+		})
+	}
+
+	lossy, err := RenderAgent(map[string]any{"agent": map[string]any{"tools": []any{"file_write", "file_edit"}}}, "collapsing-provider")
+	if err != nil {
+		t.Fatalf("RenderAgent(collapsing): %v", err)
+	}
+	if !reflect.DeepEqual(lossy.Lossy, []string{"write-edit-distinction"}) {
+		t.Fatalf("lossy = %#v", lossy.Lossy)
+	}
+	rt, err := CanonicalizeAgentProviderConfig(map[string]any{
+		"provider": "collapsing-provider",
+		"content":  lossy.Output,
+	})
+	if err != nil {
+		t.Fatalf("CanonicalizeAgentProviderConfig(collapsing): %v", err)
+	}
+	if !reflect.DeepEqual(rt.Canonical["tools"], []any{"file_edit", "file_edit"}) {
+		t.Fatalf("collapsing roundtrip tools = %#v", rt.Canonical["tools"])
+	}
+}
+
+func TestAgentResolveReference(t *testing.T) {
+	t.Parallel()
+
+	resolved, err := ResolveReference(map[string]any{
+		"item":           map[string]any{"agent": map[string]any{"mcp_servers": []any{"demo"}}},
+		"registry_state": map[string]any{"known_mcp_items_with_server": map[string]any{"demo": "550e8400-e29b-41d4-a716-446655440000"}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveReference(resolved): %v", err)
+	}
+	wantCross := map[string]any{
+		"source_path":   "agent.mcp_servers[0]",
+		"declared_name": "demo",
+		"target_kind":   "mcp_config",
+		"resolution":    "resolved",
+		"target_id":     "550e8400-e29b-41d4-a716-446655440000",
+	}
+	if !reflect.DeepEqual(resolved["cross_reference"], wantCross) || resolved["install"] != "proceed" {
+		t.Fatalf("resolved result = %#v", resolved)
+	}
+
+	unresolved, err := ResolveReference(map[string]any{
+		"item":           map[string]any{"agent": map[string]any{"mcp_servers": []any{"missing"}}},
+		"registry_state": map[string]any{"known_mcp_items_with_server": map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveReference(unresolved): %v", err)
+	}
+	if unresolved["install"] != "refuse-unless-operator-opt-in" {
+		t.Fatalf("unresolved install = %#v", unresolved)
+	}
+	diags := unresolved["diagnostics"].([]Diagnostic)
+	if len(diags) != 1 || diags[0].Params["declared_name"] != "missing" {
+		t.Fatalf("unresolved diagnostics = %#v", diags)
+	}
+}

--- a/cli/internal/acif/bodyhash.go
+++ b/cli/internal/acif/bodyhash.go
@@ -20,6 +20,10 @@ type BodyResult struct {
 	HashHex        string
 }
 
+type bodyHashOptions struct {
+	entryOverride []byte
+}
+
 type bodyFile struct {
 	abs                 string
 	rel                 string
@@ -33,6 +37,14 @@ var acifVCSDirs = map[string]bool{
 
 // BodyHash computes body_hash for a frontmatter-bearing content type.
 func BodyHash(bodyRoot, entryFile string) (*BodyResult, error) {
+	return bodyHash(bodyRoot, entryFile, bodyHashOptions{})
+}
+
+func BodyHashWithEntryBytes(bodyRoot, entryFile string, entryContent []byte) (*BodyResult, error) {
+	return bodyHash(bodyRoot, entryFile, bodyHashOptions{entryOverride: entryContent})
+}
+
+func bodyHash(bodyRoot, entryFile string, opts bodyHashOptions) (*BodyResult, error) {
 	absRoot, err := filepath.Abs(bodyRoot)
 	if err != nil {
 		return nil, fmt.Errorf("resolving body root: %w", err)
@@ -93,14 +105,14 @@ func BodyHash(bodyRoot, entryFile string) (*BodyResult, error) {
 	}
 
 	if len(contentCandidates) == 1 && contentCandidates[0].rel == entryRel {
-		hash, err := hashEntryFile(contentCandidates[0].abs)
+		hash, err := hashEntryFile(contentCandidates[0].abs, opts.entryOverride)
 		if err != nil {
 			return nil, err
 		}
 		return &BodyResult{Classification: "single-file", HashHex: hash}, nil
 	}
 
-	hash, err := multiFileBodyHash(files, entryRel)
+	hash, err := multiFileBodyHash(files, entryRel, opts.entryOverride)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +124,10 @@ func isRootLicenseOrReadme(name string) bool {
 	return strings.HasPrefix(upper, "LICENSE") || strings.HasPrefix(upper, "README")
 }
 
-func hashEntryFile(path string) (string, error) {
+func hashEntryFile(path string, override []byte) (string, error) {
+	if override != nil {
+		return sha256Hex(override), nil
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("reading entry file: %w", err)
@@ -120,7 +135,7 @@ func hashEntryFile(path string) (string, error) {
 	return sha256Hex(stripFrontmatter(moat.CanonicalText(data))), nil
 }
 
-func multiFileBodyHash(files []bodyFile, entryRel string) (string, error) {
+func multiFileBodyHash(files []bodyFile, entryRel string, entryOverride []byte) (string, error) {
 	type manifestEntry struct {
 		rel  string
 		hash string
@@ -141,7 +156,7 @@ func multiFileBodyHash(files []bodyFile, entryRel string) (string, error) {
 		var fileHash string
 		var err error
 		if f.rel == entryRel {
-			fileHash, err = hashEntryFile(f.abs)
+			fileHash, err = hashEntryFile(f.abs, entryOverride)
 		} else {
 			fileHash, err = moat.FileHash(f.abs)
 		}

--- a/cli/internal/acif/command.go
+++ b/cli/internal/acif/command.go
@@ -1,0 +1,153 @@
+package acif
+
+import (
+	"strings"
+)
+
+const argumentsToken = "$ARGUMENTS"
+
+func CanonicalizeCommand(block map[string]any) (*ItemResult, error) {
+	block = unwrapKindBlock(block, "command")
+	out := make(map[string]any, len(block))
+	for k, v := range block {
+		out[k] = cloneJSONValue(v)
+	}
+	verdict := applyRequiresVerdict(out)
+	return &ItemResult{Canonical: out, Verdict: verdict}, nil
+}
+
+func RewriteCommandPlaceholders(body string) (string, []Diagnostic) {
+	var out strings.Builder
+	out.Grow(len(body))
+	var diagnostics []Diagnostic
+	for i := 0; i < len(body); {
+		switch {
+		case strings.HasPrefix(body[i:], "{{args}}"):
+			out.WriteString(argumentsToken)
+			i += len("{{args}}")
+		case strings.HasPrefix(body[i:], "${input:"):
+			end := strings.IndexByte(body[i:], '}')
+			if end < 0 {
+				out.WriteByte(body[i])
+				i++
+				continue
+			}
+			token := body[i : i+end+1]
+			if validInputPlaceholder(token) {
+				out.WriteString(argumentsToken)
+				diagnostics = append(diagnostics, Diagnostic{ID: DiagCommandPlaceholderNamedArgCollapsed})
+			} else {
+				out.WriteString(token)
+			}
+			i += end + 1
+		default:
+			out.WriteByte(body[i])
+			i++
+		}
+	}
+	return out.String(), diagnostics
+}
+
+func validInputPlaceholder(token string) bool {
+	if !strings.HasPrefix(token, "${input:") || !strings.HasSuffix(token, "}") {
+		return false
+	}
+	inner := strings.TrimSuffix(strings.TrimPrefix(token, "${input:"), "}")
+	name, _, _ := strings.Cut(inner, ":")
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		if !isInputVarNameByte(name[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isInputVarNameByte(b byte) bool {
+	return isASCIIAlpha(b) || ('0' <= b && b <= '9') || b == '_' || b == '-'
+}
+
+func CommandAdvisoryProjection(item map[string]any) (map[string]any, error) {
+	block, _ := unwrapItemBlock(item, "command")
+	result, err := CanonicalizeCommand(block)
+	if err != nil {
+		return nil, err
+	}
+	body, _ := result.Canonical["body"].(string)
+	present := commandTokenPresent(body)
+	token := map[string]any{"present": present}
+	if present {
+		token["method"] = "substring-canonical-v1"
+	}
+	return map[string]any{
+		"argument_substitution_token": token,
+	}, nil
+}
+
+func commandTokenPresent(body string) bool {
+	for i := 0; i < len(body); {
+		idx := strings.Index(body[i:], argumentsToken)
+		if idx < 0 {
+			return false
+		}
+		pos := i + idx
+		next := pos + len(argumentsToken)
+		if next == len(body) || !isArgumentContinuation(body[next]) {
+			return true
+		}
+		i = next
+	}
+	return false
+}
+
+func RenderCommand(item map[string]any, target string) (*RenderResult, error) {
+	block, _ := unwrapItemBlock(item, "command")
+	result, err := CanonicalizeCommand(block)
+	if err != nil {
+		return nil, err
+	}
+	body, _ := result.Canonical["body"].(string)
+	switch target {
+	case "gemini-form":
+		return &RenderResult{Output: translateArgumentsToken(body, "{{args}}")}, nil
+	case "input-form":
+		return &RenderResult{Output: translateArgumentsToken(body, "${input:args}")}, nil
+	case "no-row-target":
+		rendered := translateArgumentsToken(body, argumentsToken)
+		var diagnostics []Diagnostic
+		if commandTokenPresent(body) {
+			diagnostics = append(diagnostics, Diagnostic{ID: DiagCommandPlaceholderUntranslated})
+		}
+		return &RenderResult{Output: rendered, Diagnostics: diagnostics}, nil
+	default:
+		return &RenderResult{Unsupported: true}, nil
+	}
+}
+
+func translateArgumentsToken(body, replacement string) string {
+	var out strings.Builder
+	out.Grow(len(body))
+	for i := 0; i < len(body); {
+		if strings.HasPrefix(body[i:], argumentsToken) {
+			next := i + len(argumentsToken)
+			if next == len(body) || !isArgumentContinuation(body[next]) {
+				if next < len(body) && body[next] == '[' {
+					out.WriteString(argumentsToken)
+				} else {
+					out.WriteString(replacement)
+				}
+				i = next
+				continue
+			}
+		}
+		out.WriteByte(body[i])
+		i++
+	}
+	return out.String()
+}
+
+func isArgumentContinuation(b byte) bool {
+	return isASCIIAlpha(b) || ('0' <= b && b <= '9') || b == '_'
+}

--- a/cli/internal/acif/command_test.go
+++ b/cli/internal/acif/command_test.go
@@ -1,0 +1,155 @@
+package acif
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCommandRewriteTable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		in        string
+		want      string
+		diagCount int
+	}{
+		{"claude args", "Review {{args}} carefully.\n", "Review $ARGUMENTS carefully.\n", 0},
+		{"named input", "Open ${input:filename} now.\n", "Open $ARGUMENTS now.\n", 1},
+		{"named input placeholder", "Open ${input:filename:path} now.\n", "Open $ARGUMENTS now.\n", 1},
+		{"invalid named grammar", "Open ${input:} now.\n", "Open ${input:} now.\n", 0},
+		{"positional verbatim", "Do $1 and ${@:3} and !{x} and @{y}.\n", "Do $1 and ${@:3} and !{x} and @{y}.\n", 0},
+		{"fenced code rewritten", "```sh\necho {{args}}\n```\n", "```sh\necho $ARGUMENTS\n```\n", 0},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, diags := RewriteCommandPlaceholders(tc.in)
+			if got != tc.want {
+				t.Fatalf("rewrite = %q, want %q", got, tc.want)
+			}
+			if len(diags) != tc.diagCount {
+				t.Fatalf("diagnostics = %#v, want %d", diags, tc.diagCount)
+			}
+			for _, diag := range diags {
+				if diag.ID != DiagCommandPlaceholderNamedArgCollapsed {
+					t.Fatalf("diagnostic id = %q", diag.ID)
+				}
+			}
+		})
+	}
+}
+
+func TestCommandFileIngestPinnedHashes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		hash string
+	}{
+		{"claude args", "---\ndescription: review\n---\nReview PR {{args}} carefully.\n", tvCommandA},
+		{"named input", "---\ndescription: open\n---\nOpen ${input:filename} now.\n", tvCommandB},
+		{"frontmatter stripped", "---\ndescription: task\n---\nDo the task with $ARGUMENTS.\n", tvCommandH},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			writeBodyFixture(t, dir, map[string]string{"COMMAND.md": tc.body})
+			got, err := IngestFrontmatterFile("command", dir, "COMMAND.md")
+			if err != nil {
+				t.Fatalf("IngestFrontmatterFile(command): %v", err)
+			}
+			if got.BodyHash != tc.hash {
+				t.Fatalf("body_hash = %s, want %s", got.BodyHash, tc.hash)
+			}
+		})
+	}
+}
+
+func TestCommandAdvisoryAndRenderBoundaries(t *testing.T) {
+	t.Parallel()
+
+	item := map[string]any{"command": map[string]any{"body": "$ARGUMENTS $ARGUMENTS[0] $ARGUMENTSFOO $ARGUMENTS"}}
+	projection, err := CommandAdvisoryProjection(item)
+	if err != nil {
+		t.Fatalf("CommandAdvisoryProjection(): %v", err)
+	}
+	wantProjection := map[string]any{
+		"argument_substitution_token": map[string]any{
+			"present": true,
+			"method":  "substring-canonical-v1",
+		},
+	}
+	if !reflect.DeepEqual(projection, wantProjection) {
+		t.Fatalf("projection = %#v, want %#v", projection, wantProjection)
+	}
+	absentProjection, err := CommandAdvisoryProjection(map[string]any{"command": map[string]any{"body": "git rebase --onto $1 $2 && echo ${@:3}\n"}})
+	if err != nil {
+		t.Fatalf("CommandAdvisoryProjection(absent): %v", err)
+	}
+	wantAbsent := map[string]any{
+		"argument_substitution_token": map[string]any{"present": false},
+	}
+	if !reflect.DeepEqual(absentProjection, wantAbsent) {
+		t.Fatalf("absent projection = %#v, want %#v", absentProjection, wantAbsent)
+	}
+
+	renders := []struct {
+		target string
+		want   string
+		diag   string
+	}{
+		{"gemini-form", "{{args}} $ARGUMENTS[0] $ARGUMENTSFOO {{args}}", ""},
+		{"input-form", "${input:args} $ARGUMENTS[0] $ARGUMENTSFOO ${input:args}", ""},
+		{"no-row-target", "$ARGUMENTS $ARGUMENTS[0] $ARGUMENTSFOO $ARGUMENTS", DiagCommandPlaceholderUntranslated},
+	}
+	for _, tc := range renders {
+		tc := tc
+		t.Run(tc.target, func(t *testing.T) {
+			t.Parallel()
+			got, err := RenderCommand(item, tc.target)
+			if err != nil {
+				t.Fatalf("RenderCommand(%s): %v", tc.target, err)
+			}
+			if got.Output != tc.want {
+				t.Fatalf("output = %q, want %q", got.Output, tc.want)
+			}
+			if tc.diag == "" && len(got.Diagnostics) != 0 {
+				t.Fatalf("diagnostics = %#v, want none", got.Diagnostics)
+			}
+			if tc.diag != "" {
+				if len(got.Diagnostics) != 1 || got.Diagnostics[0].ID != tc.diag {
+					t.Fatalf("diagnostics = %#v, want %s", got.Diagnostics, tc.diag)
+				}
+			}
+		})
+	}
+}
+
+func TestCommandMetadataMovesOnFrontmatterOnly(t *testing.T) {
+	t.Parallel()
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	body := "Do the task with $ARGUMENTS.\n"
+	writeBodyFixture(t, dirA, map[string]string{"COMMAND.md": "---\ndescription: one\n---\n" + body})
+	writeBodyFixture(t, dirB, map[string]string{"COMMAND.md": "---\ndescription: two\n---\n" + body})
+	a, err := IngestFrontmatterFile("command", dirA, "COMMAND.md")
+	if err != nil {
+		t.Fatalf("IngestFrontmatterFile(a): %v", err)
+	}
+	b, err := IngestFrontmatterFile("command", dirB, "COMMAND.md")
+	if err != nil {
+		t.Fatalf("IngestFrontmatterFile(b): %v", err)
+	}
+	if a.BodyHash != b.BodyHash {
+		t.Fatalf("frontmatter-only change moved body hash: %s != %s", a.BodyHash, b.BodyHash)
+	}
+	if a.MetadataHash == b.MetadataHash {
+		t.Fatalf("frontmatter change did not move metadata hash: %s", a.MetadataHash)
+	}
+}

--- a/cli/internal/acif/crossref.go
+++ b/cli/internal/acif/crossref.go
@@ -1,0 +1,118 @@
+package acif
+
+import "fmt"
+
+func DerivedCapabilitiesForItem(item map[string]any) (map[string]bool, error) {
+	switch detectItemKind(item) {
+	case "skill":
+		return skillDerivedCapabilities(item)
+	case "rule":
+		return ruleDerivedCapabilities(item)
+	case "agent":
+		return agentDerivedCapabilities(item)
+	case "mcp":
+		block, _ := unwrapItemBlock(item, "mcp")
+		return mcpDerivedCapabilities(block)
+	default:
+		return DerivedCapabilities(item)
+	}
+}
+
+func detectItemKind(item map[string]any) string {
+	if item == nil {
+		return ""
+	}
+	for _, key := range []string{"skill", "rule", "command", "agent", "mcp"} {
+		if _, ok := item[key]; ok {
+			return key
+		}
+	}
+	if kind, _ := item["kind"].(string); kind != "" {
+		return kindKey(kind)
+	}
+	return ""
+}
+
+func ResolveReference(input map[string]any) (map[string]any, error) {
+	item, _ := input["item"].(map[string]any)
+	registry, _ := input["registry_state"].(map[string]any)
+	switch detectItemKind(item) {
+	case "skill":
+		return resolveSkillHookReference(item, registry)
+	case "agent":
+		return resolveAgentReferences(item, registry)
+	default:
+		return nil, fmt.Errorf("unsupported reference item")
+	}
+}
+
+func resolveSkillHookReference(item map[string]any, registry map[string]any) (map[string]any, error) {
+	block, _ := unwrapItemBlock(item, "skill")
+	result, err := CanonicalizeSkill(block)
+	if err != nil {
+		return nil, err
+	}
+	activation, _ := result.Canonical["activation"].(map[string]any)
+	hookRef, _ := activation["hook_ref"].(map[string]any)
+	id, _ := hookRef["id"].(string)
+	knownHooks := anyStringSlice(registry["known_hooks"])
+	resolution := "unresolved"
+	if stringSliceContains(knownHooks, id) {
+		resolution = "resolved"
+	}
+	return map[string]any{
+		"cross_reference": map[string]any{
+			"source_path": "skill.activation.hook_ref",
+			"target_kind": "hook",
+			"resolution":  resolution,
+		},
+		"reciprocal_entries": []any{map[string]any{
+			"source_path": "skill.activation.hook_ref",
+			"target_kind": "skill",
+		}},
+		"install": "proceed",
+	}, nil
+}
+
+func resolveAgentReferences(item map[string]any, registry map[string]any) (map[string]any, error) {
+	block, _ := unwrapItemBlock(item, "agent")
+	result, err := CanonicalizeAgent(block, "")
+	if err != nil {
+		return nil, err
+	}
+	known, _ := registry["known_mcp_items_with_server"].(map[string]any)
+	servers := anyStringSlice(result.Canonical["mcp_servers"])
+	entries := make([]map[string]any, 0, len(servers))
+	var diagnostics []Diagnostic
+	install := "proceed"
+	for i, name := range servers {
+		sourcePath := fmt.Sprintf("agent.mcp_servers[%d]", i)
+		entry := map[string]any{
+			"source_path":   sourcePath,
+			"declared_name": name,
+			"target_kind":   "mcp_config",
+		}
+		if targetID, ok := known[name].(string); ok && targetID != "" {
+			entry["resolution"] = "resolved"
+			entry["target_id"] = targetID
+		} else {
+			entry["resolution"] = "unresolved"
+			diagnostics = append(diagnostics, Diagnostic{
+				ID:     DiagRegistryReferenceUnresolved,
+				Params: map[string]any{"declared_name": name},
+			})
+			install = "refuse-unless-operator-opt-in"
+		}
+		entries = append(entries, entry)
+	}
+	out := map[string]any{"install": install}
+	if len(entries) == 1 {
+		out["cross_reference"] = entries[0]
+	} else {
+		out["cross_references"] = entries
+	}
+	if len(diagnostics) > 0 {
+		out["diagnostics"] = diagnostics
+	}
+	return out, nil
+}

--- a/cli/internal/acif/diagnostics.go
+++ b/cli/internal/acif/diagnostics.go
@@ -47,6 +47,28 @@ const (
 	DiagHookPlatformFilenameUninferable = "acif.hook.platform_filename_uninferable"
 	DiagHookScriptNoPlatformMatch       = "acif.hook.script_no_platform_match"
 
+	ErrSkillActivationTypeMissing = "acif.skill.activation_type_missing"
+	ErrSkillActivationTypeInvalid = "acif.skill.activation_type_invalid"
+	ErrSkillHookRefForbidden      = "acif.skill.hook_ref_forbidden"
+	ErrSkillHookRefIDMissing      = "acif.skill.hook_ref_id_missing"
+
+	ErrRuleActivationModeMissing    = "acif.rule.activation_mode_missing"
+	ErrRuleActivationModeInvalid    = "acif.rule.activation_mode_invalid"
+	ErrRuleGlobModeWithoutGlobs     = "acif.rule.glob_mode_without_globs"
+	ErrRuleGlobsWithoutGlobMode     = "acif.rule.globs_without_glob_mode"
+	ErrRuleActivationModeUnmappable = "acif.rule.activation_mode_unmappable"
+	ErrRuleActivationDegraded       = "acif.rule.activation_degraded"
+
+	DiagCommandPlaceholderNamedArgCollapsed = "acif.command.placeholder_named_arg_collapsed"
+	DiagCommandPlaceholderUntranslated      = "acif.command.placeholder_untranslated"
+
+	ErrMCPServersMissing               = "acif.mcp.servers_missing"
+	ErrMCPTransportTypeInvalid         = "acif.mcp.transport_type_invalid"
+	ErrMCPTransportDefaultAmbiguous    = "acif.mcp.transport_default_ambiguous"
+	ErrMCPTransportDefaultUndetermined = "acif.mcp.transport_default_undetermined"
+	DiagMCPServerNameUnconventional    = "acif.mcp.server_name_unconventional"
+	DiagRegistryReferenceUnresolved    = "acif.registry.reference_unresolved"
+
 	ReasonRequiresOrphanKey            = "acif.requires.orphan_key"
 	ReasonCommandHandlerScriptsMissing = "command-handler-scripts-missing"
 )

--- a/cli/internal/acif/hookrender.go
+++ b/cli/internal/acif/hookrender.go
@@ -6,6 +6,7 @@ type RenderResult struct {
 	Output      string
 	Diagnostics []Diagnostic
 	Unsupported bool
+	Lossy       []string
 }
 
 func RenderHook(block map[string]any, target string, invocation map[string]any) (*RenderResult, error) {

--- a/cli/internal/acif/mcpitem.go
+++ b/cli/internal/acif/mcpitem.go
@@ -1,0 +1,293 @@
+package acif
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+var (
+	mcpServerNameRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
+	mcpEnvVarRe     = regexp.MustCompile(`\$\{[^}]+\}`)
+)
+
+func CanonicalizeMCP(block map[string]any) (*RecordResult, error) {
+	canonicalBlock, diagnostics, verdict, err := canonicalizeMCPBlock(block)
+	if err != nil {
+		return nil, err
+	}
+	record := map[string]any{
+		"kind": "mcp_config",
+		"mcp":  canonicalBlock,
+	}
+	recordRaw, err := json.Marshal(record)
+	if err != nil {
+		return nil, err
+	}
+	canonicalBytes, err := CanonicalJSON(recordRaw)
+	if err != nil {
+		return nil, err
+	}
+	bodyHash, err := mcpBodyHash(canonicalBlock)
+	if err != nil {
+		return nil, err
+	}
+	result := &RecordResult{
+		Conformant:     true,
+		Installable:    true,
+		Canonical:      record,
+		CanonicalBytes: string(canonicalBytes),
+		BodyHash:       bodyHash,
+		Diagnostics:    diagnostics,
+	}
+	if verdict != nil {
+		result.Conformant = false
+		result.Installable = false
+		result.Reason = verdict.Reason
+	}
+	return result, nil
+}
+
+func canonicalizeMCPBlock(block map[string]any) (map[string]any, []Diagnostic, *HookVerdict, error) {
+	block = unwrapKindBlock(block, "mcp")
+	rawServers, ok := block["servers"].(map[string]any)
+	if !ok || len(rawServers) == 0 {
+		return nil, nil, nil, &RejectError{ID: ErrMCPServersMissing}
+	}
+
+	names := make([]string, 0, len(rawServers))
+	for name := range rawServers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	servers := make(map[string]any, len(rawServers))
+	var diagnostics []Diagnostic
+	for _, name := range names {
+		rawServer, _ := rawServers[name].(map[string]any)
+		if rawServer == nil {
+			rawServer = map[string]any{}
+		}
+		server, err := canonicalizeMCPServer(rawServer)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if !mcpServerNameRe.MatchString(name) {
+			diagnostics = append(diagnostics, Diagnostic{
+				ID:     DiagMCPServerNameUnconventional,
+				Params: map[string]any{"server": name},
+			})
+		}
+		servers[name] = server
+	}
+
+	out := map[string]any{"servers": servers}
+	if requires, ok := block["requires"]; ok {
+		out["requires"] = cloneJSONValue(requires)
+	}
+	verdict := applyRequiresVerdict(out)
+	return out, diagnostics, verdict, nil
+}
+
+func canonicalizeMCPServer(server map[string]any) (map[string]any, error) {
+	out := make(map[string]any, len(server)+1)
+	for k, v := range server {
+		switch k {
+		case "type", "includeTools", "excludeTools", "disabledTools", "autoApprove":
+			continue
+		default:
+			out[k] = cloneJSONValue(v)
+		}
+	}
+
+	transport, hasType := server["type"].(string)
+	if hasType {
+		switch transport {
+		case "sse", "stdio", "streamable-http":
+		default:
+			return nil, &RejectError{ID: ErrMCPTransportTypeInvalid, Detail: transport}
+		}
+	} else {
+		_, hasCommand := server["command"]
+		_, hasURL := server["url"]
+		switch {
+		case hasCommand && !hasURL:
+			transport = "stdio"
+		case hasURL && !hasCommand:
+			transport = "streamable-http"
+		case hasCommand && hasURL:
+			return nil, &RejectError{ID: ErrMCPTransportDefaultAmbiguous}
+		default:
+			return nil, &RejectError{ID: ErrMCPTransportDefaultUndetermined}
+		}
+	}
+	out["type"] = transport
+
+	for _, key := range []string{"includeTools", "excludeTools", "disabledTools", "autoApprove"} {
+		if raw, ok := server[key]; ok {
+			out[key] = sortedDedupedArray(raw)
+		}
+	}
+	return out, nil
+}
+
+func sortedDedupedArray(raw any) any {
+	items, ok := raw.([]any)
+	if !ok {
+		return cloneJSONValue(raw)
+	}
+	type entry struct {
+		key   string
+		value any
+	}
+	seen := make(map[string]bool, len(items))
+	entries := make([]entry, 0, len(items))
+	for _, item := range items {
+		key := canonicalSortKey(item)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		entries = append(entries, entry{key: key, value: cloneJSONValue(item)})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
+	out := make([]any, len(entries))
+	for i, entry := range entries {
+		out[i] = entry.value
+	}
+	return out
+}
+
+func canonicalSortKey(v any) string {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprint(v)
+	}
+	canonical, err := CanonicalJSON(raw)
+	if err != nil {
+		return string(raw)
+	}
+	return string(canonical)
+}
+
+func mcpBodyHash(block map[string]any) (string, error) {
+	raw, err := json.Marshal(block)
+	if err != nil {
+		return "", err
+	}
+	wire, err := CanonicalJSON(raw)
+	if err != nil {
+		return "", err
+	}
+	digestHeader := hookSHA256Prefix + sha256Hex(nil)
+	h := sha256.New()
+	_, _ = h.Write([]byte(digestHeader))
+	_, _ = h.Write([]byte{'\n'})
+	_, _ = h.Write(wire)
+	_, _ = h.Write([]byte{'\n'})
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func CanonicalizeMCPProviderConfig(config map[string]any) (*RecordResult, error) {
+	if provider, _ := config["provider"].(string); provider != "no-type-format" {
+		return nil, &RejectError{ID: ErrMCPTransportDefaultUndetermined}
+	}
+	var block map[string]any
+	switch content := config["content"].(type) {
+	case string:
+		if err := decodeJSONUseNumberBytes([]byte(content), &block); err != nil {
+			return nil, err
+		}
+	case map[string]any:
+		block = content
+	default:
+		return nil, fmt.Errorf("mcp provider_config content must be JSON string")
+	}
+	return CanonicalizeMCP(block)
+}
+
+func mcpDerivedCapabilities(item map[string]any) (map[string]bool, error) {
+	block, _, _, err := canonicalizeMCPBlock(item)
+	if err != nil {
+		return nil, err
+	}
+	servers, _ := block["servers"].(map[string]any)
+	caps := map[string]bool{
+		"transport_types":   true,
+		"oauth_support":     false,
+		"env_var_expansion": false,
+		"tool_filtering":    false,
+		"auto_approve":      false,
+	}
+	for _, rawServer := range servers {
+		server, _ := rawServer.(map[string]any)
+		if _, ok := server["oauth"]; ok {
+			caps["oauth_support"] = true
+		}
+		if _, ok := server["autoApprove"]; ok {
+			caps["auto_approve"] = true
+		}
+		for _, key := range []string{"includeTools", "excludeTools", "disabledTools"} {
+			if _, ok := server[key]; ok {
+				caps["tool_filtering"] = true
+			}
+		}
+		if serverHasEnvVarExpansion(server) {
+			caps["env_var_expansion"] = true
+		}
+	}
+	return caps, nil
+}
+
+func serverHasEnvVarExpansion(server map[string]any) bool {
+	for _, key := range []string{"command", "url"} {
+		if s, ok := server[key].(string); ok && mcpEnvVarRe.MatchString(s) {
+			return true
+		}
+	}
+	for _, arg := range anyStringSlice(server["args"]) {
+		if mcpEnvVarRe.MatchString(arg) {
+			return true
+		}
+	}
+	for _, key := range []string{"env", "headers"} {
+		values, _ := server[key].(map[string]any)
+		for _, rawValue := range values {
+			if s, ok := rawValue.(string); ok && mcpEnvVarRe.MatchString(s) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func RenderMCP(item map[string]any, target string) (*RenderResult, error) {
+	if target != "no-type-format" {
+		return &RenderResult{Unsupported: true}, nil
+	}
+	block, _, _, err := canonicalizeMCPBlock(item)
+	if err != nil {
+		return nil, err
+	}
+	servers, _ := block["servers"].(map[string]any)
+	outServers := make(map[string]any, len(servers))
+	for name, rawServer := range servers {
+		server, _ := rawServer.(map[string]any)
+		clean := make(map[string]any, len(server))
+		for k, v := range server {
+			if k == "type" {
+				continue
+			}
+			clean[k] = cloneJSONValue(v)
+		}
+		outServers[name] = clean
+	}
+	raw, err := json.Marshal(map[string]any{"servers": outServers})
+	if err != nil {
+		return nil, err
+	}
+	return &RenderResult{Output: string(raw)}, nil
+}

--- a/cli/internal/acif/mcpitem_test.go
+++ b/cli/internal/acif/mcpitem_test.go
@@ -1,0 +1,165 @@
+package acif
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestMCPCanonicalizationPinnedHashes(t *testing.T) {
+	t.Parallel()
+
+	stdioDefault, err := CanonicalizeMCP(map[string]any{
+		"servers": map[string]any{
+			"demo": map[string]any{"command": "npx", "args": []any{"-y", "@demo/mcp-server"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CanonicalizeMCP(stdio default): %v", err)
+	}
+	if stdioDefault.BodyHash != tvMCPStdio {
+		t.Fatalf("stdio body_hash = %s, want %s", stdioDefault.BodyHash, tvMCPStdio)
+	}
+	if got := stdioDefault.Canonical["mcp"].(map[string]any)["servers"].(map[string]any)["demo"].(map[string]any)["type"]; got != "stdio" {
+		t.Fatalf("stdio type = %#v", got)
+	}
+
+	stdioExplicit, err := CanonicalizeMCP(map[string]any{
+		"servers": map[string]any{
+			"demo": map[string]any{"type": "stdio", "command": "npx", "args": []any{"-y", "@demo/mcp-server"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CanonicalizeMCP(stdio explicit): %v", err)
+	}
+	if stdioExplicit.BodyHash != stdioDefault.BodyHash || stdioExplicit.CanonicalBytes != stdioDefault.CanonicalBytes {
+		t.Fatalf("explicit/default mismatch hash=%s/%s bytes=%s/%s", stdioExplicit.BodyHash, stdioDefault.BodyHash, stdioExplicit.CanonicalBytes, stdioDefault.CanonicalBytes)
+	}
+
+	http, err := CanonicalizeMCP(map[string]any{
+		"servers": map[string]any{
+			"demo": map[string]any{"url": "https://mcp.example.com/sse-endpoint"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CanonicalizeMCP(http): %v", err)
+	}
+	if http.BodyHash != tvMCPHTTP {
+		t.Fatalf("http body_hash = %s, want %s", http.BodyHash, tvMCPHTTP)
+	}
+}
+
+func TestMCPRejectsAndDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	rejects := []struct {
+		name string
+		in   map[string]any
+		id   string
+	}{
+		{"servers absent", map[string]any{}, ErrMCPServersMissing},
+		{"servers empty", map[string]any{"servers": map[string]any{}}, ErrMCPServersMissing},
+		{"invalid type", map[string]any{"servers": map[string]any{"demo": map[string]any{"type": "STDIO", "command": "npx"}}}, ErrMCPTransportTypeInvalid},
+		{"ambiguous default", map[string]any{"servers": map[string]any{"demo": map[string]any{"command": "npx", "url": "https://example.test"}}}, ErrMCPTransportDefaultAmbiguous},
+		{"undetermined default", map[string]any{"servers": map[string]any{"demo": map[string]any{"args": []any{"x"}}}}, ErrMCPTransportDefaultUndetermined},
+	}
+	for _, tc := range rejects {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := CanonicalizeMCP(tc.in)
+			assertReject(t, err, tc.id)
+		})
+	}
+
+	got, err := CanonicalizeMCP(map[string]any{"servers": map[string]any{"1demo": map[string]any{"command": "npx"}}})
+	if err != nil {
+		t.Fatalf("CanonicalizeMCP(unconventional): %v", err)
+	}
+	if len(got.Diagnostics) != 1 || got.Diagnostics[0].ID != DiagMCPServerNameUnconventional {
+		t.Fatalf("diagnostics = %#v", got.Diagnostics)
+	}
+}
+
+func TestMCPDerivedCapabilitiesAndDeterminism(t *testing.T) {
+	t.Parallel()
+
+	rich := map[string]any{"mcp": map[string]any{"servers": map[string]any{
+		"b": map[string]any{
+			"command":       "npx",
+			"args":          []any{"${PACKAGE}", "--flag"},
+			"env":           map[string]any{"TOKEN": "${TOKEN}"},
+			"includeTools":  []any{"z", "a", "a"},
+			"excludeTools":  []any{"x"},
+			"autoApprove":   []any{"tool"},
+			"oauth":         map[string]any{"client_id": "id"},
+			"disabledTools": []any{"d"},
+		},
+	}}}
+	caps, err := DerivedCapabilitiesForItem(rich)
+	if err != nil {
+		t.Fatalf("DerivedCapabilitiesForItem(mcp): %v", err)
+	}
+	want := map[string]bool{
+		"transport_types":   true,
+		"oauth_support":     true,
+		"env_var_expansion": true,
+		"tool_filtering":    true,
+		"auto_approve":      true,
+	}
+	if !reflect.DeepEqual(caps, want) {
+		t.Fatalf("mcp caps = %#v, want %#v", caps, want)
+	}
+
+	a, err := CanonicalizeMCP(map[string]any{"servers": map[string]any{
+		"z": map[string]any{"command": "npx", "includeTools": []any{"b", "a", "a"}},
+		"a": map[string]any{"url": "https://example.test"},
+	}})
+	if err != nil {
+		t.Fatalf("CanonicalizeMCP(a): %v", err)
+	}
+	b, err := CanonicalizeMCP(map[string]any{"servers": map[string]any{
+		"a": map[string]any{"url": "https://example.test"},
+		"z": map[string]any{"includeTools": []any{"a", "b"}, "command": "npx"},
+	}})
+	if err != nil {
+		t.Fatalf("CanonicalizeMCP(b): %v", err)
+	}
+	if a.CanonicalBytes != b.CanonicalBytes || a.BodyHash != b.BodyHash {
+		t.Fatalf("canonicalization not deterministic:\n%s\n%s\n%s\n%s", a.CanonicalBytes, b.CanonicalBytes, a.BodyHash, b.BodyHash)
+	}
+	if !strings.Contains(a.CanonicalBytes, `"includeTools":["a","b"]`) {
+		t.Fatalf("filter list was not sorted/deduped: %s", a.CanonicalBytes)
+	}
+}
+
+func TestMCPStripAndRestoreRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	item, err := CanonicalizeMCP(map[string]any{"servers": map[string]any{"demo": map[string]any{"command": "npx"}}})
+	if err != nil {
+		t.Fatalf("CanonicalizeMCP(): %v", err)
+	}
+	rendered, err := RenderMCP(item.Canonical, "no-type-format")
+	if err != nil {
+		t.Fatalf("RenderMCP(no-type-format): %v", err)
+	}
+	if strings.Contains(rendered.Output, `"type"`) {
+		t.Fatalf("rendered output retained type: %s", rendered.Output)
+	}
+	var bare map[string]any
+	if err := json.Unmarshal([]byte(rendered.Output), &bare); err != nil {
+		t.Fatalf("render output is not JSON: %v", err)
+	}
+	roundtrip, err := CanonicalizeMCPProviderConfig(map[string]any{
+		"provider": "no-type-format",
+		"content":  rendered.Output,
+	})
+	if err != nil {
+		t.Fatalf("CanonicalizeMCPProviderConfig(): %v", err)
+	}
+	if roundtrip.CanonicalBytes != item.CanonicalBytes || roundtrip.BodyHash != item.BodyHash {
+		t.Fatalf("roundtrip mismatch:\n%s\n%s\n%s\n%s", roundtrip.CanonicalBytes, item.CanonicalBytes, roundtrip.BodyHash, item.BodyHash)
+	}
+}

--- a/cli/internal/acif/record.go
+++ b/cli/internal/acif/record.go
@@ -1,0 +1,266 @@
+package acif
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"gopkg.in/yaml.v3"
+)
+
+type ItemResult struct {
+	Canonical   map[string]any
+	Diagnostics []Diagnostic
+	Verdict     *HookVerdict
+}
+
+type RecordResult struct {
+	Conformant       bool
+	Installable      bool
+	Reason           string
+	Classification   string
+	BodyHash         string
+	Canonical        map[string]any
+	PublisherSection map[string]any
+	MetadataHash     string
+	CanonicalBytes   string
+	Diagnostics      []Diagnostic
+}
+
+type frontmatterDocument struct {
+	Frontmatter map[string]any
+	Body        string
+	Present     bool
+}
+
+var envelopeKeys = map[string]bool{
+	"kind":         true,
+	"id":           true,
+	"display_name": true,
+	"version":      true,
+	"description":  true,
+	"license":      true,
+	"pack_id":      true,
+}
+
+func IngestFrontmatterFile(kind, bodyRoot, entryFile string) (*RecordResult, error) {
+	entryPath := filepath.Join(bodyRoot, filepath.FromSlash(entryFile))
+	data, err := os.ReadFile(entryPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if _, bodyErr := BodyHash(bodyRoot, entryFile); bodyErr != nil {
+				return nil, bodyErr
+			}
+		}
+		return nil, fmt.Errorf("reading entry file: %w", err)
+	}
+	doc, err := parseFrontmatterDocument(data)
+	if err != nil {
+		return nil, err
+	}
+
+	body := doc.Body
+	var diagnostics []Diagnostic
+	if kind == "command" {
+		var rewriteDiagnostics []Diagnostic
+		body, rewriteDiagnostics = RewriteCommandPlaceholders(body)
+		diagnostics = append(diagnostics, rewriteDiagnostics...)
+	}
+
+	bodyResult, err := BodyHashWithEntryBytes(bodyRoot, entryFile, []byte(body))
+	if err != nil {
+		return nil, err
+	}
+
+	extension := extensionBlockFromFrontmatter(doc.Frontmatter)
+	item, err := canonicalizeExtension(kind, extension, "")
+	if err != nil {
+		return nil, err
+	}
+	item.Diagnostics = append(diagnostics, item.Diagnostics...)
+	if item.Canonical == nil {
+		item.Canonical = map[string]any{}
+	}
+	item.Canonical["body"] = body
+
+	record := map[string]any{
+		"kind":           kind,
+		"classification": bodyResult.Classification,
+		kindKey(kind):    item.Canonical,
+	}
+	result := &RecordResult{
+		Conformant:     true,
+		Installable:    true,
+		Classification: bodyResult.Classification,
+		BodyHash:       bodyResult.HashHex,
+		Canonical:      record,
+		Diagnostics:    item.Diagnostics,
+	}
+	if item.Verdict != nil {
+		result.Conformant = false
+		result.Installable = false
+		result.Reason = item.Verdict.Reason
+	}
+
+	if doc.Present {
+		section := publisherSection(kind, doc.Frontmatter)
+		result.PublisherSection = section
+		raw, err := json.Marshal(section)
+		if err != nil {
+			return nil, err
+		}
+		hashHex, _, err := MetadataHash(raw)
+		if err != nil {
+			return nil, err
+		}
+		result.MetadataHash = hashHex
+	}
+
+	return result, nil
+}
+
+func IngestExtensionBlock(kind string, sidecar map[string]any) (*RecordResult, error) {
+	key := kindKey(kind)
+	block, _ := sidecar[key].(map[string]any)
+	if block == nil {
+		block = map[string]any{}
+	}
+	item, err := canonicalizeExtension(kind, block, "")
+	if err != nil {
+		return nil, err
+	}
+	result := &RecordResult{
+		Conformant:  true,
+		Installable: true,
+		Canonical: map[string]any{
+			"kind": kind,
+			key:    item.Canonical,
+		},
+		Diagnostics: item.Diagnostics,
+	}
+	if item.Verdict != nil {
+		result.Conformant = false
+		result.Installable = false
+		result.Reason = item.Verdict.Reason
+	}
+	return result, nil
+}
+
+func parseFrontmatterDocument(data []byte) (frontmatterDocument, error) {
+	text := moat.CanonicalText(data)
+	yamlText, body, present := splitFrontmatter(text)
+	doc := frontmatterDocument{Body: string(body), Present: present}
+	if !present || len(bytes.TrimSpace(yamlText)) == 0 {
+		return doc, nil
+	}
+	var parsed map[string]any
+	if err := yaml.Unmarshal(yamlText, &parsed); err != nil {
+		return doc, fmt.Errorf("parsing frontmatter: %w", err)
+	}
+	doc.Frontmatter = normalizeYAMLValue(parsed).(map[string]any)
+	return doc, nil
+}
+
+func splitFrontmatter(text []byte) (yamlText []byte, body []byte, present bool) {
+	if !bytes.HasPrefix(text, []byte("---\n")) {
+		return nil, text, false
+	}
+	const closing = "\n---\n"
+	if idx := bytes.Index(text[3:], []byte(closing)); idx >= 0 {
+		start := idx + 3
+		return text[4:start], text[start+len(closing):], true
+	}
+	if bytes.HasSuffix(text, []byte("\n---")) {
+		return text[4 : len(text)-4], nil, true
+	}
+	return nil, text, false
+}
+
+func normalizeYAMLValue(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, v := range x {
+			out[k] = normalizeYAMLValue(v)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(x))
+		for k, v := range x {
+			out[fmt.Sprint(k)] = normalizeYAMLValue(v)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, v := range x {
+			out[i] = normalizeYAMLValue(v)
+		}
+		return out
+	default:
+		return x
+	}
+}
+
+func extensionBlockFromFrontmatter(frontmatter map[string]any) map[string]any {
+	out := make(map[string]any)
+	for k, v := range frontmatter {
+		if envelopeKeys[k] {
+			continue
+		}
+		out[k] = cloneJSONValue(v)
+	}
+	return out
+}
+
+func publisherSection(kind string, frontmatter map[string]any) map[string]any {
+	section := make(map[string]any)
+	extension := make(map[string]any)
+	for k, v := range frontmatter {
+		if envelopeKeys[k] {
+			section[k] = cloneJSONValue(v)
+			continue
+		}
+		extension[k] = cloneJSONValue(v)
+	}
+	if len(extension) > 0 {
+		section[kindKey(kind)] = extension
+	}
+	return section
+}
+
+func canonicalizeExtension(kind string, block map[string]any, provider string) (*ItemResult, error) {
+	switch kind {
+	case "skill":
+		return CanonicalizeSkill(block)
+	case "rule":
+		return CanonicalizeRule(block)
+	case "command":
+		return CanonicalizeCommand(block)
+	case "agent":
+		return CanonicalizeAgent(block, provider)
+	default:
+		return nil, fmt.Errorf("unsupported extension kind %q", kind)
+	}
+}
+
+func applyRequiresVerdict(block map[string]any) *HookVerdict {
+	requires, ok := block["requires"]
+	if !ok {
+		return nil
+	}
+	if reqMap, ok := requires.(map[string]any); ok && len(reqMap) == 0 {
+		delete(block, "requires")
+		return nil
+	}
+	return &HookVerdict{Reason: ReasonRequiresOrphanKey}
+}
+
+func kindKey(kind string) string {
+	if kind == "mcp_config" {
+		return "mcp"
+	}
+	return kind
+}

--- a/cli/internal/acif/record_test.go
+++ b/cli/internal/acif/record_test.go
@@ -1,0 +1,37 @@
+package acif
+
+import "testing"
+
+const (
+	tvSkillG1  = "12d3cb2f53305b53fff6ca4ff1166fd1d063b1319642e0a0906a5539c8fa57b7"
+	tvSkillG3  = "fef9a3e615ab4d41c1a990908bf9a3e5b47f70a73eaa16fc7e1578c9f4ab60df"
+	tvSkillN   = "b08c2af8a9d5c2eced158b49a13bacfe3d0a22221b965bd2a46672bc5b8f9648"
+	tvRuleA    = "3870d9fb5e9cff74b36ffd20141fd693c8500ff5e97469f4b2d41775c242feaf"
+	tvRuleK    = "4bcb019272bd88d646c10ca0b7ca088bf8215d0114f08e43ef164884f50fed7c"
+	tvCommandA = "eb6f4eb9bc130773a45fb39b20e9ad8e8a05fdabc011d85eeaf47dec08fa5cea"
+	tvCommandB = "200dd55e5537f6a8b7458781d1fb8e7e038b1f665a2ebe1eb1aea7aeea19a8ad"
+	tvCommandH = "711eb812c3c9e2ee14ae51852e6fe951be85a0141ec514d97eb7d63249df89fa"
+	tvMCPStdio = "26387bc7f0b779925f2d6e704f3dfe590fd381893aa301bc28d2ae399f5e3b52"
+	tvMCPHTTP  = "e55a9fc091b4e5267c4c07199ee60712de6c47a9846f929c5cf2d1d9da57f98a"
+)
+
+func TestRequiresVerdictCanonicalState(t *testing.T) {
+	t.Parallel()
+
+	empty := map[string]any{"requires": map[string]any{}}
+	if verdict := applyRequiresVerdict(empty); verdict != nil {
+		t.Fatalf("empty requires verdict = %#v, want nil", verdict)
+	}
+	if _, ok := empty["requires"]; ok {
+		t.Fatalf("empty requires was not deleted: %#v", empty)
+	}
+
+	foreign := map[string]any{"requires": map[string]any{"future": true}}
+	verdict := applyRequiresVerdict(foreign)
+	if verdict == nil || verdict.Reason != ReasonRequiresOrphanKey {
+		t.Fatalf("foreign requires verdict = %#v, want orphan key", verdict)
+	}
+	if _, ok := foreign["requires"]; !ok {
+		t.Fatalf("non-empty requires was removed: %#v", foreign)
+	}
+}

--- a/cli/internal/acif/rule.go
+++ b/cli/internal/acif/rule.go
@@ -1,0 +1,177 @@
+package acif
+
+type RuleRenderTarget string
+
+func CanonicalizeRule(block map[string]any) (*ItemResult, error) {
+	block = unwrapKindBlock(block, "rule")
+	out := make(map[string]any, len(block)+1)
+	for k, v := range block {
+		if k == "activation" || k == "requires" {
+			continue
+		}
+		out[k] = cloneJSONValue(v)
+	}
+
+	activation, err := canonicalizeRuleActivation(block["activation"])
+	if err != nil {
+		return nil, err
+	}
+	out["activation"] = activation
+
+	if requires, ok := block["requires"]; ok {
+		out["requires"] = cloneJSONValue(requires)
+	}
+	verdict := applyRequiresVerdict(out)
+	return &ItemResult{Canonical: out, Verdict: verdict}, nil
+}
+
+func canonicalizeRuleActivation(raw any) (map[string]any, error) {
+	if raw == nil {
+		return map[string]any{"mode": "always"}, nil
+	}
+	in, _ := raw.(map[string]any)
+	if in == nil {
+		return nil, &RejectError{ID: ErrRuleActivationModeMissing}
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		if k == "mode" || k == "globs" {
+			continue
+		}
+		out[k] = cloneJSONValue(v)
+	}
+
+	mode, ok := in["mode"].(string)
+	if !ok || mode == "" {
+		return nil, &RejectError{ID: ErrRuleActivationModeMissing}
+	}
+	switch mode {
+	case "always", "glob", "manual", "model_decision":
+	default:
+		return nil, &RejectError{ID: ErrRuleActivationModeInvalid, Detail: mode}
+	}
+
+	globs, hasGlobs := in["globs"]
+	if mode == "glob" {
+		items, ok := globs.([]any)
+		if !hasGlobs || !ok || len(items) == 0 {
+			return nil, &RejectError{ID: ErrRuleGlobModeWithoutGlobs}
+		}
+		out["globs"] = cloneJSONValue(items)
+	} else if hasGlobs && globs != nil {
+		return nil, &RejectError{ID: ErrRuleGlobsWithoutGlobMode}
+	}
+
+	out["mode"] = mode
+	return out, nil
+}
+
+func CanonicalizeRuleProviderConfig(config map[string]any) (*ItemResult, error) {
+	if provider, _ := config["provider"].(string); provider != "rule-activation-source" {
+		return nil, &RejectError{ID: ErrRuleActivationModeUnmappable}
+	}
+	content, _ := config["content"].(map[string]any)
+	mode, _ := content["source_sub_mode"].(string)
+	activation := map[string]any{}
+	switch mode {
+	case "always_on":
+		activation["mode"] = "always"
+	case "glob", "frontmatter_globs":
+		activation["mode"] = "glob"
+		if globs, ok := content["globs"]; ok {
+			activation["globs"] = cloneJSONValue(globs)
+		}
+	case "model_decision":
+		activation["mode"] = "model_decision"
+	case "manual", "slash_command":
+		activation["mode"] = "manual"
+	case "legacy":
+		globs, hasGlobs := content["globs"].([]any)
+		alwaysApply, _ := content["always_apply"].(bool)
+		switch {
+		case alwaysApply:
+			activation["mode"] = "always"
+		case hasGlobs && len(globs) > 0:
+			activation["mode"] = "glob"
+			activation["globs"] = cloneJSONValue(globs)
+		default:
+			activation["mode"] = "model_decision"
+		}
+	default:
+		return nil, &RejectError{ID: ErrRuleActivationModeUnmappable, Detail: mode}
+	}
+	return CanonicalizeRule(map[string]any{"activation": activation})
+}
+
+func ruleDerivedCapabilities(item map[string]any) (map[string]bool, error) {
+	block, _ := unwrapItemBlock(item, "rule")
+	result, err := CanonicalizeRule(block)
+	if err != nil {
+		return nil, err
+	}
+	activation, _ := result.Canonical["activation"].(map[string]any)
+	mode, _ := activation["mode"].(string)
+	return map[string]bool{
+		"activation_mode": mode == "glob" || mode == "manual" || mode == "model_decision",
+	}, nil
+}
+
+func RuleActivationProjection(item map[string]any) (map[string]any, error) {
+	block, _ := unwrapItemBlock(item, "rule")
+	result, err := CanonicalizeRule(block)
+	if err != nil {
+		return nil, err
+	}
+	activation, _ := result.Canonical["activation"].(map[string]any)
+	mode, _ := activation["mode"].(string)
+	globs := anyStringSlice(activation["globs"])
+	sample := globs
+	truncated := false
+	if len(sample) > 16 {
+		sample = sample[:16]
+		truncated = true
+	}
+	return map[string]any{
+		"derivable": mode == "glob" || mode == "manual" || mode == "model_decision",
+		"mode":      mode,
+		"globs": map[string]any{
+			"present":   mode == "glob" && len(globs) > 0,
+			"count":     len(globs),
+			"sample":    stringsToAnySlice(sample),
+			"truncated": truncated,
+		},
+	}, nil
+}
+
+func RenderRule(item map[string]any, target string) (*RenderResult, error) {
+	block, _ := unwrapItemBlock(item, "rule")
+	result, err := CanonicalizeRule(block)
+	if err != nil {
+		return nil, err
+	}
+	body, _ := result.Canonical["body"].(string)
+	activation, _ := result.Canonical["activation"].(map[string]any)
+	mode, _ := activation["mode"].(string)
+	switch target {
+	case "native-rule-format":
+		return &RenderResult{Output: body}, nil
+	case "no-declaration-surface-provider":
+		output := body
+		if output == "" {
+			output = "<!-- rule-body -->\n"
+		}
+		var diagnostics []Diagnostic
+		if mode != "always" {
+			diagnostics = append(diagnostics, Diagnostic{
+				ID: ErrRuleActivationDegraded,
+				Params: map[string]any{
+					"mode_lost":          mode,
+					"effective_behavior": "always-on",
+				},
+			})
+		}
+		return &RenderResult{Output: output, Diagnostics: diagnostics}, nil
+	default:
+		return &RenderResult{Unsupported: true}, nil
+	}
+}

--- a/cli/internal/acif/rule_test.go
+++ b/cli/internal/acif/rule_test.go
@@ -1,0 +1,185 @@
+package acif
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRuleFileIngestPinnedHashes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeBodyFixture(t, dir, map[string]string{
+			"RULE.md": "---\nactivation:\n  mode: always\n---\nPrefer functional patterns.\n",
+		})
+		got, err := IngestFrontmatterFile("rule", dir, "RULE.md")
+		if err != nil {
+			t.Fatalf("IngestFrontmatterFile(rule): %v", err)
+		}
+		if got.BodyHash != tvRuleA {
+			t.Fatalf("body_hash = %s, want %s", got.BodyHash, tvRuleA)
+		}
+	})
+
+	t.Run("prose imports opaque", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		body := "Follow @security.md and @~/company-standards.md.\n"
+		writeBodyFixture(t, dir, map[string]string{"RULE.md": "---\nactivation:\n  mode: always\n---\n" + body})
+		got, err := IngestFrontmatterFile("rule", dir, "RULE.md")
+		if err != nil {
+			t.Fatalf("IngestFrontmatterFile(rule): %v", err)
+		}
+		if got.BodyHash != tvRuleK {
+			t.Fatalf("body_hash = %s, want %s", got.BodyHash, tvRuleK)
+		}
+		rendered, err := RenderRule(got.Canonical, "native-rule-format")
+		if err != nil {
+			t.Fatalf("RenderRule(native): %v", err)
+		}
+		if rendered.Output != body {
+			t.Fatalf("native render = %q, want %q", rendered.Output, body)
+		}
+	})
+}
+
+func TestRuleCanonicalization(t *testing.T) {
+	t.Parallel()
+
+	defaulted, err := CanonicalizeRule(map[string]any{})
+	if err != nil {
+		t.Fatalf("CanonicalizeRule(default) error: %v", err)
+	}
+	if !reflect.DeepEqual(defaulted.Canonical["activation"], map[string]any{"mode": "always"}) {
+		t.Fatalf("default activation = %#v", defaulted.Canonical["activation"])
+	}
+
+	rejects := []struct {
+		name string
+		in   map[string]any
+		id   string
+	}{
+		{"mode missing", map[string]any{"activation": map[string]any{}}, ErrRuleActivationModeMissing},
+		{"mode invalid", map[string]any{"activation": map[string]any{"mode": " always"}}, ErrRuleActivationModeInvalid},
+		{"glob mode without globs", map[string]any{"activation": map[string]any{"mode": "glob"}}, ErrRuleGlobModeWithoutGlobs},
+		{"glob mode empty globs", map[string]any{"activation": map[string]any{"mode": "glob", "globs": []any{}}}, ErrRuleGlobModeWithoutGlobs},
+		{"globs without glob mode", map[string]any{"activation": map[string]any{"mode": "manual", "globs": []any{"*.go"}}}, ErrRuleGlobsWithoutGlobMode},
+	}
+	for _, tc := range rejects {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := CanonicalizeRule(tc.in)
+			assertReject(t, err, tc.id)
+		})
+	}
+
+	requires := map[string]any{
+		"activation": map[string]any{"mode": "glob"},
+		"requires":   map[string]any{"future": true},
+	}
+	_, err = CanonicalizeRule(requires)
+	assertReject(t, err, ErrRuleGlobModeWithoutGlobs)
+}
+
+func TestRuleMechanismDecode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		cfg  map[string]any
+		want map[string]any
+	}{
+		{
+			name: "always on",
+			cfg:  map[string]any{"provider": "rule-activation-source", "content": map[string]any{"source_sub_mode": "always_on"}},
+			want: map[string]any{"mode": "always"},
+		},
+		{
+			name: "frontmatter globs",
+			cfg:  map[string]any{"provider": "rule-activation-source", "content": map[string]any{"source_sub_mode": "frontmatter_globs", "globs": []any{"*.go"}}},
+			want: map[string]any{"mode": "glob", "globs": []any{"*.go"}},
+		},
+		{
+			name: "legacy residual",
+			cfg:  map[string]any{"provider": "rule-activation-source", "content": map[string]any{"source_sub_mode": "legacy", "always_apply": false}},
+			want: map[string]any{"mode": "model_decision"},
+		},
+		{
+			name: "slash command",
+			cfg:  map[string]any{"provider": "rule-activation-source", "content": map[string]any{"source_sub_mode": "slash_command"}},
+			want: map[string]any{"mode": "manual"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := CanonicalizeRuleProviderConfig(tc.cfg)
+			if err != nil {
+				t.Fatalf("CanonicalizeRuleProviderConfig() error: %v", err)
+			}
+			if !reflect.DeepEqual(got.Canonical["activation"], tc.want) {
+				t.Fatalf("activation = %#v, want %#v", got.Canonical["activation"], tc.want)
+			}
+		})
+	}
+
+	_, err := CanonicalizeRuleProviderConfig(map[string]any{
+		"provider": "rule-activation-source",
+		"content":  map[string]any{"source_sub_mode": "sometimes"},
+	})
+	assertReject(t, err, ErrRuleActivationModeUnmappable)
+}
+
+func TestRuleDerivedProjectionAndDegradedRender(t *testing.T) {
+	t.Parallel()
+
+	item := map[string]any{"rule": map[string]any{"activation": map[string]any{"mode": "glob", "globs": []any{"*.go", "cmd/**", "internal/**"}}}}
+	caps, err := DerivedCapabilitiesForItem(item)
+	if err != nil {
+		t.Fatalf("DerivedCapabilitiesForItem(rule): %v", err)
+	}
+	if !reflect.DeepEqual(caps, map[string]bool{"activation_mode": true}) {
+		t.Fatalf("rule caps = %#v", caps)
+	}
+
+	projection, err := RuleActivationProjection(item)
+	if err != nil {
+		t.Fatalf("RuleActivationProjection(): %v", err)
+	}
+	wantProjection := map[string]any{
+		"derivable": true,
+		"mode":      "glob",
+		"globs": map[string]any{
+			"present":   true,
+			"count":     3,
+			"sample":    []any{"*.go", "cmd/**", "internal/**"},
+			"truncated": false,
+		},
+	}
+	if !reflect.DeepEqual(projection, wantProjection) {
+		t.Fatalf("projection = %#v, want %#v", projection, wantProjection)
+	}
+
+	rendered, err := RenderRule(map[string]any{"rule": map[string]any{"activation": map[string]any{"mode": "manual"}}}, "no-declaration-surface-provider")
+	if err != nil {
+		t.Fatalf("RenderRule(degraded): %v", err)
+	}
+	if !strings.Contains(rendered.Output, "rule-body") {
+		t.Fatalf("degraded output = %q, want placeholder", rendered.Output)
+	}
+	wantDiag := Diagnostic{
+		ID: ErrRuleActivationDegraded,
+		Params: map[string]any{
+			"mode_lost":          "manual",
+			"effective_behavior": "always-on",
+		},
+	}
+	if !reflect.DeepEqual(rendered.Diagnostics, []Diagnostic{wantDiag}) {
+		t.Fatalf("diagnostics = %#v, want %#v", rendered.Diagnostics, []Diagnostic{wantDiag})
+	}
+}

--- a/cli/internal/acif/skill.go
+++ b/cli/internal/acif/skill.go
@@ -1,0 +1,87 @@
+package acif
+
+func CanonicalizeSkill(block map[string]any) (*ItemResult, error) {
+	block = unwrapKindBlock(block, "skill")
+	out := make(map[string]any, len(block)+1)
+	for k, v := range block {
+		if k == "activation" || k == "requires" {
+			continue
+		}
+		out[k] = cloneJSONValue(v)
+	}
+
+	activation, err := canonicalizeSkillActivation(block["activation"])
+	if err != nil {
+		return nil, err
+	}
+	out["activation"] = activation
+
+	if requires, ok := block["requires"]; ok {
+		out["requires"] = cloneJSONValue(requires)
+	}
+	verdict := applyRequiresVerdict(out)
+	return &ItemResult{Canonical: out, Verdict: verdict}, nil
+}
+
+func canonicalizeSkillActivation(raw any) (map[string]any, error) {
+	if raw == nil {
+		return map[string]any{"type": "auto", "user_invocable": true}, nil
+	}
+	in, _ := raw.(map[string]any)
+	if in == nil {
+		return nil, &RejectError{ID: ErrSkillActivationTypeMissing}
+	}
+	out := make(map[string]any, len(in)+1)
+	for k, v := range in {
+		if k == "type" || k == "user_invocable" || k == "hook_ref" {
+			continue
+		}
+		out[k] = cloneJSONValue(v)
+	}
+
+	activationType, ok := in["type"].(string)
+	if !ok || activationType == "" {
+		return nil, &RejectError{ID: ErrSkillActivationTypeMissing}
+	}
+	switch activationType {
+	case "auto", "hook", "manual":
+	default:
+		return nil, &RejectError{ID: ErrSkillActivationTypeInvalid, Detail: activationType}
+	}
+	out["type"] = activationType
+
+	if hookRef, ok := in["hook_ref"]; ok {
+		if activationType != "hook" {
+			return nil, &RejectError{ID: ErrSkillHookRefForbidden}
+		}
+		refMap, _ := hookRef.(map[string]any)
+		id, _ := refMap["id"].(string)
+		if refMap == nil || id == "" {
+			return nil, &RejectError{ID: ErrSkillHookRefIDMissing}
+		}
+		out["hook_ref"] = cloneJSONValue(refMap)
+	}
+
+	if userInvocable, ok := in["user_invocable"]; ok {
+		out["user_invocable"] = cloneJSONValue(userInvocable)
+	} else {
+		out["user_invocable"] = true
+	}
+	return out, nil
+}
+
+func skillDerivedCapabilities(item map[string]any) (map[string]bool, error) {
+	block, classification := unwrapItemBlock(item, "skill")
+	result, err := CanonicalizeSkill(block)
+	if err != nil {
+		return nil, err
+	}
+	activation, _ := result.Canonical["activation"].(map[string]any)
+	activationType, _ := activation["type"].(string)
+	return map[string]bool{
+		"auto_invocable":           activationType == "auto",
+		"disable_model_invocation": activationType == "manual" || activationType == "hook",
+		"user_invocable":           activation["user_invocable"] == false,
+		"skill_bundled_resources":  classification == "multi-file",
+	}, nil
+}

--- a/cli/internal/acif/skill_test.go
+++ b/cli/internal/acif/skill_test.go
@@ -1,0 +1,171 @@
+package acif
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestSkillFileIngestPinnedHashes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single-file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeBodyFixture(t, dir, map[string]string{
+			"SKILL.md": "---\ndescription: demo\n---\nUse this to demo classification.\n",
+		})
+		got, err := IngestFrontmatterFile("skill", dir, "SKILL.md")
+		if err != nil {
+			t.Fatalf("IngestFrontmatterFile() error: %v", err)
+		}
+		if got.BodyHash != tvSkillG1 || got.Classification != "single-file" {
+			t.Fatalf("hash/classification = %s/%s", got.BodyHash, got.Classification)
+		}
+		if got.Canonical["classification"] != "single-file" {
+			t.Fatalf("canonical classification = %#v", got.Canonical)
+		}
+		body := got.Canonical["skill"].(map[string]any)["body"]
+		if body != "Use this to demo classification.\n" {
+			t.Fatalf("canonical skill body = %#v", body)
+		}
+		if got.MetadataHash == "" || got.PublisherSection == nil {
+			t.Fatalf("frontmatter did not produce metadata: %#v", got)
+		}
+	})
+
+	t.Run("multi-file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeBodyFixture(t, dir, map[string]string{
+			"SKILL.md":       "Use this to demo classification.\n",
+			"scripts/run.sh": "#!/bin/sh\necho hi\n",
+		})
+		got, err := IngestFrontmatterFile("skill", dir, "SKILL.md")
+		if err != nil {
+			t.Fatalf("IngestFrontmatterFile() error: %v", err)
+		}
+		if got.BodyHash != tvSkillG3 || got.Classification != "multi-file" {
+			t.Fatalf("hash/classification = %s/%s", got.BodyHash, got.Classification)
+		}
+	})
+
+	t.Run("multi-file-entry-frontmatter-stripped", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeBodyFixture(t, dir, map[string]string{
+			"SKILL.md":       "---\ndescription: one\n---\nProse body.\n",
+			"scripts/run.sh": "#!/bin/sh\necho hi\n",
+		})
+		got, err := IngestFrontmatterFile("skill", dir, "SKILL.md")
+		if err != nil {
+			t.Fatalf("IngestFrontmatterFile() error: %v", err)
+		}
+		if got.BodyHash != tvSkillN {
+			t.Fatalf("body_hash = %s, want %s", got.BodyHash, tvSkillN)
+		}
+	})
+}
+
+func TestSkillCanonicalizationAndPredicates(t *testing.T) {
+	t.Parallel()
+
+	defaulted, err := CanonicalizeSkill(map[string]any{})
+	if err != nil {
+		t.Fatalf("CanonicalizeSkill(default) error: %v", err)
+	}
+	wantActivation := map[string]any{"type": "auto", "user_invocable": true}
+	if !reflect.DeepEqual(defaulted.Canonical["activation"], wantActivation) {
+		t.Fatalf("default activation = %#v, want %#v", defaulted.Canonical["activation"], wantActivation)
+	}
+
+	rejects := []struct {
+		name string
+		in   map[string]any
+		id   string
+	}{
+		{"missing type", map[string]any{"activation": map[string]any{}}, ErrSkillActivationTypeMissing},
+		{"invalid type", map[string]any{"activation": map[string]any{"type": "automatic"}}, ErrSkillActivationTypeInvalid},
+		{"hook ref forbidden", map[string]any{"activation": map[string]any{"type": "auto", "hook_ref": map[string]any{"id": "h1"}}}, ErrSkillHookRefForbidden},
+		{"hook ref id missing", map[string]any{"activation": map[string]any{"type": "hook", "hook_ref": map[string]any{}}}, ErrSkillHookRefIDMissing},
+	}
+	for _, tc := range rejects {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := CanonicalizeSkill(tc.in)
+			assertReject(t, err, tc.id)
+		})
+	}
+
+	hookSkill, err := CanonicalizeSkill(map[string]any{"activation": map[string]any{"type": "hook"}})
+	if err != nil {
+		t.Fatalf("hook skill without hook_ref rejected: %v", err)
+	}
+	if hookSkill.Canonical["activation"].(map[string]any)["user_invocable"] != true {
+		t.Fatalf("hook skill did not materialize user_invocable: %#v", hookSkill.Canonical)
+	}
+
+	caps, err := DerivedCapabilitiesForItem(map[string]any{
+		"kind":           "skill",
+		"classification": "multi-file",
+		"skill": map[string]any{
+			"activation": map[string]any{"type": "manual", "user_invocable": false},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DerivedCapabilitiesForItem(skill) error: %v", err)
+	}
+	wantCaps := map[string]bool{
+		"auto_invocable":           false,
+		"disable_model_invocation": true,
+		"user_invocable":           true,
+		"skill_bundled_resources":  true,
+	}
+	if !reflect.DeepEqual(caps, wantCaps) {
+		t.Fatalf("skill capabilities = %#v, want %#v", caps, wantCaps)
+	}
+}
+
+func TestSkillDeclaredMetadataMovesIndependentlyFromBody(t *testing.T) {
+	t.Parallel()
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	body := "Use this to demo classification.\n"
+	writeBodyFixture(t, dirA, map[string]string{
+		"SKILL.md": "---\nactivation:\n  type: auto\n---\n" + body,
+	})
+	writeBodyFixture(t, dirB, map[string]string{
+		"SKILL.md": "---\nactivation:\n  type: auto\n  user_invocable: true\n---\n" + body,
+	})
+	a, err := IngestFrontmatterFile("skill", dirA, "SKILL.md")
+	if err != nil {
+		t.Fatalf("IngestFrontmatterFile(a): %v", err)
+	}
+	b, err := IngestFrontmatterFile("skill", dirB, "SKILL.md")
+	if err != nil {
+		t.Fatalf("IngestFrontmatterFile(b): %v", err)
+	}
+	if a.BodyHash != b.BodyHash {
+		t.Fatalf("declared metadata changed body hash: %s != %s", a.BodyHash, b.BodyHash)
+	}
+	if a.MetadataHash == b.MetadataHash {
+		t.Fatalf("declared user_invocable did not move metadata hash: %s", a.MetadataHash)
+	}
+
+	if err := os.WriteFile(filepath.Join(dirB, "extra.md"), []byte("extra\n"), 0o644); err != nil {
+		t.Fatalf("write extra: %v", err)
+	}
+	b2, err := IngestFrontmatterFile("skill", dirB, "SKILL.md")
+	if err != nil {
+		t.Fatalf("IngestFrontmatterFile(b2): %v", err)
+	}
+	if b.MetadataHash != b2.MetadataHash {
+		t.Fatalf("bundled-resource edit moved metadata hash: %s != %s", b.MetadataHash, b2.MetadataHash)
+	}
+	if b.BodyHash == b2.BodyHash {
+		t.Fatalf("bundled-resource edit did not move body hash: %s", b.BodyHash)
+	}
+}


### PR DESCRIPTION
Stage 2 of syllago-as-ACIF-implementation-#1: the adapter now claims all five content-type scopes (`skill`, `rule`, `command`, `agent`, `mcp`) on top of `core` + `hook`.

## What's here

- Shared frontmatter-record ingestion: faithful-observation `publisher_section` + `metadata_hash` (declared form — untranslated spellings, no materialized defaults), canonical records, per-kind extension-block canonicalization.
- Per-type semantics: skill activation model, rule four-value activation enum + sub-mode mapping (adapter-scoped; shipped `RuleMeta` untouched by decision), command placeholder rewrite + advisory projection, agent tool-name canonicalization reusing `converter.ToolNames`, MCP transport materialization + sidecar-only preimage.
- New op `resolve_reference` (skill `hook_ref`, agent name-declared references); new projections `rule_activation`, `advisory`, `builtin_shadowing_advisory`.

## Conformance

Seven scopes: **core 13/13, hook fully green, agent 11/11, mcp 14/14, command 13/13 (+1 vacuous), skill 13/14, rule 12/13.**

The two failures are published-suite defects, each failing on exactly one check (`metadata_hash_unaffected_by_materialization`): the bindings compare an undeclared source against an explicitly-declared one, but declaring a previously-defaulted value moves `metadata_hash` per [ACIF-SKILL] §8.3 / [ACIF-RULE] §8.2 — and TV-SKILL-k / TV-AGENT-h force the declared-form definition, so the suite is jointly unsatisfiable as published. An upstream report accompanies this work (binding fixes, an `acif.registry.reference_unresolved` identifier mint the adapter implements pending ratification, and two consistency notes).

All 10 pinned vector hashes were re-derived independently in Python before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7tRhi8WaVhr1iMMkNNgfN
