### PR TITLE
ACIF Stage 5: render scope — graduation (all ten scopes)

### DIFF
--- a/cli/cmd/acif-adapter/handlers.go
+++ b/cli/cmd/acif-adapter/handlers.go
@@ -48,7 +48,7 @@ func dispatch(req request) any {
 			"implementation":   "syllago",
 			"version":          adapterVersion,
 			"adapter_protocol": 1,
-			"scopes":           []string{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher", "registry"},
+			"scopes":           []string{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher", "registry", "render"},
 		})
 	case "ingest":
 		return handleIngest(req.Input)
@@ -617,6 +617,7 @@ func handleRender(raw json.RawMessage) any {
 
 func renderItem(block map[string]any, target string, invocation map[string]any) (*acif.RenderResult, error) {
 	renderers := []func(map[string]any, string) (*acif.RenderResult, error){
+		acif.RenderStructured,
 		acif.RenderCommand,
 		acif.RenderRule,
 		acif.RenderAgent,

--- a/cli/cmd/acif-adapter/main_test.go
+++ b/cli/cmd/acif-adapter/main_test.go
@@ -61,7 +61,7 @@ func TestHello(t *testing.T) {
 			"implementation":   "syllago",
 			"version":          "0.0.0-dev",
 			"adapter_protocol": float64(1),
-			"scopes":           []any{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher", "registry"},
+			"scopes":           []any{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher", "registry", "render"},
 		},
 	}
 	if !reflect.DeepEqual(responses[0], want) {

--- a/cli/internal/acif/structuredrender.go
+++ b/cli/internal/acif/structuredrender.go
@@ -1,0 +1,29 @@
+package acif
+
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RenderStructured emits the canonical value through a generic structured
+// encoder for the framework-level render targets ([ACIF-RENDER] §8,
+// TV-RENDER-b). Values are never string-spliced into output.
+func RenderStructured(block map[string]any, target string) (*RenderResult, error) {
+	switch target {
+	case "json-format":
+		raw, err := json.Marshal(block)
+		if err != nil {
+			return nil, err
+		}
+		return &RenderResult{Output: string(raw)}, nil
+	case "yaml-format":
+		raw, err := yaml.Marshal(block)
+		if err != nil {
+			return nil, err
+		}
+		return &RenderResult{Output: string(raw)}, nil
+	default:
+		return &RenderResult{Unsupported: true}, nil
+	}
+}

--- a/cli/internal/acif/structuredrender_test.go
+++ b/cli/internal/acif/structuredrender_test.go
@@ -1,0 +1,65 @@
+package acif
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TV-RENDER-b: an injection-shaped passthrough value must survive both
+// generic structured encoders byte-identically when parsed back.
+const injectionValue = "pwsh\", \"payload\": {\"x"
+
+func TestRenderStructuredJSONFormat(t *testing.T) {
+	result, err := RenderStructured(map[string]any{"passthrough": injectionValue}, "json-format")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result.Output), &parsed); err != nil {
+		t.Fatalf("output does not parse as JSON: %v\noutput: %s", err, result.Output)
+	}
+	if parsed["passthrough"] != injectionValue {
+		t.Fatalf("value did not round-trip: %q", parsed["passthrough"])
+	}
+}
+
+func TestRenderStructuredYAMLFormat(t *testing.T) {
+	result, err := RenderStructured(map[string]any{"passthrough": injectionValue}, "yaml-format")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	var parsed map[string]any
+	if err := yaml.Unmarshal([]byte(result.Output), &parsed); err != nil {
+		t.Fatalf("output does not parse as YAML: %v\noutput: %s", err, result.Output)
+	}
+	if parsed["passthrough"] != injectionValue {
+		t.Fatalf("value did not round-trip: %q", parsed["passthrough"])
+	}
+}
+
+func TestRenderStructuredDeterminism(t *testing.T) {
+	block := map[string]any{"b": "2", "a": "1", "nested": map[string]any{"y": true, "x": false}}
+	first, err := RenderStructured(block, "json-format")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	second, err := RenderStructured(block, "json-format")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if first.Output != second.Output {
+		t.Fatalf("json-format output not deterministic:\n%s\n%s", first.Output, second.Output)
+	}
+}
+
+func TestRenderStructuredUnknownTargetUnsupported(t *testing.T) {
+	result, err := RenderStructured(map[string]any{"passthrough": "x"}, "toml-format")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if !result.Unsupported {
+		t.Fatal("expected unsupported for unknown target")
+	}
+}


### PR DESCRIPTION
The final stage of syllago-as-ACIF-implementation-#1 — and the graduation run.

## What's here

- `structuredrender.go`: the TV-RENDER-b generic `json-format`/`yaml-format` structured-encode targets (injection-shaped passthrough values round-trip byte-identically; string-splicing is structurally impossible).
- `hello` now claims all ten scopes.

TV-RENDER-a/c/d needed no new code — determinism, degradation-diagnostic pairing, and round-trip closure were built across Stages 1–4.

## 🎓 Graduation

The single all-ten-scope run passes everything:

| Catalog | Result |
|---|---|
| core | 23/23 |
| hook + platform | 33/33 |
| skill / rule / command / agent / mcp | 14 + 13 + 13(+1 vacuous) + 11 + 14 |
| uri + fresh (registry) | 30(+1 vacuous) + 11 |
| render | 4/4 |

**166 passing, 2 vacuous by design, zero failures, all scopes claimed.** The graduation report is pinned to the published suite's catalog hashes and binding-set hash; the adapter source lives in this repository per the runner DESIGN §8 publication requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7tRhi8WaVhr1iMMkNNgfN
