### PR TITLE
ACIF Stage 4: registry scope (45/45)

### DIFF
--- a/cli/cmd/acif-adapter/handlers.go
+++ b/cli/cmd/acif-adapter/handlers.go
@@ -48,10 +48,18 @@ func dispatch(req request) any {
 			"implementation":   "syllago",
 			"version":          adapterVersion,
 			"adapter_protocol": 1,
-			"scopes":           []string{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher"},
+			"scopes":           []string{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher", "registry"},
 		})
 	case "ingest":
 		return handleIngest(req.Input)
+	case "normalize_uri":
+		return handleNormalizeURI(req.Input)
+	case "fetch_uri":
+		return handleFetchURI(req.Input)
+	case "derive_url_name":
+		return handleDeriveURLName(req.Input)
+	case "evaluate_freshness":
+		return handleEvaluateFreshness(req.Input)
 	case "reconcile_frontmatter":
 		return handleReconcileFrontmatter(req.Input)
 	case "project":
@@ -146,6 +154,16 @@ func handleIngest(raw json.RawMessage) any {
 					"reason":     "sidecar-not-object",
 				})
 			}
+			var sidecarValue map[string]any
+			if err := decodeJSONUseNumber(input.Sidecar, &sidecarValue); err != nil {
+				return errorResponse("adapter: " + err.Error())
+			}
+			if result, handled, err := acif.ValidateRegistryEmitSidecar(sidecarValue); handled {
+				if err != nil {
+					return hookErrorResponse(err)
+				}
+				return okResponse(result)
+			}
 			if _, ok := sidecar[input.Kind]; !ok {
 				return handleSidecarIngest(input.Sidecar)
 			}
@@ -163,6 +181,80 @@ func handleIngest(raw json.RawMessage) any {
 	}
 
 	return unsupportedResponse()
+}
+
+type normalizeURIInput struct {
+	URI string `json:"uri"`
+}
+
+func handleNormalizeURI(raw json.RawMessage) any {
+	var input normalizeURIInput
+	if err := decodeJSONUseNumber(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	normalized, err := acif.NormalizeSourceURI(input.URI)
+	if err != nil {
+		return hookErrorResponse(err)
+	}
+	return okResponse(map[string]any{"source_uri": normalized})
+}
+
+type fetchURIInput struct {
+	URL     string            `json:"url"`
+	TrustCA string            `json:"trust_ca"`
+	Resolve map[string]string `json:"resolve"`
+}
+
+func handleFetchURI(raw json.RawMessage) any {
+	var input fetchURIInput
+	if err := decodeJSONUseNumber(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	if input.Resolve == nil {
+		input.Resolve = map[string]string{}
+	}
+	sourceURI, err := acif.FetchSourceURI(input.URL, input.TrustCA, input.Resolve)
+	if err != nil {
+		return hookErrorResponse(err)
+	}
+	return okResponse(map[string]any{"source_uri": sourceURI})
+}
+
+type deriveURLNameInput struct {
+	URI                string  `json:"uri"`
+	BodyClassification string  `json:"body_classification"`
+	FrontmatterName    *string `json:"frontmatter_name"`
+}
+
+func handleDeriveURLName(raw json.RawMessage) any {
+	var input deriveURLNameInput
+	if err := decodeJSONUseNumber(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	result, err := acif.DeriveURLName(input.URI, input.BodyClassification, derefString(input.FrontmatterName))
+	if err != nil {
+		return hookErrorResponse(err)
+	}
+	return okResponse(result)
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func handleEvaluateFreshness(raw json.RawMessage) any {
+	var input acif.FreshnessInput
+	if err := decodeJSONUseNumber(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+	result, err := acif.EvaluateFreshness(input)
+	if err != nil {
+		return hookErrorResponse(err)
+	}
+	return okResponse(result)
 }
 
 func handleProviderConfigIngest(kind string, rawProviderConfig json.RawMessage) any {
@@ -405,9 +497,32 @@ func handleProject(raw json.RawMessage) any {
 		return errorResponse("adapter: " + err.Error())
 	}
 	switch input.Projection {
-	case "script_selection", "derived_capabilities", "os_coverage", "rule_activation", "advisory", "builtin_shadowing_advisory":
+	case "script_selection", "derived_capabilities", "os_coverage", "rule_activation", "advisory", "builtin_shadowing_advisory", "tuple_endpoint", "install_scope_capabilities":
 	default:
 		return unsupportedResponse()
+	}
+	if input.Projection == "tuple_endpoint" || input.Projection == "install_scope_capabilities" {
+		item, err := decodeProjectItem(input.Item)
+		if err != nil {
+			return errorResponse("adapter: " + err.Error())
+		}
+		switch input.Projection {
+		case "tuple_endpoint":
+			return okResponse(map[string]any{"projection": acif.TupleEndpointProjection(item)})
+		case "install_scope_capabilities":
+			return okResponse(acif.ValidateInstallScopeCapabilities(item))
+		}
+	}
+	if input.Projection == "advisory" {
+		item, err := decodeProjectItem(input.Item)
+		if err != nil {
+			return errorResponse("adapter: " + err.Error())
+		}
+		if _, hasCommand := item["command"]; !hasCommand {
+			if _, hasBody := item["body"]; !hasBody {
+				return okResponse(acif.ValidateRegistryAdvisory(item))
+			}
+		}
 	}
 	block, err := decodeHookBlockInput(input.Item, input.Canonical, input.Hook, input.Sidecar)
 	if err != nil {
@@ -453,6 +568,17 @@ func handleProject(raw json.RawMessage) any {
 	default:
 		return unsupportedResponse()
 	}
+}
+
+func decodeProjectItem(raw json.RawMessage) (map[string]any, error) {
+	var item map[string]any
+	if len(raw) == 0 || string(raw) == "null" {
+		return map[string]any{}, nil
+	}
+	if err := decodeJSONUseNumber(raw, &item); err != nil {
+		return nil, err
+	}
+	return item, nil
 }
 
 type renderInput struct {
@@ -518,15 +644,33 @@ func handleEvaluateInstall(raw json.RawMessage) any {
 	if err := json.Unmarshal(raw, &input); err != nil {
 		return errorResponse("adapter: " + err.Error())
 	}
-	block, err := decodeHookBlockInput(input.Item, nil, nil, nil)
+	item, err := decodeProjectItem(input.Item)
 	if err != nil {
 		return errorResponse("adapter: " + err.Error())
 	}
-	result, err := acif.EvaluateInstall(block, input.InstallTargetOS)
+	if result, handled := acif.EvaluateRegistryInstallCrossReferences(item); handled {
+		return okResponse(result)
+	}
+	if !isHookInstallItem(item) {
+		return okResponse(map[string]any{"install": "proceed"})
+	}
+	result, err := acif.EvaluateInstall(item, input.InstallTargetOS)
 	if err != nil {
 		return hookErrorResponse(err)
 	}
 	return okResponse(result)
+}
+
+func isHookInstallItem(item map[string]any) bool {
+	if item == nil {
+		return false
+	}
+	for _, key := range []string{"hook", "event", "handlers"} {
+		if _, ok := item[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func handleEvaluateRequires(raw json.RawMessage) any {

--- a/cli/cmd/acif-adapter/main_test.go
+++ b/cli/cmd/acif-adapter/main_test.go
@@ -3,6 +3,10 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"encoding/pem"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -57,7 +61,7 @@ func TestHello(t *testing.T) {
 			"implementation":   "syllago",
 			"version":          "0.0.0-dev",
 			"adapter_protocol": float64(1),
-			"scopes":           []any{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher"},
+			"scopes":           []any{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher", "registry"},
 		},
 	}
 	if !reflect.DeepEqual(responses[0], want) {
@@ -392,6 +396,108 @@ func TestPublisherStage3NDJSON(t *testing.T) {
 	}
 }
 
+func TestRegistryStage4NDJSONOps(t *testing.T) {
+	t.Parallel()
+
+	request := `{"op":"normalize_uri","input":{"uri":"HTTPS://GitHub.IO/A%3ab"}}` + "\n" +
+		`{"op":"normalize_uri","input":{"uri":"https://example.com/x?token=secret"}}` + "\n" +
+		`{"op":"derive_url_name","input":{"uri":"https://example.com/skills/my-skill.md","body_classification":"single-file","frontmatter_name":"declared"}}` + "\n" +
+		`{"op":"evaluate_freshness","input":{"record":{"fetched_at":"2026-05-01T00:00:00Z","expires":"2026-05-02T00:00:00Z"},"consumer_clock":"2026-05-03T00:00:00Z","policies":["freshness-enforcement-opt-in"]}}` + "\n" +
+		`{"op":"project","input":{"projection":"tuple_endpoint","item":{"pack_members":[{"item_id":"one","publisher_section":"present"},{"item_id":"two","publisher_section":"absent"}]}}}` + "\n" +
+		`{"op":"project","input":{"projection":"install_scope_capabilities","item":{"filesystem":{"read":true}}}}` + "\n" +
+		`{"op":"project","input":{"projection":"advisory","item":{"warning":{"text":"needs review"}}}}` + "\n" +
+		`{"op":"evaluate_install","input":{"item":{"cross_references":[{"resolution":"revoked"}]}}}` + "\n" +
+		`{"op":"evaluate_install","input":{"item":{"registry_section":{"source_uri":"https://example.com/skill.md"}}}}` + "\n" +
+		`{"op":"ingest","input":{"kind":"skill","sidecar":{"registry_section":{"source_uri":"https://example.com/skill.md"}}}}` + "\n" +
+		`{"op":"ingest","input":{"kind":"skill","sidecar":{"registry_section":{}}}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 11 {
+		t.Fatalf("responses = %d, want 11", len(responses))
+	}
+
+	normalized := responses[0]["result"].(map[string]any)
+	if normalized["source_uri"] != "https://github.io/A%3Ab" {
+		t.Fatalf("normalize_uri success = %#v", normalized)
+	}
+	if responses[1]["ok"] != false || responses[1]["error"] != "acif.source_uri.query_present" {
+		t.Fatalf("normalize_uri query error = %#v", responses[1])
+	}
+
+	name := responses[2]["result"].(map[string]any)
+	if name["url_derived_name"] != "my-skill" {
+		t.Fatalf("derive_url_name = %#v", name)
+	}
+	diag := name["diagnostics"].([]any)[0].(map[string]any)
+	if diag["id"] != "acif.source_uri.filename_conflict" {
+		t.Fatalf("derive_url_name diagnostics = %#v", name["diagnostics"])
+	}
+
+	freshness := responses[3]["result"].(map[string]any)
+	if freshness["staleness"] != "stale" || freshness["install"] != "refuse" || freshness["response_hash"] == "" {
+		t.Fatalf("evaluate_freshness = %#v", freshness)
+	}
+	if _, ok := freshness["combined_scalar"]; ok {
+		t.Fatalf("evaluate_freshness combined_scalar present: %#v", freshness)
+	}
+
+	tuple := responses[4]["result"].(map[string]any)["projection"].(map[string]any)
+	if tuple["member_1"].(map[string]any)["metadata_hash"] != "present" || tuple["member_2"].(map[string]any)["metadata_hash"] != nil {
+		t.Fatalf("tuple endpoint = %#v", tuple)
+	}
+	scopeVerdict := responses[5]["result"].(map[string]any)
+	if scopeVerdict["conformant"] != false || scopeVerdict["reason"] != "acif.registry.provenance_tag_missing" {
+		t.Fatalf("install scope capabilities = %#v", scopeVerdict)
+	}
+	advisoryVerdict := responses[6]["result"].(map[string]any)
+	if advisoryVerdict["conformant"] != false || advisoryVerdict["reason"] != "acif.registry.method_stamp_missing" {
+		t.Fatalf("registry advisory = %#v", advisoryVerdict)
+	}
+
+	if got := responses[7]["result"].(map[string]any)["install"]; got != "refuse-unless-operator-opt-in" {
+		t.Fatalf("evaluate_install cross refs = %#v", responses[7])
+	}
+	if got := responses[8]["result"].(map[string]any)["install"]; got != "proceed" {
+		t.Fatalf("evaluate_install non-hook = %#v", responses[8])
+	}
+	if result := responses[9]["result"].(map[string]any); result["conformant"] != true {
+		t.Fatalf("registry emit valid = %#v", result)
+	}
+	if responses[10]["ok"] != false || responses[10]["error"] != "acif.source_uri.missing" {
+		t.Fatalf("registry emit missing source_uri = %#v", responses[10])
+	}
+}
+
+func TestRegistryStage4FetchURINDJSON(t *testing.T) {
+	t.Parallel()
+
+	server, trustCA := newAdapterTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/start":
+			w.Header().Set("Location", "/target")
+			w.WriteHeader(http.StatusMovedPermanently)
+		case "/target":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer server.Close()
+
+	request := `{"op":"fetch_uri","input":{"url":"https://127.0.0.1/start","trust_ca":` + mustJSON(t, trustCA) + `,"resolve":{"127.0.0.1":` + mustJSON(t, server.Listener.Addr().String()) + `}}}` + "\n"
+	responses := runLines(t, request)
+	if len(responses) != 1 {
+		t.Fatalf("responses = %d, want 1", len(responses))
+	}
+	result := responses[0]["result"].(map[string]any)
+	if result["source_uri"] != "https://127.0.0.1/target" {
+		t.Fatalf("fetch_uri = %#v", responses[0])
+	}
+	if _, ok := result["source_status"]; ok {
+		t.Fatalf("fetch_uri emitted source_status: %#v", result)
+	}
+}
+
 func TestUnknownOpUnsupported(t *testing.T) {
 	t.Parallel()
 	responses := runLines(t, `{"op":"not_real","input":{}}`+"\n")
@@ -444,4 +550,30 @@ func mustJSON(t *testing.T, v any) string {
 		t.Fatalf("json marshal: %v", err)
 	}
 	return string(data)
+}
+
+func newAdapterTLSServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, string) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("sandbox blocks local sockets: %v", err)
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.Listener = ln
+	server.StartTLS()
+
+	cert := server.Certificate()
+	if cert == nil {
+		t.Fatal("test TLS server has no certificate")
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	if pemBytes == nil {
+		t.Fatal("encoding test TLS certificate PEM")
+	}
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(path, pemBytes, 0o644); err != nil {
+		t.Fatalf("write trust CA: %v", err)
+	}
+	return server, path
 }

--- a/cli/internal/acif/diagnostics.go
+++ b/cli/internal/acif/diagnostics.go
@@ -69,6 +69,24 @@ const (
 	DiagMCPServerNameUnconventional    = "acif.mcp.server_name_unconventional"
 	DiagRegistryReferenceUnresolved    = "acif.registry.reference_unresolved"
 
+	ErrSourceURIMissing                 = "acif.source_uri.missing"
+	ErrSourceURIMalformed               = "acif.source_uri.malformed"
+	ErrSourceURISchemeForbidden         = "acif.source_uri.scheme_forbidden"
+	ErrSourceURIUserinfoPresent         = "acif.source_uri.userinfo_present"
+	ErrSourceURIQueryPresent            = "acif.source_uri.query_present"
+	ErrSourceURIRedirectDowngrade       = "acif.source_uri.redirect_downgrade"
+	ErrSourceURIRedirectLimit           = "acif.source_uri.redirect_limit"
+	ErrSourceURIDirectFileTrailingSlash = "acif.source_uri.direct_file_trailing_slash"
+	ErrSourceURIFilenameConflict        = "acif.source_uri.filename_conflict"
+
+	ErrRegistryExpiresBeforeFetchedAt = "acif.registry.expires_before_fetched_at"
+	ErrRegistryStale                  = "acif.registry.stale"
+
 	ReasonRequiresOrphanKey            = "acif.requires.orphan_key"
 	ReasonCommandHandlerScriptsMissing = "command-handler-scripts-missing"
+
+	ReasonRegistryTimestampOffsetMissing         = "acif.registry.timestamp_offset_missing"
+	ReasonRegistryMethodStampMissing             = "acif.registry.method_stamp_missing"
+	ReasonRegistryProvenanceTagMissing           = "acif.registry.provenance_tag_missing"
+	ReasonResponseEnvelopeClockNotStalenessInput = "response-envelope-clock-is-not-a-staleness-input"
 )

--- a/cli/internal/acif/fetch.go
+++ b/cli/internal/acif/fetch.go
@@ -1,0 +1,146 @@
+package acif
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+func FetchSourceURI(seed, trustCAPath string, resolve map[string]string) (string, error) {
+	recorded, err := NormalizeSourceURI(seed)
+	if err != nil {
+		return "", err
+	}
+	current, err := url.Parse(seed)
+	if err != nil {
+		return "", &RejectError{ID: ErrSourceURIMalformed, Detail: err.Error()}
+	}
+
+	transport, err := fetchTransport(trustCAPath, resolve)
+	if err != nil {
+		return "", err
+	}
+	defer transport.CloseIdleConnections()
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   10 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	frozen := false
+	visited := map[string]bool{recorded: true}
+	for hop := 0; ; hop++ {
+		resp, err := client.Get(current.String())
+		if err != nil {
+			return "", err
+		}
+
+		status := resp.StatusCode
+		if !isRedirectStatus(status) {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			break
+		}
+
+		location := resp.Header.Get("Location")
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if location == "" {
+			return "", fmt.Errorf("redirect missing Location")
+		}
+		ref, err := url.Parse(location)
+		if err != nil {
+			return "", err
+		}
+		next := current.ResolveReference(ref)
+		if strings.ToLower(next.Scheme) != "https" {
+			return "", &RejectError{ID: ErrSourceURIRedirectDowngrade}
+		}
+
+		if isPermanentRedirect(status) && !frozen {
+			normalized, err := NormalizeSourceURI(next.String())
+			if err != nil {
+				return "", err
+			}
+			recorded = normalized
+		} else if isTemporaryRedirect(status) {
+			frozen = true
+		}
+
+		if hop+1 > 10 {
+			return "", &RejectError{ID: ErrSourceURIRedirectLimit}
+		}
+		visitKey, err := redirectVisitKey(next)
+		if err != nil {
+			return "", err
+		}
+		if visited[visitKey] {
+			return "", &RejectError{ID: ErrSourceURIRedirectLimit}
+		}
+		visited[visitKey] = true
+		current = next
+	}
+
+	return recorded, nil
+}
+
+func fetchTransport(trustCAPath string, resolve map[string]string) (*http.Transport, error) {
+	tlsConfig := &tls.Config{}
+	if trustCAPath != "" {
+		data, err := os.ReadFile(trustCAPath)
+		if err != nil {
+			return nil, err
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(data) {
+			return nil, fmt.Errorf("trust_ca contains no PEM certificates")
+		}
+		tlsConfig.RootCAs = pool
+	}
+
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	return &http.Transport{
+		TLSClientConfig: tlsConfig,
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return nil, err
+			}
+			if mapped, ok := resolve[host]; ok && mapped != "" {
+				address = mapped
+			}
+			return dialer.DialContext(ctx, network, address)
+		},
+	}, nil
+}
+
+func isRedirectStatus(status int) bool {
+	return isPermanentRedirect(status) || isTemporaryRedirect(status)
+}
+
+func isPermanentRedirect(status int) bool {
+	return status == http.StatusMovedPermanently || status == http.StatusPermanentRedirect
+}
+
+func isTemporaryRedirect(status int) bool {
+	return status == http.StatusFound || status == http.StatusSeeOther || status == http.StatusTemporaryRedirect
+}
+
+func redirectVisitKey(u *url.URL) (string, error) {
+	copyURL := *u
+	copyURL.RawQuery = ""
+	copyURL.ForceQuery = false
+	copyURL.Fragment = ""
+	return NormalizeSourceURI(copyURL.String())
+}

--- a/cli/internal/acif/fetch_test.go
+++ b/cli/internal/acif/fetch_test.go
@@ -1,0 +1,197 @@
+package acif
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFetchSourceURIComposition(t *testing.T) {
+	t.Parallel()
+
+	type route struct {
+		status int
+		loc    string
+	}
+	tests := []struct {
+		name    string
+		routes  map[string]route
+		want    string
+		wantErr string
+	}{
+		{
+			name: "301 advances recorded URI",
+			routes: map[string]route{
+				"/start":  {status: http.StatusMovedPermanently, loc: "/target"},
+				"/target": {status: http.StatusOK},
+			},
+			want: "https://127.0.0.1/target",
+		},
+		{
+			name: "302 freezes before signed query target",
+			routes: map[string]route{
+				"/start":  {status: http.StatusFound, loc: "/signed?token=secret"},
+				"/signed": {status: http.StatusOK},
+			},
+			want: "https://127.0.0.1/start",
+		},
+		{
+			name: "303 freezes recorded URI",
+			routes: map[string]route{
+				"/start":  {status: http.StatusSeeOther, loc: "/target"},
+				"/target": {status: http.StatusOK},
+			},
+			want: "https://127.0.0.1/start",
+		},
+		{
+			name: "301 then 302 keeps first permanent target",
+			routes: map[string]route{
+				"/start": {status: http.StatusMovedPermanently, loc: "/p1"},
+				"/p1":    {status: http.StatusFound, loc: "/tmp"},
+				"/tmp":   {status: http.StatusOK},
+			},
+			want: "https://127.0.0.1/p1",
+		},
+		{
+			name: "301 then 308 advances to final permanent target",
+			routes: map[string]route{
+				"/start": {status: http.StatusMovedPermanently, loc: "/p1"},
+				"/p1":    {status: http.StatusPermanentRedirect, loc: "/p2"},
+				"/p2":    {status: http.StatusOK},
+			},
+			want: "https://127.0.0.1/p2",
+		},
+		{
+			name: "301 then 302 then 301 keeps first permanent target",
+			routes: map[string]route{
+				"/start": {status: http.StatusMovedPermanently, loc: "/p1"},
+				"/p1":    {status: http.StatusFound, loc: "/tmp"},
+				"/tmp":   {status: http.StatusMovedPermanently, loc: "/p2"},
+				"/p2":    {status: http.StatusOK},
+			},
+			want: "https://127.0.0.1/p1",
+		},
+		{
+			name: "302 then 301 keeps seed",
+			routes: map[string]route{
+				"/start": {status: http.StatusFound, loc: "/tmp"},
+				"/tmp":   {status: http.StatusMovedPermanently, loc: "/p1"},
+				"/p1":    {status: http.StatusOK},
+			},
+			want: "https://127.0.0.1/start",
+		},
+		{
+			name: "permanent downgrade rejects",
+			routes: map[string]route{
+				"/start": {status: http.StatusMovedPermanently, loc: "http://127.0.0.1/insecure"},
+			},
+			wantErr: ErrSourceURIRedirectDowngrade,
+		},
+		{
+			name: "temporary then permanent downgrade rejects",
+			routes: map[string]route{
+				"/start": {status: http.StatusFound, loc: "/tmp"},
+				"/tmp":   {status: http.StatusMovedPermanently, loc: "http://127.0.0.1/insecure"},
+			},
+			wantErr: ErrSourceURIRedirectDowngrade,
+		},
+		{
+			name: "loop rejects",
+			routes: map[string]route{
+				"/start": {status: http.StatusMovedPermanently, loc: "/a"},
+				"/a":     {status: http.StatusMovedPermanently, loc: "/start"},
+			},
+			wantErr: ErrSourceURIRedirectLimit,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server, trustCA := newFetchTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+				step, ok := tc.routes[r.URL.Path]
+				if !ok {
+					http.NotFound(w, r)
+					return
+				}
+				if step.loc != "" {
+					w.Header().Set("Location", step.loc)
+				}
+				if step.status == 0 {
+					step.status = http.StatusOK
+				}
+				w.WriteHeader(step.status)
+				_, _ = w.Write([]byte("ok"))
+			})
+			defer server.Close()
+
+			got, err := FetchSourceURI("https://127.0.0.1/start", trustCA, map[string]string{
+				"127.0.0.1": server.Listener.Addr().String(),
+			})
+			if tc.wantErr != "" {
+				assertRejectID(t, err, tc.wantErr)
+				return
+			}
+			if err != nil {
+				t.Fatalf("FetchSourceURI() error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("FetchSourceURI() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFetchSourceURIRedirectHopLimit(t *testing.T) {
+	t.Parallel()
+
+	server, trustCA := newFetchTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var n int
+		_, _ = fmt.Sscanf(r.URL.Path, "/hop/%d", &n)
+		w.Header().Set("Location", fmt.Sprintf("/hop/%d", n+1))
+		w.WriteHeader(http.StatusMovedPermanently)
+	})
+	defer server.Close()
+
+	_, err := FetchSourceURI("https://127.0.0.1/hop/0", trustCA, map[string]string{
+		"127.0.0.1": server.Listener.Addr().String(),
+	})
+	assertRejectID(t, err, ErrSourceURIRedirectLimit)
+}
+
+func newFetchTLSServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, string) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("sandbox blocks local sockets: %v", err)
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.Listener = ln
+	server.StartTLS()
+
+	cert := server.Certificate()
+	if cert == nil {
+		t.Fatal("test TLS server has no certificate")
+	}
+	if _, err := x509.ParseCertificate(cert.Raw); err != nil {
+		t.Fatalf("test TLS certificate parse: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	if pemBytes == nil {
+		t.Fatal("encoding test TLS certificate PEM")
+	}
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(path, pemBytes, 0o644); err != nil {
+		t.Fatalf("write trust CA: %v", err)
+	}
+	return server, path
+}

--- a/cli/internal/acif/freshness.go
+++ b/cli/internal/acif/freshness.go
@@ -1,0 +1,152 @@
+package acif
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"time"
+)
+
+type FreshnessInput struct {
+	Record                   map[string]any `json:"record"`
+	ConsumerClock            string         `json:"consumer_clock,omitempty"`
+	Policies                 []string       `json:"policies,omitempty"`
+	AttestationEvaluation    string         `json:"attestation_evaluation,omitempty"`
+	DeclaredToleranceSeconds any            `json:"declared_tolerance_seconds,omitempty"`
+	AttestationSystem        string         `json:"attestation_system,omitempty"`
+	ImplementationBehavior   string         `json:"implementation_behavior,omitempty"`
+}
+
+func EvaluateFreshness(input FreshnessInput) (map[string]any, error) {
+	if input.ImplementationBehavior == "staleness-from-generated_at" {
+		return map[string]any{
+			"conformant": false,
+			"reason":     ReasonResponseEnvelopeClockNotStalenessInput,
+		}, nil
+	}
+
+	fetchedAt, ok := parseRecordTime(input.Record, "fetched_at")
+	if !ok {
+		return timestampOffsetMissingVerdict(), nil
+	}
+	var expires time.Time
+	if rawExpires, ok := input.Record["expires"]; ok {
+		expiresString, ok := rawExpires.(string)
+		if !ok {
+			return timestampOffsetMissingVerdict(), nil
+		}
+		parsed, err := time.Parse(time.RFC3339, expiresString)
+		if err != nil {
+			return timestampOffsetMissingVerdict(), nil
+		}
+		expires = parsed
+	} else {
+		expires = fetchedAt.Add(72 * time.Hour)
+	}
+
+	if expires.Before(fetchedAt) {
+		return nil, &RejectError{ID: ErrRegistryExpiresBeforeFetchedAt}
+	}
+
+	stale := false
+	if input.ConsumerClock != "" {
+		consumerClock, err := time.Parse(time.RFC3339, input.ConsumerClock)
+		if err != nil {
+			return timestampOffsetMissingVerdict(), nil
+		}
+		tolerance := time.Duration(numberAsInt64(input.DeclaredToleranceSeconds)) * time.Second
+		stale = consumerClock.After(expires.Add(-tolerance))
+	}
+
+	staleness := "fresh"
+	if stale {
+		staleness = "stale"
+	}
+	trustTier := "unattested"
+	if input.AttestationEvaluation == "valid" {
+		trustTier = "attested"
+	}
+	install := "proceed"
+	if stale && stringSliceContains(input.Policies, "freshness-enforcement-opt-in") {
+		install = "refuse"
+	}
+
+	result := map[string]any{
+		"conformant": true,
+		"staleness":  staleness,
+		"trust_tier": trustTier,
+		"install":    install,
+	}
+	if stale {
+		result["warnings"] = []any{map[string]any{
+			"id": ErrRegistryStale,
+			"params": map[string]any{
+				"expires": expires.Format(time.RFC3339),
+			},
+		}}
+	}
+	if err := attachResponseHash(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func parseRecordTime(record map[string]any, key string) (time.Time, bool) {
+	raw, ok := record[key]
+	if !ok {
+		return time.Time{}, false
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
+}
+
+func timestampOffsetMissingVerdict() map[string]any {
+	return map[string]any{
+		"conformant": false,
+		"reason":     ReasonRegistryTimestampOffsetMissing,
+	}
+}
+
+func numberAsInt64(raw any) int64 {
+	switch v := raw.(type) {
+	case nil:
+		return 0
+	case int:
+		return int64(v)
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	case json.Number:
+		n, err := v.Int64()
+		if err == nil {
+			return n
+		}
+		f, err := v.Float64()
+		if err == nil {
+			return int64(f)
+		}
+	}
+	return 0
+}
+
+func attachResponseHash(result map[string]any) error {
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	canonical, err := CanonicalJSON(raw)
+	if err != nil {
+		return err
+	}
+	sum := sha256.Sum256(canonical)
+	result["response_hash"] = hex.EncodeToString(sum[:])
+	return nil
+}

--- a/cli/internal/acif/freshness_test.go
+++ b/cli/internal/acif/freshness_test.go
@@ -1,0 +1,172 @@
+package acif
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEvaluateFreshnessBattery(t *testing.T) {
+	t.Parallel()
+
+	baseRecord := map[string]any{
+		"fetched_at": "2026-05-01T00:00:00Z",
+		"expires":    "2026-05-02T00:00:00Z",
+	}
+
+	fresh, err := EvaluateFreshness(FreshnessInput{
+		Record:                cloneMap(baseRecord),
+		ConsumerClock:         "2026-05-01T12:00:00Z",
+		AttestationEvaluation: "valid",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFreshness(fresh) error: %v", err)
+	}
+	if fresh["conformant"] != true || fresh["staleness"] != "fresh" || fresh["trust_tier"] != "attested" || fresh["install"] != "proceed" {
+		t.Fatalf("fresh result = %#v", fresh)
+	}
+	if fresh["response_hash"] == "" {
+		t.Fatalf("fresh response_hash missing: %#v", fresh)
+	}
+	if _, ok := fresh["warnings"]; ok {
+		t.Fatalf("fresh warnings present: %#v", fresh)
+	}
+	if _, ok := fresh["combined_scalar"]; ok {
+		t.Fatalf("combined_scalar present: %#v", fresh)
+	}
+
+	stale, err := EvaluateFreshness(FreshnessInput{
+		Record:        cloneMap(baseRecord),
+		ConsumerClock: "2026-05-02T00:00:01Z",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFreshness(stale) error: %v", err)
+	}
+	if stale["staleness"] != "stale" || stale["trust_tier"] != "unattested" || stale["install"] != "proceed" {
+		t.Fatalf("stale result = %#v", stale)
+	}
+	wantWarnings := []any{map[string]any{
+		"id":     ErrRegistryStale,
+		"params": map[string]any{"expires": "2026-05-02T00:00:00Z"},
+	}}
+	if !reflect.DeepEqual(stale["warnings"], wantWarnings) {
+		t.Fatalf("stale warnings = %#v, want %#v", stale["warnings"], wantWarnings)
+	}
+
+	noClockA, err := EvaluateFreshness(FreshnessInput{
+		Record:            cloneMap(baseRecord),
+		AttestationSystem: "system-a",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFreshness(no clock a) error: %v", err)
+	}
+	noClockB, err := EvaluateFreshness(FreshnessInput{
+		Record:            cloneMap(baseRecord),
+		AttestationSystem: "system-b",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFreshness(no clock b) error: %v", err)
+	}
+	if noClockA["staleness"] != "fresh" || !reflect.DeepEqual(noClockA, noClockB) {
+		t.Fatalf("attestation_system or absent clock changed result:\na=%#v\nb=%#v", noClockA, noClockB)
+	}
+
+	defaultFresh, err := EvaluateFreshness(FreshnessInput{
+		Record:        map[string]any{"fetched_at": "2026-05-01T00:00:00Z"},
+		ConsumerClock: "2026-05-03T23:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFreshness(default fresh) error: %v", err)
+	}
+	defaultStale, err := EvaluateFreshness(FreshnessInput{
+		Record:        map[string]any{"fetched_at": "2026-05-01T00:00:00Z"},
+		ConsumerClock: "2026-05-04T01:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFreshness(default stale) error: %v", err)
+	}
+	if defaultFresh["staleness"] != "fresh" || defaultStale["staleness"] != "stale" {
+		t.Fatalf("default 72h results: fresh=%#v stale=%#v", defaultFresh, defaultStale)
+	}
+
+	_, err = EvaluateFreshness(FreshnessInput{
+		Record: map[string]any{
+			"fetched_at": "2026-05-02T00:00:00Z",
+			"expires":    "2026-05-01T00:00:00Z",
+		},
+	})
+	assertRejectID(t, err, ErrRegistryExpiresBeforeFetchedAt)
+
+	missingOffset, err := EvaluateFreshness(FreshnessInput{
+		Record: map[string]any{"fetched_at": "2026-05-01T00:00:00"},
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFreshness(missing offset) error: %v", err)
+	}
+	if missingOffset["conformant"] != false || missingOffset["reason"] != ReasonRegistryTimestampOffsetMissing {
+		t.Fatalf("missing offset verdict = %#v", missingOffset)
+	}
+
+	tolerance, err := EvaluateFreshness(FreshnessInput{
+		Record:                   cloneMap(baseRecord),
+		ConsumerClock:            "2026-05-01T23:59:45Z",
+		DeclaredToleranceSeconds: 30,
+		AttestationEvaluation:    "lapsed",
+		ImplementationBehavior:   "",
+		Policies:                 nil,
+		AttestationSystem:        "ignored",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFreshness(tolerance) error: %v", err)
+	}
+	if tolerance["staleness"] != "stale" || tolerance["trust_tier"] != "unattested" {
+		t.Fatalf("tolerance result = %#v", tolerance)
+	}
+
+	enforced, err := EvaluateFreshness(FreshnessInput{
+		Record:        cloneMap(baseRecord),
+		ConsumerClock: "2026-05-03T00:00:00Z",
+		Policies:      []string{"freshness-enforcement-opt-in"},
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFreshness(enforced) error: %v", err)
+	}
+	if enforced["install"] != "refuse" {
+		t.Fatalf("enforced install = %#v", enforced)
+	}
+
+	generatedIgnored, err := EvaluateFreshness(FreshnessInput{
+		Record: map[string]any{
+			"fetched_at":    "2026-05-01T00:00:00Z",
+			"expires":       "2026-05-02T00:00:00Z",
+			"generated_at":  "1999-01-01T00:00:00Z",
+			"max_staleness": "PT1S",
+			"body_hash":     "unchanged",
+		},
+		ConsumerClock: "2026-05-01T00:01:00Z",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFreshness(generated ignored) error: %v", err)
+	}
+	if generatedIgnored["staleness"] != "fresh" {
+		t.Fatalf("generated_at/max_staleness affected staleness: %#v", generatedIgnored)
+	}
+
+	generatedBehavior, err := EvaluateFreshness(FreshnessInput{
+		Record:                 cloneMap(baseRecord),
+		ImplementationBehavior: "staleness-from-generated_at",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateFreshness(generated behavior) error: %v", err)
+	}
+	if generatedBehavior["conformant"] != false || generatedBehavior["reason"] != ReasonResponseEnvelopeClockNotStalenessInput {
+		t.Fatalf("generated behavior verdict = %#v", generatedBehavior)
+	}
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/cli/internal/acif/registryproj.go
+++ b/cli/internal/acif/registryproj.go
@@ -1,0 +1,91 @@
+package acif
+
+import "fmt"
+
+func TupleEndpointProjection(item map[string]any) map[string]any {
+	projection := map[string]any{
+		"tuple_fields": []any{"item_id", "body_hash", "metadata_hash_if_present", "version_if_declared"},
+	}
+	members, _ := item["pack_members"].([]any)
+	for i, rawMember := range members {
+		member, _ := rawMember.(map[string]any)
+		value := any(nil)
+		if member != nil && member["publisher_section"] == "present" {
+			value = "present"
+		}
+		projection[fmt.Sprintf("member_%d", i+1)] = map[string]any{"metadata_hash": value}
+	}
+	return projection
+}
+
+func ValidateInstallScopeCapabilities(item map[string]any) map[string]any {
+	for _, rawEntry := range item {
+		entry, ok := rawEntry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, ok := entry["source"]; !ok {
+			return map[string]any{
+				"conformant": false,
+				"reason":     ReasonRegistryProvenanceTagMissing,
+			}
+		}
+	}
+	return map[string]any{"conformant": true}
+}
+
+func ValidateRegistryAdvisory(item map[string]any) map[string]any {
+	for _, rawEntry := range item {
+		entry, ok := rawEntry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, ok := entry["method"]; !ok {
+			return map[string]any{
+				"conformant": false,
+				"reason":     ReasonRegistryMethodStampMissing,
+			}
+		}
+	}
+	return map[string]any{"conformant": true}
+}
+
+func EvaluateRegistryInstallCrossReferences(item map[string]any) (map[string]any, bool) {
+	refs, ok := item["cross_references"].([]any)
+	if !ok {
+		return nil, false
+	}
+	for _, rawRef := range refs {
+		ref, ok := rawRef.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch ref["resolution"] {
+		case "unresolved", "revoked":
+			return map[string]any{"install": "refuse-unless-operator-opt-in"}, true
+		}
+	}
+	return nil, false
+}
+
+func ValidateRegistryEmitSidecar(sidecar map[string]any) (map[string]any, bool, error) {
+	if sidecar == nil {
+		return nil, false, nil
+	}
+	if _, ok := sidecar["kind"]; ok {
+		return nil, false, nil
+	}
+	if _, ok := sidecar["publisher_section"]; ok {
+		return nil, false, nil
+	}
+	rawRegistry, ok := sidecar["registry_section"]
+	if !ok {
+		return nil, false, nil
+	}
+	registry, _ := rawRegistry.(map[string]any)
+	sourceURI, _ := registry["source_uri"].(string)
+	if sourceURI == "" {
+		return nil, true, &RejectError{ID: ErrSourceURIMissing}
+	}
+	return map[string]any{"conformant": true}, true, nil
+}

--- a/cli/internal/acif/registryproj_test.go
+++ b/cli/internal/acif/registryproj_test.go
@@ -1,0 +1,113 @@
+package acif
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTupleEndpointProjection(t *testing.T) {
+	t.Parallel()
+
+	got := TupleEndpointProjection(map[string]any{
+		"pack_members": []any{
+			map[string]any{"item_id": "one", "publisher_section": "present"},
+			map[string]any{"item_id": "two", "publisher_section": "absent"},
+		},
+	})
+	want := map[string]any{
+		"tuple_fields": []any{"item_id", "body_hash", "metadata_hash_if_present", "version_if_declared"},
+		"member_1":     map[string]any{"metadata_hash": "present"},
+		"member_2":     map[string]any{"metadata_hash": nil},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("TupleEndpointProjection() = %#v, want %#v", got, want)
+	}
+}
+
+func TestInstallScopeCapabilitiesProjection(t *testing.T) {
+	t.Parallel()
+
+	missing := ValidateInstallScopeCapabilities(map[string]any{
+		"filesystem": map[string]any{"read": true},
+	})
+	if missing["conformant"] != false || missing["reason"] != ReasonRegistryProvenanceTagMissing {
+		t.Fatalf("missing source verdict = %#v", missing)
+	}
+
+	tagged := ValidateInstallScopeCapabilities(map[string]any{
+		"filesystem": map[string]any{"source": "publisher", "read": true},
+		"network":    map[string]any{"source": "registry", "egress": true},
+	})
+	if !reflect.DeepEqual(tagged, map[string]any{"conformant": true}) {
+		t.Fatalf("tagged verdict = %#v", tagged)
+	}
+}
+
+func TestRegistryAdvisoryValidation(t *testing.T) {
+	t.Parallel()
+
+	missing := ValidateRegistryAdvisory(map[string]any{
+		"warning": map[string]any{"text": "needs review"},
+	})
+	if missing["conformant"] != false || missing["reason"] != ReasonRegistryMethodStampMissing {
+		t.Fatalf("missing method verdict = %#v", missing)
+	}
+
+	stamped := ValidateRegistryAdvisory(map[string]any{
+		"warning": map[string]any{"method": "registry-review-v1", "text": "needs review"},
+	})
+	if !reflect.DeepEqual(stamped, map[string]any{"conformant": true}) {
+		t.Fatalf("stamped verdict = %#v", stamped)
+	}
+}
+
+func TestEvaluateRegistryInstallCrossReferences(t *testing.T) {
+	t.Parallel()
+
+	got, handled := EvaluateRegistryInstallCrossReferences(map[string]any{
+		"cross_references": []any{
+			map[string]any{"resolution": "resolved"},
+			map[string]any{"resolution": "revoked"},
+		},
+	})
+	if !handled || got["install"] != "refuse-unless-operator-opt-in" {
+		t.Fatalf("revoked cross reference = %#v handled=%v", got, handled)
+	}
+
+	got, handled = EvaluateRegistryInstallCrossReferences(map[string]any{
+		"cross_references": []any{map[string]any{"resolution": "resolved"}},
+	})
+	if handled || got != nil {
+		t.Fatalf("resolved cross references = %#v handled=%v", got, handled)
+	}
+}
+
+func TestValidateRegistryEmitSidecar(t *testing.T) {
+	t.Parallel()
+
+	got, handled, err := ValidateRegistryEmitSidecar(map[string]any{
+		"registry_section": map[string]any{"source_uri": "https://example.com/skill.md"},
+	})
+	if err != nil {
+		t.Fatalf("ValidateRegistryEmitSidecar(valid) error: %v", err)
+	}
+	if !handled || !reflect.DeepEqual(got, map[string]any{"conformant": true}) {
+		t.Fatalf("valid registry emit = %#v handled=%v", got, handled)
+	}
+
+	_, handled, err = ValidateRegistryEmitSidecar(map[string]any{
+		"registry_section": map[string]any{},
+	})
+	if !handled {
+		t.Fatal("missing source_uri was not handled as registry emit")
+	}
+	assertRejectID(t, err, ErrSourceURIMissing)
+
+	got, handled, err = ValidateRegistryEmitSidecar(map[string]any{
+		"kind":             "skill",
+		"registry_section": map[string]any{"source_uri": "https://example.com/skill.md"},
+	})
+	if err != nil || handled || got != nil {
+		t.Fatalf("envelope-like sidecar should not be handled: got=%#v handled=%v err=%v", got, handled, err)
+	}
+}

--- a/cli/internal/acif/uri.go
+++ b/cli/internal/acif/uri.go
@@ -1,0 +1,220 @@
+package acif
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+type URLNameResult struct {
+	Conformant     bool         `json:"conformant,omitempty"`
+	URLDerivedName string       `json:"url_derived_name"`
+	Diagnostics    []Diagnostic `json:"diagnostics,omitempty"`
+}
+
+func NormalizeSourceURI(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", &RejectError{ID: ErrSourceURIMalformed, Detail: err.Error()}
+	}
+	if u.Scheme == "" {
+		return "", &RejectError{ID: ErrSourceURIMalformed}
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "https" {
+		return "", &RejectError{ID: ErrSourceURISchemeForbidden}
+	}
+	if u.Host == "" || u.Hostname() == "" {
+		return "", &RejectError{ID: ErrSourceURIMalformed}
+	}
+	if u.User != nil {
+		return "", &RejectError{ID: ErrSourceURIUserinfoPresent}
+	}
+
+	escapedPath := u.EscapedPath()
+	normalizedPath := removeDotSegments(normalizeEscapedPath(escapedPath))
+	if normalizedPath == "" {
+		normalizedPath = "/"
+	}
+
+	port := u.Port()
+	if port == "443" {
+		port = ""
+	}
+
+	if u.RawQuery != "" {
+		return "", &RejectError{ID: ErrSourceURIQueryPresent}
+	}
+
+	return "https://" + normalizedAuthority(strings.ToLower(u.Hostname()), port) + normalizedPath, nil
+}
+
+func DeriveURLName(uri, bodyClassification, frontmatterName string) (URLNameResult, error) {
+	return deriveURLName(uri, bodyClassification, nilIfEmpty(frontmatterName))
+}
+
+func deriveURLName(uri, bodyClassification string, frontmatterName *string) (URLNameResult, error) {
+	if bodyClassification == "multi-file" {
+		return URLNameResult{Conformant: true, URLDerivedName: "none"}, nil
+	}
+
+	normalized, err := NormalizeSourceURI(uri)
+	if err != nil {
+		return URLNameResult{}, err
+	}
+	pathStart := strings.Index(normalized[len("https://"):], "/")
+	if pathStart < 0 {
+		return URLNameResult{}, &RejectError{ID: ErrSourceURIMalformed}
+	}
+	escapedPath := normalized[len("https://")+pathStart:]
+	if strings.HasSuffix(escapedPath, "/") {
+		return URLNameResult{}, &RejectError{ID: ErrSourceURIDirectFileTrailingSlash}
+	}
+
+	segment := escapedPath[strings.LastIndex(escapedPath, "/")+1:]
+	if dot := strings.LastIndex(segment, "."); dot >= 0 {
+		segment = segment[:dot]
+	}
+
+	result := URLNameResult{URLDerivedName: segment}
+	if frontmatterName != nil && *frontmatterName != segment {
+		result.Diagnostics = []Diagnostic{{
+			ID: ErrSourceURIFilenameConflict,
+			Params: map[string]any{
+				"url_derived_name": segment,
+				"declared_name":    *frontmatterName,
+			},
+		}}
+	}
+	return result, nil
+}
+
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func normalizedAuthority(host, port string) string {
+	if port != "" {
+		return net.JoinHostPort(host, port)
+	}
+	if strings.Contains(host, ":") {
+		return "[" + host + "]"
+	}
+	return host
+}
+
+func normalizeEscapedPath(path string) string {
+	var out strings.Builder
+	out.Grow(len(path))
+	for i := 0; i < len(path); {
+		if path[i] == '%' && i+2 < len(path) && isHex(path[i+1]) && isHex(path[i+2]) {
+			hi := upperHex(path[i+1])
+			lo := upperHex(path[i+2])
+			decoded := fromHex(hi)<<4 | fromHex(lo)
+			if isUnreserved(decoded) {
+				out.WriteByte(decoded)
+			} else {
+				out.WriteByte('%')
+				out.WriteByte(hi)
+				out.WriteByte(lo)
+			}
+			i += 3
+			continue
+		}
+		out.WriteByte(path[i])
+		i++
+	}
+	return out.String()
+}
+
+func removeDotSegments(input string) string {
+	var output strings.Builder
+	for input != "" {
+		switch {
+		case strings.HasPrefix(input, "../"):
+			input = input[3:]
+		case strings.HasPrefix(input, "./"):
+			input = input[2:]
+		case strings.HasPrefix(input, "/./"):
+			input = "/" + input[3:]
+		case input == "/.":
+			input = "/"
+		case strings.HasPrefix(input, "/../"):
+			input = "/" + input[4:]
+			removeLastOutputSegment(&output)
+		case input == "/..":
+			input = "/"
+			removeLastOutputSegment(&output)
+		case input == "." || input == "..":
+			input = ""
+		default:
+			segment, rest := firstPathSegment(input)
+			output.WriteString(segment)
+			input = rest
+		}
+	}
+	return output.String()
+}
+
+func firstPathSegment(input string) (segment, rest string) {
+	if strings.HasPrefix(input, "/") {
+		next := strings.Index(input[1:], "/")
+		if next < 0 {
+			return input, ""
+		}
+		idx := next + 1
+		return input[:idx], input[idx:]
+	}
+	next := strings.Index(input, "/")
+	if next < 0 {
+		return input, ""
+	}
+	return input[:next], input[next:]
+}
+
+func removeLastOutputSegment(output *strings.Builder) {
+	current := output.String()
+	if current == "" {
+		return
+	}
+	idx := strings.LastIndex(current, "/")
+	switch {
+	case idx < 0:
+		current = ""
+	case idx == 0:
+		current = ""
+	default:
+		current = current[:idx]
+	}
+	output.Reset()
+	output.WriteString(current)
+}
+
+func isUnreserved(b byte) bool {
+	return isASCIIAlpha(b) || ('0' <= b && b <= '9') || b == '.' || b == '_' || b == '~' || b == '-'
+}
+
+func isHex(b byte) bool {
+	return ('0' <= b && b <= '9') || ('a' <= b && b <= 'f') || ('A' <= b && b <= 'F')
+}
+
+func upperHex(b byte) byte {
+	if 'a' <= b && b <= 'f' {
+		return b - ('a' - 'A')
+	}
+	return b
+}
+
+func fromHex(b byte) byte {
+	switch {
+	case '0' <= b && b <= '9':
+		return b - '0'
+	case 'A' <= b && b <= 'F':
+		return b - 'A' + 10
+	default:
+		return 0
+	}
+}

--- a/cli/internal/acif/uri_test.go
+++ b/cli/internal/acif/uri_test.go
@@ -1,0 +1,132 @@
+package acif
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeSourceURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr string
+	}{
+		{name: "scheme host and percent hex case", in: "HTTPS://GitHub.IO/A%3ab", want: "https://github.io/A%3Ab"},
+		{name: "unreserved percent decode", in: "https://example.com/a%2Db%7Ec", want: "https://example.com/a-b~c"},
+		{name: "reserved percent preserved", in: "https://example.com/a%2Fb", want: "https://example.com/a%2Fb"},
+		{name: "decoded dot segments collapse", in: "https://example.com/x/%2E%2E/y", want: "https://example.com/y"},
+		{name: "literal dot segments collapse", in: "https://example.com/a/./b/../c", want: "https://example.com/a/c"},
+		{name: "default port stripped", in: "https://example.com:443/x", want: "https://example.com/x"},
+		{name: "non default port retained", in: "https://example.com:8443/x", want: "https://example.com:8443/x"},
+		{name: "empty path becomes slash", in: "https://example.com", want: "https://example.com/"},
+		{name: "fragment dropped", in: "https://example.com/x#readme", want: "https://example.com/x"},
+		{name: "bare query marker dropped", in: "https://example.com/x?", want: "https://example.com/x"},
+		{name: "query rejected", in: "https://example.com/x?token=secret", wantErr: ErrSourceURIQueryPresent},
+		{name: "http rejected by scheme gate", in: "http://example.com/x", wantErr: ErrSourceURISchemeForbidden},
+		{name: "scp style malformed", in: "git@github.com:o/r.git", wantErr: ErrSourceURIMalformed},
+		{name: "javascript rejected by scheme gate", in: "javascript:alert(1)", wantErr: ErrSourceURISchemeForbidden},
+		{name: "data rejected by scheme gate", in: "data:text/plain,hi", wantErr: ErrSourceURISchemeForbidden},
+		{name: "file rejected by scheme gate", in: "file:///etc/passwd", wantErr: ErrSourceURISchemeForbidden},
+		{name: "userinfo rejected", in: "https://user:pw@example.com/x", wantErr: ErrSourceURIUserinfoPresent},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NormalizeSourceURI(tc.in)
+			if tc.wantErr != "" {
+				assertRejectID(t, err, tc.wantErr)
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeSourceURI() error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("NormalizeSourceURI() = %q, want %q", got, tc.want)
+			}
+			again, err := NormalizeSourceURI(got)
+			if err != nil {
+				t.Fatalf("NormalizeSourceURI(normalized) error: %v", err)
+			}
+			if again != got {
+				t.Fatalf("NormalizeSourceURI() not idempotent: %q then %q", got, again)
+			}
+		})
+	}
+}
+
+func TestNormalizeSourceURIIdempotencyLiterals(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{
+		"HTTPS://GitHub.IO:443/A%3ab/./x/../y#frag",
+		"https://example.com/a%2Db",
+	} {
+		got, err := NormalizeSourceURI(in)
+		if err != nil {
+			t.Fatalf("NormalizeSourceURI(%q) error: %v", in, err)
+		}
+		again, err := NormalizeSourceURI(got)
+		if err != nil {
+			t.Fatalf("NormalizeSourceURI(%q normalized) error: %v", in, err)
+		}
+		if again != got {
+			t.Fatalf("NormalizeSourceURI(%q) not idempotent: %q then %q", in, got, again)
+		}
+	}
+}
+
+func TestDeriveURLName(t *testing.T) {
+	t.Parallel()
+
+	got, err := DeriveURLName("https://example.com/skills/my-skill.md", "single-file", "")
+	if err != nil {
+		t.Fatalf("DeriveURLName(single-file) error: %v", err)
+	}
+	if got.URLDerivedName != "my-skill" || len(got.Diagnostics) != 0 {
+		t.Fatalf("DeriveURLName(single-file) = %#v", got)
+	}
+
+	conflict, err := DeriveURLName("https://example.com/skills/my-skill.md", "single-file", "declared")
+	if err != nil {
+		t.Fatalf("DeriveURLName(conflict) error: %v", err)
+	}
+	wantDiag := []Diagnostic{{
+		ID: ErrSourceURIFilenameConflict,
+		Params: map[string]any{
+			"url_derived_name": "my-skill",
+			"declared_name":    "declared",
+		},
+	}}
+	if !reflect.DeepEqual(conflict.Diagnostics, wantDiag) {
+		t.Fatalf("conflict diagnostics = %#v, want %#v", conflict.Diagnostics, wantDiag)
+	}
+
+	multi, err := DeriveURLName("https://example.com/skills/", "multi-file", "")
+	if err != nil {
+		t.Fatalf("DeriveURLName(multi-file) error: %v", err)
+	}
+	if !multi.Conformant || multi.URLDerivedName != "none" {
+		t.Fatalf("DeriveURLName(multi-file) = %#v", multi)
+	}
+
+	_, err = DeriveURLName("https://example.com/skills/", "single-file", "")
+	assertRejectID(t, err, ErrSourceURIDirectFileTrailingSlash)
+}
+
+func assertRejectID(t *testing.T, err error, want string) {
+	t.Helper()
+	var reject *RejectError
+	if !errors.As(err, &reject) {
+		t.Fatalf("error = %v, want RejectError %s", err, want)
+	}
+	if reject.ID != want {
+		t.Fatalf("reject ID = %q, want %q", reject.ID, want)
+	}
+}


### PR DESCRIPTION
Stage 4 of syllago-as-ACIF-implementation-#1: the adapter now claims the `registry` scope — nine of ten scopes implemented, render remaining.

## What's here

- `uri.go`: the §10.3 normalization pipeline (byte-exact, order-normative, idempotent) + §10.5 URL-derived names.
- `fetch.go`: real-HTTP `fetch_uri` honoring the runner's ephemeral-CA `trust_ca` and hostname `resolve` knobs, with the Decision #35 redirect composition rule (permanent-prefix / freeze-at-first-temporary), downgrade rejection on every hop, and hop/loop budgets.
- `freshness.go`: the §11 three-clock model with fail-closed skew, RFC 3339 offset enforcement, orthogonal attestation tier, and deterministic `response_hash` for the byte-identity probe.
- `registryproj.go`: tuple endpoint, provenance-tag/method-stamp verdicts, revoked-reference install refusal, registry-emit validation.

## Conformance

Nine scopes: **all fully green** — registry 45/45 including all mock-transport TLS vectors (TV-URI-u vacuous by design: the OPTIONAL `source_status` is deliberately omitted in 0.1).

One upstream note (report to follow): no identifier is minted for the §11.4 staleness warning; the adapter emits a proposed `acif.registry.stale` pending ratification — the same pattern Decision #38 followed for `reference_unresolved`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7tRhi8WaVhr1iMMkNNgfN
