### PR TITLE
feat(provider): Zed Agent Skills support

### DIFF
--- a/cli/internal/converter/skills.go
+++ b/cli/internal/converter/skills.go
@@ -114,6 +114,7 @@ func init() {
 	RegisterFrontmatter(catalog.Skills, "factory-droid", factoryDroidSkillMeta{})
 	RegisterFrontmatter(catalog.Skills, "pi", piSkillMeta{})
 	RegisterFrontmatter(catalog.Skills, "crush", crushSkillMeta{})
+	RegisterFrontmatter(catalog.Skills, "zed", zedSkillMeta{})
 }
 
 // flexStringList is a []string that also accepts a single YAML scalar string.
@@ -243,6 +244,8 @@ func (c *SkillsConverter) Render(content []byte, target provider.Provider) (*Res
 		return renderCopilotSkill(meta, body)
 	case "roo-code":
 		return renderRooCodeSkill(meta, body)
+	case "zed":
+		return renderZedSkill(meta, body)
 	default:
 		// Claude Code — full frontmatter preserved
 		return renderClaudeSkill(meta, body)
@@ -748,6 +751,42 @@ type crushSkillMeta struct {
 	License       string            `yaml:"license,omitempty"`
 	Compatibility string            `yaml:"compatibility,omitempty"`
 	Metadata      map[string]string `yaml:"metadata,omitempty"`
+}
+
+// zedSkillMeta is the subset of fields Zed supports in SKILL.md frontmatter.
+// Zed supports name, description, and disable-model-invocation
+// (https://zed.dev/docs/ai/skills).
+type zedSkillMeta struct {
+	Name                   string `yaml:"name,omitempty"`
+	Description            string `yaml:"description,omitempty"`
+	DisableModelInvocation bool   `yaml:"disable-model-invocation,omitempty"`
+}
+
+// renderZedSkill renders a canonical skill to Zed's SKILL.md format.
+// Zed supports name, description, and disable-model-invocation fields.
+// CC-specific fields (allowed-tools, context, agent, etc.) are embedded as
+// prose notes; Zed has no lifecycle hooks, so hooks are prose too.
+func renderZedSkill(meta SkillMeta, body string) (*Result, error) {
+	cleanBody := StripConversionNotes(body)
+
+	// disable-model-invocation survives as a structured frontmatter field,
+	// so blank it before building prose notes to avoid duplicating it.
+	noteMeta := meta
+	noteMeta.DisableModelInvocation = false
+	notes := buildSkillProseNotes(noteMeta)
+	outBody := cleanBody
+	if len(notes) > 0 {
+		notesBlock := BuildConversionNotes("claude-code", notes)
+		outBody = AppendNotes(outBody, notesBlock)
+	}
+
+	zm := zedSkillMeta{
+		Name:                   meta.Name,
+		Description:            meta.Description,
+		DisableModelInvocation: meta.DisableModelInvocation,
+	}
+
+	return renderWithFrontmatter(zm, outBody, "SKILL.md")
 }
 
 // renderRooCodeSkill renders a canonical skill to Roo Code's SKILL.md format.

--- a/cli/internal/converter/skills_test.go
+++ b/cli/internal/converter/skills_test.go
@@ -534,6 +534,66 @@ func TestWindsurfSkillRoundTrip(t *testing.T) {
 	assertEqual(t, "SKILL.md", result.Filename)
 }
 
+// --- Zed skills ---
+
+func TestClaudeSkillToZed(t *testing.T) {
+	input := []byte("---\nname: go-expert\ndescription: Go coding guidelines\nallowed-tools:\n  - Read\n  - Grep\nmodel: opus\ncontext: fork\ndisable-model-invocation: true\n---\n\nUse idiomatic Go patterns.\n")
+
+	conv := &SkillsConverter{}
+	canonical, err := conv.Canonicalize(input, "claude-code")
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+
+	result, err := conv.Render(canonical.Content, provider.Zed)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	out := string(result.Content)
+	assertContains(t, out, "name: go-expert")
+	assertContains(t, out, "description: Go coding guidelines")
+	assertContains(t, out, "idiomatic Go")
+	// disable-model-invocation is a supported Zed frontmatter key — it must
+	// survive structurally, not as prose.
+	assertContains(t, out, "disable-model-invocation: true")
+	assertNotContains(t, out, "Only invoke when the user explicitly requests it")
+	// Claude-specific fields should be embedded as prose, not in frontmatter
+	assertNotContains(t, out, "allowed-tools:")
+	assertNotContains(t, out, "context: fork")
+	assertContains(t, out, "Tool restriction")
+	assertContains(t, out, "isolated context")
+	assertContains(t, out, "Designed for model: opus.")
+	assertContains(t, out, "syllago:converted")
+	assertEqual(t, "SKILL.md", result.Filename)
+}
+
+func TestZedSkillRoundTrip(t *testing.T) {
+	input := []byte("---\nname: deploy-to-production\ndescription: Guides the deployment process\ndisable-model-invocation: true\n---\n\n## Steps\n\n1. Run pre-deployment checks\n2. Build the release artifact\n")
+
+	conv := &SkillsConverter{}
+
+	// Zed -> canonical
+	canonical, err := conv.Canonicalize(input, "zed")
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+
+	// canonical -> Zed
+	result, err := conv.Render(canonical.Content, provider.Zed)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	out := string(result.Content)
+	assertContains(t, out, "name: deploy-to-production")
+	assertContains(t, out, "description: Guides the deployment process")
+	assertContains(t, out, "disable-model-invocation: true")
+	assertContains(t, out, "pre-deployment checks")
+	assertContains(t, out, "release artifact")
+	assertEqual(t, "SKILL.md", result.Filename)
+}
+
 func TestSkillAllowedToolsCommaSeparated(t *testing.T) {
 	// Comma-separated string in frontmatter: "Read, Grep, Glob"
 	input := []byte("---\nname: test\nallowed-tools: \"Read, Grep, Glob\"\n---\n\nDo things.\n")

--- a/cli/internal/provider/zed.go
+++ b/cli/internal/provider/zed.go
@@ -14,6 +14,10 @@ var Zed = Provider{
 		switch ct {
 		case catalog.Rules:
 			return ProjectScopeSentinel // Rules go in project root as .rules
+		case catalog.Skills:
+			// Zed's only skills location is the cross-provider convention
+			// (https://zed.dev/docs/ai/skills) — no zed-native directory.
+			return filepath.Join(homeDir, ".agents", "skills")
 		case catalog.MCP:
 			return JSONMergeSentinel // Merges into ~/.config/zed/settings.json
 		}
@@ -34,6 +38,8 @@ var Zed = Provider{
 				filepath.Join(projectRoot, ".cursorrules"),
 				filepath.Join(projectRoot, "CLAUDE.md"),
 			}
+		case catalog.Skills:
+			return []string{filepath.Join(projectRoot, ".agents", "skills")}
 		default:
 			return nil
 		}
@@ -51,15 +57,16 @@ var Zed = Provider{
 	},
 	SupportsType: func(ct catalog.ContentType) bool {
 		switch ct {
-		case catalog.Rules, catalog.MCP:
+		case catalog.Rules, catalog.Skills, catalog.MCP:
 			return true
 		default:
 			return false
 		}
 	},
 	SymlinkSupport: map[catalog.ContentType]bool{
-		catalog.Rules: true,
-		catalog.MCP:   false, // JSON merge
+		catalog.Rules:  true,
+		catalog.Skills: true,
+		catalog.MCP:    false, // JSON merge
 	},
 	ConfigLocations: map[catalog.ContentType]string{
 		catalog.MCP: "~/.config/zed/settings.json",

--- a/cli/internal/provider/zed_test.go
+++ b/cli/internal/provider/zed_test.go
@@ -62,15 +62,39 @@ func TestZedDetect(t *testing.T) {
 
 func TestZedSupportsTypes(t *testing.T) {
 	t.Parallel()
-	for _, ct := range []catalog.ContentType{catalog.Rules, catalog.MCP} {
+	for _, ct := range []catalog.ContentType{catalog.Rules, catalog.Skills, catalog.MCP} {
 		if !Zed.SupportsType(ct) {
 			t.Errorf("Zed.SupportsType(%s) = false, want true", ct)
 		}
 	}
-	for _, ct := range []catalog.ContentType{catalog.Skills, catalog.Agents, catalog.Hooks, catalog.Commands} {
+	for _, ct := range []catalog.ContentType{catalog.Agents, catalog.Hooks, catalog.Commands} {
 		if Zed.SupportsType(ct) {
 			t.Errorf("Zed.SupportsType(%s) = true, want false", ct)
 		}
+	}
+}
+
+// TestZedSkillsPaths: Zed loads skills exclusively from the cross-provider
+// .agents/skills convention — ~/.agents/skills/<name>/SKILL.md globally and
+// <worktree>/.agents/skills/<name>/SKILL.md per project. There is no
+// zed-native skills directory (https://zed.dev/docs/ai/skills).
+func TestZedSkillsPaths(t *testing.T) {
+	t.Parallel()
+	if got, want := Zed.InstallDir("/home/user", catalog.Skills), filepath.Join("/home/user", ".agents", "skills"); got != want {
+		t.Errorf("Zed.InstallDir(Skills) = %q, want %q", got, want)
+	}
+	paths := Zed.DiscoveryPaths("/project", catalog.Skills)
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 Skills discovery path, got %d: %v", len(paths), paths)
+	}
+	if want := filepath.Join("/project", ".agents", "skills"); paths[0] != want {
+		t.Errorf("expected Skills discovery path %q, got %q", want, paths[0])
+	}
+	if !Zed.SymlinkSupport[catalog.Skills] {
+		t.Error("Zed.SymlinkSupport[Skills] = false, want true")
+	}
+	if got := Zed.FileFormat(catalog.Skills); got != FormatMarkdown {
+		t.Errorf("Zed.FileFormat(Skills) = %q, want %q", got, FormatMarkdown)
 	}
 }
 


### PR DESCRIPTION
## Why

PR #500 (Capability Feed mirror update) fails the non-required Coverage Drift check: the feed now asserts `zed/skills supported: true` but Go's `SupportsType` returned false. Zed shipped Agent Skills (SKILL.md folders under `~/.agents/skills/` and `<worktree>/.agents/skills/`, verified against https://zed.dev/docs/ai/skills). The `acceptedFeedDrift` policy only accepts drift for capabilities with no installable form — Zed skills are installable files, so this implements support instead.

## What

- **provider/zed**: skills via the cross-provider `.agents/skills` convention (codex pattern — it is Zed's only skills location, so `InstallDir` points at the shared dir and `GlobalSharedReadPaths` stays nil).
- **converter**: `zedSkillMeta` with Zed's three supported frontmatter keys (`name`, `description`, `disable-model-invocation`); `renderZedSkill` embeds unsupported canonical fields as prose notes.

## Testing

- TDD: provider tests (`TestZedSupportsTypes`, `TestZedSkillsPaths`) and converter tests (`TestClaudeSkillToZed`, `TestZedSkillRoundTrip`) written first and observed failing; `TestFrontmatterRegistry_Completeness` caught the converter registration requirement.
- Full `make test` passes; `SYLLAGO_COVERAGE_FEED=1` drift gate passes against main's mirror (no skills entry yet = no finding) and will agree with #500's updated mirror.

## Follow-ups (not in this PR)

- `docs/provider-formats/zed.yaml` still records skills as unsupported (capmon formatdoc refresh owns that file; strict Go↔YAML gate is env-gated off).
- `.develop/seeder-specs/zed-skills.yaml` records the now-stale negative result.
- After merge: update PR #500's branch so Coverage Drift re-runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKkjYnF9zuGSajoSVSRmz6
