### PR TITLE
ACIF Stage 3: publisher scope (19/19)

### DIFF
--- a/cli/cmd/acif-adapter/handlers.go
+++ b/cli/cmd/acif-adapter/handlers.go
@@ -48,10 +48,12 @@ func dispatch(req request) any {
 			"implementation":   "syllago",
 			"version":          adapterVersion,
 			"adapter_protocol": 1,
-			"scopes":           []string{"core", "hook", "skill", "rule", "command", "agent", "mcp"},
+			"scopes":           []string{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher"},
 		})
 	case "ingest":
 		return handleIngest(req.Input)
+	case "reconcile_frontmatter":
+		return handleReconcileFrontmatter(req.Input)
 	case "project":
 		return handleProject(req.Input)
 	case "render":
@@ -106,8 +108,11 @@ func handleIngest(raw json.RawMessage) any {
 		return handleProviderConfigIngest(input.Kind, input.ProviderConfig)
 	}
 	if input.Kind == "pack" {
-		if _, ok := rawInput["manifests"]; ok {
-			return unsupportedResponse()
+		if rawManifests, ok := rawInput["manifests"]; ok {
+			return handlePackManifests(rawManifests)
+		}
+		if rawSidecar, ok := rawInput["sidecar"]; ok {
+			return handlePackSidecar(rawSidecar)
 		}
 	}
 
@@ -127,6 +132,9 @@ func handleIngest(raw json.RawMessage) any {
 			result, err := acif.CanonicalizeMCP(block)
 			if err != nil {
 				return hookErrorResponse(err)
+			}
+			if err := attachEnvelopePublisher(result, block); err != nil {
+				return errorResponse("adapter: " + err.Error())
 			}
 			return okResponse(recordResponse(result))
 		}
@@ -161,6 +169,21 @@ func handleProviderConfigIngest(kind string, rawProviderConfig json.RawMessage) 
 	var config map[string]any
 	if err := decodeJSONUseNumber(rawProviderConfig, &config); err != nil {
 		return errorResponse("adapter: " + err.Error())
+	}
+	if provider, _ := config["provider"].(string); provider == "provider-native-frontmatter" && isFrontmatterKind(kind) {
+		content, ok := config["content"].(map[string]any)
+		if !ok {
+			return errorResponse("adapter: provider-native-frontmatter content must be object")
+		}
+		frontmatter, ok := content["frontmatter"].(map[string]any)
+		if !ok {
+			return errorResponse("adapter: provider-native-frontmatter frontmatter must be object")
+		}
+		result, err := acif.IngestProviderNativeFrontmatter(kind, frontmatter)
+		if err != nil {
+			return hookErrorResponse(err)
+		}
+		return okResponse(recordResponse(result))
 	}
 	switch kind {
 	case "rule":
@@ -202,6 +225,7 @@ func handleProviderConfigIngest(kind string, rawProviderConfig json.RawMessage) 
 func handleHookIngest(rawInput map[string]json.RawMessage, input ingestInput) any {
 	opts := acif.HookOpts{BodyRoot: input.BodyRoot}
 	var result *acif.HookResult
+	var sidecarBlock map[string]any
 	var err error
 	if rawProviderConfig, ok := rawInput["provider_config"]; ok {
 		var config map[string]any
@@ -214,6 +238,7 @@ func handleHookIngest(rawInput map[string]json.RawMessage, input ingestInput) an
 		if err := decodeJSONUseNumber(rawSidecar, &block); err != nil {
 			return errorResponse("adapter: " + err.Error())
 		}
+		sidecarBlock = block
 		result, err = acif.CanonicalizeHook(block, opts)
 	} else {
 		return unsupportedResponse()
@@ -251,10 +276,51 @@ func handleHookIngest(rawInput map[string]json.RawMessage, input ingestInput) an
 	if computed {
 		response["body_hash"] = bodyHash
 	}
+	if sidecarBlock != nil {
+		section := acif.EnvelopePublisherSection(sidecarBlock)
+		if section != nil {
+			rawSection, err := json.Marshal(section)
+			if err != nil {
+				return errorResponse("adapter: " + err.Error())
+			}
+			hashHex, _, err := acif.MetadataHash(rawSection)
+			if err != nil {
+				return errorResponse("adapter: " + err.Error())
+			}
+			response["publisher_section"] = section
+			response["metadata_hash"] = hashHex
+		}
+	}
 	if len(result.Diagnostics) > 0 {
 		response["diagnostics"] = result.Diagnostics
 	}
 	return okResponse(response)
+}
+
+func handlePackManifests(rawManifests json.RawMessage) any {
+	var manifests []acif.PackManifest
+	if err := json.Unmarshal(rawManifests, &manifests); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	return okResponse(acif.ReconcilePackManifests(manifests))
+}
+
+func handlePackSidecar(rawSidecar json.RawMessage) any {
+	if _, ok := parseJSONObject(rawSidecar); !ok {
+		return okResponse(map[string]any{
+			"conformant": false,
+			"reason":     "sidecar-not-object",
+		})
+	}
+	var block map[string]any
+	if err := decodeJSONUseNumber(rawSidecar, &block); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	result, err := acif.IngestPackSidecar(block)
+	if err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	return okResponse(recordResponse(result))
 }
 
 func isFrontmatterKind(kind string) bool {
@@ -308,6 +374,20 @@ func recordResponse(result *acif.RecordResult) map[string]any {
 		response["diagnostics"] = result.Diagnostics
 	}
 	return response
+}
+
+type reconcileFrontmatterInput struct {
+	SidecarValue      map[string]any `json:"sidecar_value"`
+	SourceFrontmatter map[string]any `json:"source_frontmatter"`
+	Mode              string         `json:"mode"`
+}
+
+func handleReconcileFrontmatter(raw json.RawMessage) any {
+	var input reconcileFrontmatterInput
+	if err := decodeJSONUseNumber(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	return okResponse(acif.ReconcileFrontmatter(input.SidecarValue, input.SourceFrontmatter, input.Mode))
 }
 
 type projectInput struct {
@@ -534,6 +614,24 @@ func handleSidecarIngest(rawSidecar json.RawMessage) any {
 		Reason:           verdict.Reason,
 		Installable:      verdict.Conformant,
 	})
+}
+
+func attachEnvelopePublisher(result *acif.RecordResult, block map[string]any) error {
+	section := acif.EnvelopePublisherSection(block)
+	if section == nil {
+		return nil
+	}
+	rawSection, err := json.Marshal(section)
+	if err != nil {
+		return err
+	}
+	hashHex, _, err := acif.MetadataHash(rawSection)
+	if err != nil {
+		return err
+	}
+	result.PublisherSection = section
+	result.MetadataHash = hashHex
+	return nil
 }
 
 func parseJSONObject(raw json.RawMessage) (map[string]json.RawMessage, bool) {

--- a/cli/cmd/acif-adapter/main_test.go
+++ b/cli/cmd/acif-adapter/main_test.go
@@ -57,7 +57,7 @@ func TestHello(t *testing.T) {
 			"implementation":   "syllago",
 			"version":          "0.0.0-dev",
 			"adapter_protocol": float64(1),
-			"scopes":           []any{"core", "hook", "skill", "rule", "command", "agent", "mcp"},
+			"scopes":           []any{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher"},
 		},
 	}
 	if !reflect.DeepEqual(responses[0], want) {
@@ -318,6 +318,77 @@ func TestStage2IngestProjectRenderAndResolveOps(t *testing.T) {
 		"resolution":  "resolved",
 	}) {
 		t.Fatalf("skill cross reference = %#v", cross)
+	}
+}
+
+func TestPublisherStage3NDJSON(t *testing.T) {
+	t.Parallel()
+
+	request := `{"op":"reconcile_frontmatter","input":{"sidecar_value":{"description":"canonical"},"source_frontmatter":{"description":"declared"},"mode":"default"}}` + "\n" +
+		`{"op":"reconcile_frontmatter","input":{"sidecar_value":{"description":"canonical"},"source_frontmatter":{"description":"declared"},"mode":"overwrite"}}` + "\n" +
+		`{"op":"ingest","input":{"kind":"pack","manifests":[{"source":"package.json","name":"superpowers"},{"source":"gemini-extension.json","name":"super-powers"}]}}` + "\n" +
+		`{"op":"ingest","input":{"kind":"pack","sidecar":{"source_kind":"declared"}}}` + "\n" +
+		`{"op":"ingest","input":{"kind":"pack","sidecar":{"source_kind":"inferred"}}}` + "\n" +
+		`{"op":"ingest","input":{"kind":"agent","provider_config":{"provider":"provider-native-frontmatter","content":{"frontmatter":{"tools":["Read","Task"]}}}}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 6 {
+		t.Fatalf("responses = %d, want 6", len(responses))
+	}
+
+	defaultReconcile := responses[0]["result"].(map[string]any)
+	if defaultReconcile["action"] != "block" {
+		t.Fatalf("default reconcile = %#v", defaultReconcile)
+	}
+	overwriteReconcile := responses[1]["result"].(map[string]any)
+	if overwriteReconcile["action"] != "overwrite" {
+		t.Fatalf("overwrite reconcile = %#v", overwriteReconcile)
+	}
+
+	manifest := responses[2]["result"].(map[string]any)
+	if manifest["canonical_source"] != "package.json" || manifest["canonical_display_name"] != "superpowers" {
+		t.Fatalf("pack manifest result = %#v", manifest)
+	}
+	manifestDiag := manifest["diagnostics"].([]any)[0].(map[string]any)
+	params := manifestDiag["params"].(map[string]any)
+	if !reflect.DeepEqual(params["sources"], []any{"package.json", "gemini-extension.json"}) {
+		t.Fatalf("manifest sources = %#v", params["sources"])
+	}
+	if !reflect.DeepEqual(params["values"], []any{"superpowers", "super-powers"}) {
+		t.Fatalf("manifest values = %#v", params["values"])
+	}
+
+	declaredPack := responses[3]["result"].(map[string]any)
+	if declaredPack["metadata_hash"] == "" || declaredPack["publisher_section"] == nil {
+		t.Fatalf("declared pack missing publisher hash fields: %#v", declaredPack)
+	}
+	if _, ok := declaredPack["body_hash"]; ok {
+		t.Fatalf("declared pack body_hash present: %#v", declaredPack)
+	}
+
+	inferredPack := responses[4]["result"].(map[string]any)
+	if inferredPack["conformant"] != true || inferredPack["installable"] != true {
+		t.Fatalf("inferred pack = %#v", inferredPack)
+	}
+	for _, key := range []string{"publisher_section", "metadata_hash", "body_hash"} {
+		if _, ok := inferredPack[key]; ok {
+			t.Fatalf("inferred pack has %s: %#v", key, inferredPack)
+		}
+	}
+
+	agent := responses[5]["result"].(map[string]any)
+	publisherTools := agent["publisher_section"].(map[string]any)["agent"].(map[string]any)["tools"]
+	if !reflect.DeepEqual(publisherTools, []any{"Read", "Task"}) {
+		t.Fatalf("publisher tools = %#v", publisherTools)
+	}
+	canonicalTools := agent["canonical"].(map[string]any)["agent"].(map[string]any)["tools"]
+	if !reflect.DeepEqual(canonicalTools, []any{"file_read", "agent"}) {
+		t.Fatalf("canonical tools = %#v", canonicalTools)
+	}
+	if agent["metadata_hash"] == "" {
+		t.Fatalf("agent metadata_hash missing: %#v", agent)
+	}
+	if _, ok := agent["body_hash"]; ok {
+		t.Fatalf("agent body_hash present: %#v", agent)
 	}
 }
 

--- a/cli/internal/acif/publisher.go
+++ b/cli/internal/acif/publisher.go
@@ -1,0 +1,228 @@
+package acif
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+const (
+	DiagPublisherPackSourceConflict  = "acif.publisher.pack_source_conflict"
+	DiagPublisherFrontmatterConflict = "acif.publisher.frontmatter_conflict"
+)
+
+type PackManifest struct {
+	Source string `json:"source"`
+	Name   string `json:"name"`
+}
+
+type PackManifestReconciliation struct {
+	CanonicalSource      string       `json:"canonical_source,omitempty"`
+	CanonicalDisplayName string       `json:"canonical_display_name,omitempty"`
+	Diagnostics          []Diagnostic `json:"diagnostics,omitempty"`
+}
+
+func ReconcilePackManifests(manifests []PackManifest) PackManifestReconciliation {
+	precedence := map[string]int{
+		"package.json":               0,
+		".claude-plugin/plugin.json": 1,
+		".cursor-plugin/plugin.json": 2,
+		".codex-plugin/plugin.json":  3,
+		"gemini-extension.json":      4,
+	}
+	bestRank := len(precedence) + len(manifests) + 1
+	bestIndex := -1
+	sources := make([]string, 0, len(manifests))
+	values := make([]string, 0, len(manifests))
+	for i, manifest := range manifests {
+		name := strings.TrimSpace(manifest.Name)
+		if name == "" {
+			continue
+		}
+		rank, ok := precedence[manifest.Source]
+		if !ok {
+			rank = len(precedence) + i
+		}
+		if rank < bestRank {
+			bestRank = rank
+			bestIndex = i
+		}
+		sources = append(sources, manifest.Source)
+		values = append(values, name)
+	}
+
+	result := PackManifestReconciliation{}
+	if bestIndex >= 0 {
+		result.CanonicalSource = manifests[bestIndex].Source
+		result.CanonicalDisplayName = strings.TrimSpace(manifests[bestIndex].Name)
+	}
+	if len(values) >= 2 {
+		first := values[0]
+		for _, value := range values[1:] {
+			if value != first {
+				result.Diagnostics = []Diagnostic{{
+					ID: DiagPublisherPackSourceConflict,
+					Params: map[string]any{
+						"sources": sources,
+						"values":  values,
+					},
+				}}
+				break
+			}
+		}
+	}
+	return result
+}
+
+type FrontmatterReconcileResult struct {
+	Action      string       `json:"action"`
+	Diagnostics []Diagnostic `json:"diagnostics,omitempty"`
+}
+
+func ReconcileFrontmatter(sidecarValue, sourceFrontmatter map[string]any, mode string) FrontmatterReconcileResult {
+	if sidecarValue == nil {
+		sidecarValue = map[string]any{}
+	}
+	if sourceFrontmatter == nil {
+		sourceFrontmatter = map[string]any{}
+	}
+	action := "leave-untouched"
+	var diagnostics []Diagnostic
+
+	fields := make([]string, 0, len(sidecarValue))
+	for field := range sidecarValue {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	for _, field := range fields {
+		canonical := sidecarValue[field]
+		declared, present := sourceFrontmatter[field]
+		switch {
+		case !present:
+			action = strongestFrontmatterAction(action, "add-silently")
+		case reflect.DeepEqual(declared, canonical):
+			action = strongestFrontmatterAction(action, "leave-untouched")
+		case mode == "overwrite":
+			action = strongestFrontmatterAction(action, "overwrite")
+			diagnostics = append(diagnostics, frontmatterConflictDiagnostic(field, declared, canonical))
+		default:
+			action = strongestFrontmatterAction(action, "block")
+			diagnostics = append(diagnostics, frontmatterConflictDiagnostic(field, declared, canonical))
+		}
+	}
+
+	return FrontmatterReconcileResult{Action: action, Diagnostics: diagnostics}
+}
+
+func strongestFrontmatterAction(current, candidate string) string {
+	rank := map[string]int{
+		"leave-untouched": 0,
+		"add-silently":    1,
+		"overwrite":       2,
+		"block":           3,
+	}
+	if rank[candidate] > rank[current] {
+		return candidate
+	}
+	return current
+}
+
+func frontmatterConflictDiagnostic(field string, declared, canonical any) Diagnostic {
+	return Diagnostic{
+		ID: DiagPublisherFrontmatterConflict,
+		Params: map[string]any{
+			"field":     field,
+			"declared":  cloneJSONValue(declared),
+			"canonical": cloneJSONValue(canonical),
+		},
+	}
+}
+
+func EnvelopePublisherSection(sidecar map[string]any) map[string]any {
+	section := make(map[string]any)
+	for key, value := range sidecar {
+		if envelopeKeys[key] {
+			section[key] = cloneJSONValue(value)
+		}
+	}
+	if len(section) == 0 {
+		return nil
+	}
+	return section
+}
+
+func IngestPackSidecar(sidecar map[string]any) (*RecordResult, error) {
+	if sidecar == nil {
+		sidecar = map[string]any{}
+	}
+	if packSourceKind(sidecar) == "inferred" {
+		return &RecordResult{Conformant: true, Installable: true}, nil
+	}
+
+	section := cloneJSONValue(sidecar).(map[string]any)
+	raw, err := json.Marshal(section)
+	if err != nil {
+		return nil, err
+	}
+	hashHex, _, err := MetadataHash(raw)
+	if err != nil {
+		return nil, err
+	}
+	return &RecordResult{
+		Conformant:       true,
+		Installable:      true,
+		PublisherSection: section,
+		MetadataHash:     hashHex,
+	}, nil
+}
+
+func packSourceKind(sidecar map[string]any) string {
+	if sourceKind, _ := sidecar["source_kind"].(string); sourceKind != "" {
+		return sourceKind
+	}
+	pack, _ := sidecar["pack"].(map[string]any)
+	sourceKind, _ := pack["source_kind"].(string)
+	return sourceKind
+}
+
+func IngestProviderNativeFrontmatter(kind string, frontmatter map[string]any) (*RecordResult, error) {
+	if frontmatter == nil {
+		frontmatter = map[string]any{}
+	}
+	extension := extensionBlockFromFrontmatter(frontmatter)
+	item, err := canonicalizeExtension(kind, extension, "")
+	if err != nil {
+		return nil, err
+	}
+	if item.Canonical == nil {
+		item.Canonical = map[string]any{}
+	}
+	section := publisherSection(kind, frontmatter)
+	raw, err := json.Marshal(section)
+	if err != nil {
+		return nil, err
+	}
+	hashHex, _, err := MetadataHash(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &RecordResult{
+		Conformant:  true,
+		Installable: true,
+		Canonical: map[string]any{
+			"kind":        kind,
+			kindKey(kind): item.Canonical,
+		},
+		PublisherSection: section,
+		MetadataHash:     hashHex,
+		Diagnostics:      item.Diagnostics,
+	}
+	if item.Verdict != nil {
+		result.Conformant = false
+		result.Installable = false
+		result.Reason = item.Verdict.Reason
+	}
+	return result, nil
+}

--- a/cli/internal/acif/publisher_test.go
+++ b/cli/internal/acif/publisher_test.go
@@ -1,0 +1,303 @@
+package acif
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestPackManifestReconciliation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("winner follows source precedence", func(t *testing.T) {
+		t.Parallel()
+		got := ReconcilePackManifests([]PackManifest{
+			{Source: ".codex-plugin/plugin.json", Name: "superpowers"},
+			{Source: "package.json", Name: "superpowers"},
+			{Source: "gemini-extension.json", Name: "superpowers"},
+		})
+		if got.CanonicalSource != "package.json" || got.CanonicalDisplayName != "superpowers" {
+			t.Fatalf("ReconcilePackManifests() = %+v, want package.json/superpowers", got)
+		}
+		if len(got.Diagnostics) != 0 {
+			t.Fatalf("diagnostics = %#v, want none", got.Diagnostics)
+		}
+	})
+
+	t.Run("empty name falls through", func(t *testing.T) {
+		t.Parallel()
+		got := ReconcilePackManifests([]PackManifest{
+			{Source: "package.json", Name: " \t\n"},
+			{Source: ".codex-plugin/plugin.json", Name: " codex-pack "},
+			{Source: "gemini-extension.json", Name: "gemini-pack"},
+		})
+		if got.CanonicalSource != ".codex-plugin/plugin.json" || got.CanonicalDisplayName != "codex-pack" {
+			t.Fatalf("ReconcilePackManifests() = %+v, want codex plugin/codex-pack", got)
+		}
+		if len(got.Diagnostics) != 1 {
+			t.Fatalf("diagnostics = %#v, want conflict from non-empty names", got.Diagnostics)
+		}
+	})
+
+	t.Run("conflict diagnostic preserves input order", func(t *testing.T) {
+		t.Parallel()
+		got := ReconcilePackManifests([]PackManifest{
+			{Source: "package.json", Name: "superpowers"},
+			{Source: "gemini-extension.json", Name: "super-powers"},
+		})
+		if got.CanonicalSource != "package.json" || got.CanonicalDisplayName != "superpowers" {
+			t.Fatalf("ReconcilePackManifests() = %+v, want package.json/superpowers", got)
+		}
+		if len(got.Diagnostics) != 1 || got.Diagnostics[0].ID != "acif.publisher.pack_source_conflict" {
+			t.Fatalf("diagnostics = %#v, want one pack_source_conflict", got.Diagnostics)
+		}
+		if !reflect.DeepEqual(got.Diagnostics[0].Params["sources"], []string{"package.json", "gemini-extension.json"}) {
+			t.Fatalf("sources = %#v", got.Diagnostics[0].Params["sources"])
+		}
+		if !reflect.DeepEqual(got.Diagnostics[0].Params["values"], []string{"superpowers", "super-powers"}) {
+			t.Fatalf("values = %#v", got.Diagnostics[0].Params["values"])
+		}
+	})
+
+	t.Run("no conflict for equal trimmed names", func(t *testing.T) {
+		t.Parallel()
+		got := ReconcilePackManifests([]PackManifest{
+			{Source: "package.json", Name: " superpowers "},
+			{Source: "gemini-extension.json", Name: "superpowers"},
+		})
+		if got.CanonicalSource != "package.json" || got.CanonicalDisplayName != "superpowers" {
+			t.Fatalf("ReconcilePackManifests() = %+v, want package.json/superpowers", got)
+		}
+		if len(got.Diagnostics) != 0 {
+			t.Fatalf("diagnostics = %#v, want none", got.Diagnostics)
+		}
+	})
+}
+
+func TestReconcileFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		side   map[string]any
+		source map[string]any
+		mode   string
+		action string
+		diags  int
+	}{
+		{
+			name:   "default absent adds silently",
+			side:   map[string]any{"description": "demo"},
+			source: map[string]any{},
+			mode:   "default",
+			action: "add-silently",
+		},
+		{
+			name:   "overwrite absent adds silently",
+			side:   map[string]any{"description": "demo"},
+			source: map[string]any{},
+			mode:   "overwrite",
+			action: "add-silently",
+		},
+		{
+			name:   "default equal leaves untouched",
+			side:   map[string]any{"tools": []any{"Read", "Task"}},
+			source: map[string]any{"tools": []any{"Read", "Task"}},
+			mode:   "default",
+			action: "leave-untouched",
+		},
+		{
+			name:   "overwrite equal leaves untouched",
+			side:   map[string]any{"tools": []any{"Read", "Task"}},
+			source: map[string]any{"tools": []any{"Read", "Task"}},
+			mode:   "overwrite",
+			action: "leave-untouched",
+		},
+		{
+			name:   "default conflict blocks",
+			side:   map[string]any{"description": "canonical"},
+			source: map[string]any{"description": "declared"},
+			mode:   "default",
+			action: "block",
+			diags:  1,
+		},
+		{
+			name:   "overwrite conflict overwrites",
+			side:   map[string]any{"description": "canonical"},
+			source: map[string]any{"description": "declared"},
+			mode:   "overwrite",
+			action: "overwrite",
+			diags:  1,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ReconcileFrontmatter(tc.side, tc.source, tc.mode)
+			if got.Action != tc.action || len(got.Diagnostics) != tc.diags {
+				t.Fatalf("ReconcileFrontmatter() = %+v, want action=%q diagnostics=%d", got, tc.action, tc.diags)
+			}
+			if tc.diags > 0 {
+				diag := got.Diagnostics[0]
+				if diag.ID != "acif.publisher.frontmatter_conflict" {
+					t.Fatalf("diagnostic ID = %q", diag.ID)
+				}
+				if diag.Params["field"] != "description" || diag.Params["declared"] != "declared" || diag.Params["canonical"] != "canonical" {
+					t.Fatalf("diagnostic params = %#v", diag.Params)
+				}
+			}
+		})
+	}
+
+	t.Run("multiple fields choose strongest action", func(t *testing.T) {
+		t.Parallel()
+		block := ReconcileFrontmatter(
+			map[string]any{"a": "new", "b": "canonical", "c": "same"},
+			map[string]any{"b": "declared", "c": "same"},
+			"default",
+		)
+		if block.Action != "block" {
+			t.Fatalf("default action = %q, want block", block.Action)
+		}
+
+		overwrite := ReconcileFrontmatter(
+			map[string]any{"a": "new", "b": "canonical", "c": "same"},
+			map[string]any{"b": "declared", "c": "same"},
+			"overwrite",
+		)
+		if overwrite.Action != "overwrite" {
+			t.Fatalf("overwrite action = %q, want overwrite", overwrite.Action)
+		}
+	})
+}
+
+func TestEnvelopePublisherSectionForHookSidecar(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"kind":         "hook",
+		"id":           "550e8400-e29b-41d4-a716-446655440000",
+		"display_name": "Run Checks",
+		"pack_id":      "11111111-1111-4111-8111-111111111111",
+		"hook": map[string]any{
+			"event": "before_tool_execute",
+			"handlers": []any{
+				map[string]any{"scripts": []any{map[string]any{"type": "inline", "content": "#!/bin/sh\nexit 0\n"}}},
+			},
+		},
+	}
+	edited := cloneJSONValue(base).(map[string]any)
+	edited["display_name"] = "Run Checks Now"
+
+	section := EnvelopePublisherSection(base)
+	keys := make([]string, 0, len(section))
+	for key := range section {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if !reflect.DeepEqual(keys, []string{"display_name", "id", "kind", "pack_id"}) {
+		t.Fatalf("publisher_section keys = %#v", keys)
+	}
+	if _, ok := section["hook"]; ok {
+		t.Fatalf("publisher_section includes hook extension: %#v", section)
+	}
+
+	hash := metadataHashForMap(t, section)
+	editedHash := metadataHashForMap(t, EnvelopePublisherSection(edited))
+	if hash == editedHash {
+		t.Fatalf("display_name edit did not move metadata_hash: %s", hash)
+	}
+
+	baseHook, err := CanonicalizeHook(base, HookOpts{})
+	if err != nil {
+		t.Fatalf("CanonicalizeHook(base): %v", err)
+	}
+	editedHook, err := CanonicalizeHook(edited, HookOpts{})
+	if err != nil {
+		t.Fatalf("CanonicalizeHook(edited): %v", err)
+	}
+	baseBody := hookHash(t, baseHook.Canonical, "")
+	editedBody := hookHash(t, editedHook.Canonical, "")
+	if baseBody != editedBody {
+		t.Fatalf("display_name edit moved body_hash: %s != %s", baseBody, editedBody)
+	}
+}
+
+func TestPackSidecarHashing(t *testing.T) {
+	t.Parallel()
+
+	declared, err := IngestPackSidecar(map[string]any{"source_kind": "declared"})
+	if err != nil {
+		t.Fatalf("IngestPackSidecar(declared): %v", err)
+	}
+	if !declared.Conformant || !declared.Installable {
+		t.Fatalf("declared conformant/installable = %#v/%#v", declared.Conformant, declared.Installable)
+	}
+	if !reflect.DeepEqual(declared.PublisherSection, map[string]any{"source_kind": "declared"}) {
+		t.Fatalf("declared publisher_section = %#v", declared.PublisherSection)
+	}
+	if declared.MetadataHash == "" {
+		t.Fatalf("declared metadata_hash is empty")
+	}
+	if declared.BodyHash != "" {
+		t.Fatalf("declared body_hash = %q, want empty", declared.BodyHash)
+	}
+
+	inferred, err := IngestPackSidecar(map[string]any{"source_kind": "inferred"})
+	if err != nil {
+		t.Fatalf("IngestPackSidecar(inferred): %v", err)
+	}
+	if !inferred.Conformant || !inferred.Installable {
+		t.Fatalf("inferred conformant/installable = %#v/%#v", inferred.Conformant, inferred.Installable)
+	}
+	if inferred.PublisherSection != nil || inferred.MetadataHash != "" || inferred.BodyHash != "" {
+		t.Fatalf("inferred hash fields = publisher_section:%#v metadata_hash:%q body_hash:%q",
+			inferred.PublisherSection, inferred.MetadataHash, inferred.BodyHash)
+	}
+}
+
+func TestProviderNativeFrontmatterAgent(t *testing.T) {
+	t.Parallel()
+
+	got, err := IngestProviderNativeFrontmatter("agent", map[string]any{
+		"tools": []any{"Read", "Task"},
+	})
+	if err != nil {
+		t.Fatalf("IngestProviderNativeFrontmatter(agent): %v", err)
+	}
+	if !got.Conformant || !got.Installable {
+		t.Fatalf("conformant/installable = %#v/%#v", got.Conformant, got.Installable)
+	}
+	publisherAgent, ok := got.PublisherSection["agent"].(map[string]any)
+	if !ok {
+		t.Fatalf("publisher_section.agent = %#v", got.PublisherSection["agent"])
+	}
+	if !reflect.DeepEqual(publisherAgent["tools"], []any{"Read", "Task"}) {
+		t.Fatalf("publisher tools = %#v, want declared spellings", publisherAgent["tools"])
+	}
+	canonicalAgent, ok := got.Canonical["agent"].(map[string]any)
+	if !ok {
+		t.Fatalf("canonical.agent = %#v", got.Canonical["agent"])
+	}
+	if !reflect.DeepEqual(canonicalAgent["tools"], []any{"file_read", "agent"}) {
+		t.Fatalf("canonical tools = %#v, want translated names", canonicalAgent["tools"])
+	}
+	if got.MetadataHash == "" || got.BodyHash != "" {
+		t.Fatalf("hash fields = metadata_hash:%q body_hash:%q", got.MetadataHash, got.BodyHash)
+	}
+}
+
+func metadataHashForMap(t *testing.T, section map[string]any) string {
+	t.Helper()
+	raw, err := json.Marshal(section)
+	if err != nil {
+		t.Fatalf("marshal publisher_section: %v", err)
+	}
+	hash, _, err := MetadataHash(raw)
+	if err != nil {
+		t.Fatalf("MetadataHash(): %v", err)
+	}
+	return hash
+}


### PR DESCRIPTION
Stage 3 of syllago-as-ACIF-implementation-#1: the adapter now claims the `publisher` scope — eight of ten scopes implemented.

## What's here

- `cli/internal/acif/publisher.go`: envelope-only `publisher_section` for sidecar-only kinds (§5.2), pack-record hashing rules (§8.2), pack-manifest reconciliation with the §9.1 precedence table and pinned-params conflict diagnostic, the §7 frontmatter reconciliation matrix, and the `provider-native-frontmatter` ingest form (faithful observation, §5.3).
- Adapter: new op `reconcile_frontmatter`; `kind: pack` sidecar + manifests ingest branches; hook/MCP sidecar ingests now attach envelope-only publisher metadata.

## Conformance

Eight scopes: **all fully green** — publisher 19/19 (TV-1..13 + TV-L2-a..f), everything prior unchanged. First stage with zero suite defects found.

Remaining for graduation: registry (Stage 4), render (Stage 5), then the single all-scope run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7tRhi8WaVhr1iMMkNNgfN
