### PR TITLE
Fix strict coverage gate: honor accepted drifts, run on every make test (syllago-zpg5h)

### DIFF
--- a/cli/internal/converter/adapter_crush.go
+++ b/cli/internal/converter/adapter_crush.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 func init() {
@@ -57,6 +58,15 @@ func (a *CrushAdapter) Encode(hooks *CanonicalHooks) (*EncodedResult, error) {
 			continue
 		}
 
+		// Crush's schema requires command; an empty one is invalid config.
+		if hook.Handler.Command == "" {
+			warnings = append(warnings, ConversionWarning{
+				Severity:    "warning",
+				Description: "crush hooks require a command; hook with empty command skipped",
+			})
+			continue
+		}
+
 		// 3. Non-blocking intent cannot be preserved: crush PreToolUse hooks
 		// always carry veto power (exit code 2 blocks).
 		if !hook.Blocking {
@@ -77,9 +87,9 @@ func (a *CrushAdapter) Encode(hooks *CanonicalHooks) (*EncodedResult, error) {
 		if hook.Matcher != nil {
 			translatedMatcher, mWarnings := TranslateMatcherToProvider(hook.Matcher, "crush")
 			warnings = append(warnings, mWarnings...)
-			if translatedMatcher != nil {
-				_ = json.Unmarshal(translatedMatcher, &matcherStr)
-			}
+			s, sWarnings := crushMatcherString(translatedMatcher)
+			matcherStr = s
+			warnings = append(warnings, sWarnings...)
 		}
 
 		entry := crushHookEntry{
@@ -100,6 +110,29 @@ func (a *CrushAdapter) Encode(hooks *CanonicalHooks) (*EncodedResult, error) {
 		Filename: "crush.json",
 		Warnings: warnings,
 	}, nil
+}
+
+// crushMatcherString renders a translated matcher as a crush regex string.
+// Crush matchers are a single regex tested against the tool name, so array
+// matchers join as an alternation. Shapes that can't be represented (e.g.
+// nested objects) drop to match-all with a warning rather than silently.
+func crushMatcherString(m json.RawMessage) (string, []ConversionWarning) {
+	if len(m) == 0 {
+		return "", nil
+	}
+	var s string
+	if json.Unmarshal(m, &s) == nil {
+		return s, nil
+	}
+	var parts []string
+	if json.Unmarshal(m, &parts) == nil {
+		return strings.Join(parts, "|"), nil
+	}
+	return "", []ConversionWarning{{
+		Severity:    "warning",
+		Capability:  "matcher",
+		Description: "matcher shape not representable as a crush regex; hook will match all tools",
+	}}
 }
 
 func (a *CrushAdapter) Decode(content []byte) (*CanonicalHooks, error) {

--- a/cli/internal/converter/adapter_crush.go
+++ b/cli/internal/converter/adapter_crush.go
@@ -1,0 +1,144 @@
+package converter
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func init() {
+	RegisterAdapter(&CrushAdapter{})
+}
+
+// CrushAdapter handles hooks for Crush (charmbracelet/crush).
+//
+// Crush stores hooks in its unified crush.json under the hooks key, an object
+// keyed by event name. PreToolUse is the only event. Each entry is a flat
+// HookConfig — {name?, matcher?, command, timeout?} — with no nested hooks
+// array, and timeouts in seconds (default 30). Crush's schema declares
+// additionalProperties: false, so no syllago metadata fields may be added.
+// Hooks run before permission checks; exit code 2 or a JSON decision of
+// "deny" blocks the tool call, so every crush hook is blocking-capable.
+type CrushAdapter struct{}
+
+func (a *CrushAdapter) ProviderSlug() string { return "crush" }
+
+// crushHookEntry is a single HookConfig in crush.json (schema.json HookConfig).
+type crushHookEntry struct {
+	Name    string `json:"name,omitempty"`
+	Matcher string `json:"matcher,omitempty"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"` // seconds
+}
+
+// crushHooksFile is the hooks section of crush.json.
+type crushHooksFile struct {
+	Hooks map[string][]crushHookEntry `json:"hooks"`
+}
+
+func (a *CrushAdapter) Encode(hooks *CanonicalHooks) (*EncodedResult, error) {
+	var warnings []ConversionWarning
+	result := crushHooksFile{Hooks: make(map[string][]crushHookEntry)}
+
+	for _, hook := range hooks.Hooks {
+		// 1. Translate event (crush supports before_tool_execute only)
+		nativeEvent, err := TranslateEventToProvider(hook.Event, "crush")
+		if err != nil {
+			warnings = append(warnings, ConversionWarning{
+				Severity:    "warning",
+				Description: fmt.Sprintf("hook event %q not supported by crush; skipped", hook.Event),
+			})
+			continue
+		}
+
+		// 2. Check handler type against the degradation policy (ADR 0001)
+		_, hWarnings, keep := TranslateHandlerType(hook.Handler, "crush", hook.Degradation)
+		warnings = append(warnings, hWarnings...)
+		if !keep {
+			continue
+		}
+
+		// 3. Non-blocking intent cannot be preserved: crush PreToolUse hooks
+		// always carry veto power (exit code 2 blocks).
+		if !hook.Blocking {
+			warnings = append(warnings, ConversionWarning{
+				Severity:    "info",
+				Description: "crush PreToolUse hooks always have veto power (exit code 2 blocks); non-blocking intent is not preserved",
+			})
+		}
+		if hook.Handler.Async {
+			warnings = append(warnings, ConversionWarning{
+				Severity:    "info",
+				Description: "crush hooks are synchronous; async flag dropped",
+			})
+		}
+
+		// 4. Translate matcher
+		var matcherStr string
+		if hook.Matcher != nil {
+			translatedMatcher, mWarnings := TranslateMatcherToProvider(hook.Matcher, "crush")
+			warnings = append(warnings, mWarnings...)
+			if translatedMatcher != nil {
+				_ = json.Unmarshal(translatedMatcher, &matcherStr)
+			}
+		}
+
+		entry := crushHookEntry{
+			Name:    hook.Name,
+			Matcher: matcherStr,
+			Command: hook.Handler.Command,
+			Timeout: TranslateTimeoutToProvider(hook.Handler.Timeout, "crush"),
+		}
+		result.Hooks[nativeEvent] = append(result.Hooks[nativeEvent], entry)
+	}
+
+	content, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return &EncodedResult{
+		Content:  content,
+		Filename: "crush.json",
+		Warnings: warnings,
+	}, nil
+}
+
+func (a *CrushAdapter) Decode(content []byte) (*CanonicalHooks, error) {
+	var file crushHooksFile
+	if err := json.Unmarshal(content, &file); err != nil {
+		return nil, fmt.Errorf("parsing crush hooks: %w", err)
+	}
+
+	ch := &CanonicalHooks{Spec: SpecVersion}
+
+	for nativeEvent, entries := range file.Hooks {
+		canonEvent, _ := TranslateEventFromProvider(nativeEvent, "crush")
+
+		for _, entry := range entries {
+			var matcherJSON json.RawMessage
+			if entry.Matcher != "" {
+				rawMatcher, _ := json.Marshal(entry.Matcher)
+				translatedMatcher, _ := TranslateMatcherFromProvider(rawMatcher, "crush")
+				matcherJSON = translatedMatcher
+			}
+
+			ch.Hooks = append(ch.Hooks, CanonicalHook{
+				Name:    entry.Name,
+				Event:   canonEvent,
+				Matcher: matcherJSON,
+				// Crush hooks run pre-permission with veto power.
+				Blocking: canonEvent == "before_tool_execute",
+				Handler: HookHandler{
+					Type:    "command",
+					Command: entry.Command,
+					Timeout: TranslateTimeoutFromProvider(entry.Timeout, "crush"),
+				},
+			})
+		}
+	}
+
+	return ch, nil
+}
+
+func (a *CrushAdapter) Capabilities() ProviderCapabilities {
+	return providerHookCapabilities[a.ProviderSlug()]
+}

--- a/cli/internal/converter/adapter_crush_test.go
+++ b/cli/internal/converter/adapter_crush_test.go
@@ -1,0 +1,271 @@
+package converter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestCrushAdapterEncode_Basic(t *testing.T) {
+	hooks := &CanonicalHooks{
+		Spec: SpecVersion,
+		Hooks: []CanonicalHook{
+			{
+				Name:     "guard-shell",
+				Event:    "before_tool_execute",
+				Matcher:  json.RawMessage(`"shell"`),
+				Blocking: true,
+				Handler: HookHandler{
+					Type:    "command",
+					Command: "echo check",
+					Timeout: 5,
+				},
+			},
+		},
+	}
+
+	adapter := AdapterFor("crush")
+	if adapter == nil {
+		t.Fatal("crush adapter not registered")
+	}
+	encoded, err := adapter.Encode(hooks)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	if encoded.Filename != "crush.json" {
+		t.Errorf("filename: got %q, want crush.json", encoded.Filename)
+	}
+
+	entry := gjson.GetBytes(encoded.Content, "hooks.PreToolUse.0")
+	if !entry.Exists() {
+		t.Fatalf("expected hooks.PreToolUse.0 in output, got: %s", encoded.Content)
+	}
+	if got := entry.Get("command").String(); got != "echo check" {
+		t.Errorf("command: got %q, want %q", got, "echo check")
+	}
+	// Canonical "shell" must translate to crush's native tool name "bash".
+	if got := entry.Get("matcher").String(); got != "bash" {
+		t.Errorf("matcher: got %q, want %q", got, "bash")
+	}
+	// Crush timeouts are seconds — canonical 5s stays 5, not 5000.
+	if got := entry.Get("timeout").Int(); got != 5 {
+		t.Errorf("timeout: got %d, want 5", got)
+	}
+	if got := entry.Get("name").String(); got != "guard-shell" {
+		t.Errorf("name: got %q, want %q", got, "guard-shell")
+	}
+}
+
+func TestCrushAdapterEncode_UnsupportedEventSkipped(t *testing.T) {
+	hooks := &CanonicalHooks{
+		Spec: SpecVersion,
+		Hooks: []CanonicalHook{
+			{
+				Event:   "session_start",
+				Handler: HookHandler{Type: "command", Command: "echo hi"},
+			},
+		},
+	}
+
+	encoded, err := AdapterFor("crush").Encode(hooks)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if gjson.GetBytes(encoded.Content, "hooks.session_start").Exists() ||
+		gjson.GetBytes(encoded.Content, "hooks.SessionStart").Exists() {
+		t.Error("unsupported event should not appear in output")
+	}
+	if len(encoded.Warnings) == 0 {
+		t.Error("expected a warning for the skipped event")
+	}
+}
+
+func TestCrushAdapterEncode_DegradationBlock(t *testing.T) {
+	hooks := &CanonicalHooks{
+		Spec: SpecVersion,
+		Hooks: []CanonicalHook{
+			{
+				Event:       "before_tool_execute",
+				Degradation: map[string]string{"llm_evaluated": "block"},
+				Handler:     HookHandler{Type: "prompt", Prompt: "Is this safe?"},
+			},
+		},
+	}
+
+	encoded, err := AdapterFor("crush").Encode(hooks)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if gjson.GetBytes(encoded.Content, "hooks.PreToolUse").Exists() {
+		t.Error("blocked hook should not appear in output")
+	}
+	var sawError bool
+	for _, w := range encoded.Warnings {
+		if w.Severity == "error" {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Errorf("expected error-severity warning from block degradation, got: %+v", encoded.Warnings)
+	}
+}
+
+func TestCrushAdapterEncode_LLMExcludedByDefault(t *testing.T) {
+	hooks := &CanonicalHooks{
+		Spec: SpecVersion,
+		Hooks: []CanonicalHook{
+			{
+				Event:   "before_tool_execute",
+				Handler: HookHandler{Type: "prompt", Prompt: "Is this safe?"},
+			},
+		},
+	}
+
+	encoded, err := AdapterFor("crush").Encode(hooks)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if gjson.GetBytes(encoded.Content, "hooks.PreToolUse").Exists() {
+		t.Error("LLM hook should be excluded for crush")
+	}
+	if len(encoded.Warnings) == 0 {
+		t.Error("expected a warning for the excluded LLM hook")
+	}
+}
+
+func TestCrushAdapterEncode_NonBlockingWarns(t *testing.T) {
+	hooks := &CanonicalHooks{
+		Spec: SpecVersion,
+		Hooks: []CanonicalHook{
+			{
+				Event:    "before_tool_execute",
+				Blocking: false,
+				Handler:  HookHandler{Type: "command", Command: "echo log"},
+			},
+		},
+	}
+
+	encoded, err := AdapterFor("crush").Encode(hooks)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	// The hook is still encoded (command unchanged) but crush PreToolUse hooks
+	// always carry veto power, so the non-blocking intent is flagged.
+	if got := gjson.GetBytes(encoded.Content, "hooks.PreToolUse.0.command").String(); got != "echo log" {
+		t.Errorf("command: got %q, want %q", got, "echo log")
+	}
+	if len(encoded.Warnings) == 0 {
+		t.Error("expected an info warning that non-blocking intent is not preserved")
+	}
+}
+
+func TestCrushAdapterDecode_Basic(t *testing.T) {
+	input := []byte(`{
+		"hooks": {
+			"PreToolUse": [
+				{"name": "guard-shell", "matcher": "bash", "command": "echo check", "timeout": 5}
+			]
+		}
+	}`)
+
+	hooks, err := AdapterFor("crush").Decode(input)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(hooks.Hooks) != 1 {
+		t.Fatalf("expected 1 hook, got %d", len(hooks.Hooks))
+	}
+	h := hooks.Hooks[0]
+	assertEqual(t, "before_tool_execute", h.Event)
+	assertEqual(t, "guard-shell", h.Name)
+	assertEqual(t, "echo check", h.Handler.Command)
+	assertEqual(t, "command", h.Handler.Type)
+	// Crush native "bash" reverse-translates to canonical "shell".
+	var matcher string
+	if err := json.Unmarshal(h.Matcher, &matcher); err != nil {
+		t.Fatalf("matcher unmarshal: %v", err)
+	}
+	assertEqual(t, "shell", matcher)
+	// Seconds stay seconds.
+	if h.Handler.Timeout != 5 {
+		t.Errorf("timeout: got %d, want 5", h.Handler.Timeout)
+	}
+	// Crush PreToolUse hooks run before permission checks with veto power.
+	if !h.Blocking {
+		t.Error("crush hooks should decode as blocking")
+	}
+}
+
+func TestCrushAdapter_VerifyRoundTrip(t *testing.T) {
+	original := &CanonicalHooks{
+		Spec: SpecVersion,
+		Hooks: []CanonicalHook{
+			{
+				Name:     "rt",
+				Event:    "before_tool_execute",
+				Matcher:  json.RawMessage(`"shell"`),
+				Blocking: true,
+				Handler: HookHandler{
+					Type:    "command",
+					Command: "echo rt",
+					Timeout: 10,
+				},
+			},
+		},
+	}
+
+	adapter := AdapterFor("crush")
+	encoded, err := adapter.Encode(original)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if err := Verify(encoded, adapter, original); err != nil {
+		t.Errorf("Verify: %v", err)
+	}
+}
+
+func TestCrushAdapter_Capabilities(t *testing.T) {
+	caps := AdapterFor("crush").Capabilities()
+	if len(caps.Events) != 1 || caps.Events[0] != "before_tool_execute" {
+		t.Errorf("events: got %v, want [before_tool_execute]", caps.Events)
+	}
+	if !caps.SupportsMatchers {
+		t.Error("crush supports matchers")
+	}
+	if !caps.SupportsBlocking {
+		t.Error("crush supports blocking (exit code 2 / deny decision)")
+	}
+	if !caps.SupportsStructuredOutput {
+		t.Error("crush supports structured output (JSON decision/context)")
+	}
+	if caps.TimeoutUnit != "seconds" {
+		t.Errorf("timeout unit: got %q, want seconds", caps.TimeoutUnit)
+	}
+	if caps.SupportsAsync {
+		t.Error("crush hooks are synchronous")
+	}
+	if caps.SupportsLLMHooks || caps.SupportsHTTPHooks {
+		t.Error("crush supports command hooks only")
+	}
+}
+
+func TestTranslateHookEvent_Crush(t *testing.T) {
+	got, ok := TranslateHookEvent("before_tool_execute", "crush")
+	if !ok || got != "PreToolUse" {
+		t.Errorf("before_tool_execute: got (%q, %v), want (PreToolUse, true)", got, ok)
+	}
+	if _, ok := TranslateHookEvent("session_start", "crush"); ok {
+		t.Error("session_start should not be supported by crush")
+	}
+}
+
+func TestTranslateMatcher_Crush(t *testing.T) {
+	if got := TranslateMatcher("file_edit|shell", "crush"); got != "edit|bash" {
+		t.Errorf("got %q, want edit|bash", got)
+	}
+	if got := ReverseTranslateTool("view", "crush"); got != "file_read" {
+		t.Errorf("got %q, want file_read", got)
+	}
+}

--- a/cli/internal/converter/adapter_crush_test.go
+++ b/cli/internal/converter/adapter_crush_test.go
@@ -161,6 +161,55 @@ func TestCrushAdapterEncode_NonBlockingWarns(t *testing.T) {
 	}
 }
 
+func TestCrushAdapterEncode_ArrayMatcherJoins(t *testing.T) {
+	// Spec-valid array matchers must become a regex alternation, not silently
+	// vanish into a match-all entry (Codex review finding on PR #505).
+	hooks := &CanonicalHooks{
+		Spec: SpecVersion,
+		Hooks: []CanonicalHook{
+			{
+				Event:    "before_tool_execute",
+				Matcher:  json.RawMessage(`["shell","file_write"]`),
+				Blocking: true,
+				Handler:  HookHandler{Type: "command", Command: "echo check"},
+			},
+		},
+	}
+
+	encoded, err := AdapterFor("crush").Encode(hooks)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if got := gjson.GetBytes(encoded.Content, "hooks.PreToolUse.0.matcher").String(); got != "bash|write" {
+		t.Errorf("matcher: got %q, want %q", got, "bash|write")
+	}
+}
+
+func TestCrushAdapterEncode_EmptyCommandSkipped(t *testing.T) {
+	// Crush's schema requires command; an empty command entry is invalid
+	// config and must be skipped with a warning (Codex review finding).
+	hooks := &CanonicalHooks{
+		Spec: SpecVersion,
+		Hooks: []CanonicalHook{
+			{
+				Event:   "before_tool_execute",
+				Handler: HookHandler{Type: "command", Command: ""},
+			},
+		},
+	}
+
+	encoded, err := AdapterFor("crush").Encode(hooks)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if gjson.GetBytes(encoded.Content, "hooks.PreToolUse").Exists() {
+		t.Errorf("empty-command hook should be skipped, got: %s", encoded.Content)
+	}
+	if len(encoded.Warnings) == 0 {
+		t.Error("expected a warning for the skipped empty-command hook")
+	}
+}
+
 func TestCrushAdapterDecode_Basic(t *testing.T) {
 	input := []byte(`{
 		"hooks": {

--- a/cli/internal/converter/adapter_test.go
+++ b/cli/internal/converter/adapter_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAdapterRegistry(t *testing.T) {
 	// All expected adapters should be registered via init()
-	expected := []string{"claude-code", "gemini-cli", "copilot-cli", "kiro", "cursor", "windsurf", "vs-code-copilot", "factory-droid", "pi"}
+	expected := []string{"claude-code", "gemini-cli", "copilot-cli", "kiro", "cursor", "windsurf", "vs-code-copilot", "factory-droid", "pi", "crush"}
 	for _, slug := range expected {
 		if AdapterFor(slug) == nil {
 			t.Errorf("expected adapter for %q to be registered", slug)

--- a/cli/internal/converter/capabilities.go
+++ b/cli/internal/converter/capabilities.go
@@ -145,6 +145,24 @@ var providerHookCapabilities = map[string]ProviderCapabilities{
 		SupportsCWD:           true,
 		SupportsEnv:           true,
 	},
+	"crush": {
+		// Crush fires hooks only before tool execution (PreToolUse); they run
+		// before permission checks with veto power (exit code 2 or a JSON
+		// decision of "deny" blocks the tool call).
+		Events: []string{"before_tool_execute"},
+
+		SupportsMatchers:         true,
+		SupportsAsync:            false,
+		SupportsStatusMessage:    false,
+		SupportsStructuredOutput: true, // JSON response: decision + context
+		SupportsBlocking:         true,
+		TimeoutUnit:              "seconds",
+		SupportsPlatform:         false,
+		SupportsCWD:              false,
+		SupportsEnv:              false,
+		SupportsLLMHooks:         false,
+		SupportsHTTPHooks:        false,
+	},
 	"pi": {
 		Events: []string{
 			"before_tool_execute", "after_tool_execute", "session_start", "session_end",

--- a/cli/internal/converter/compat.go
+++ b/cli/internal/converter/compat.go
@@ -112,11 +112,20 @@ var HookCapabilities = map[string]ProviderCapability{
 			FeatureTimeout:       {Supported: true, Notes: "milliseconds"},
 		},
 	},
+	"crush": {
+		Features: map[HookFeature]FeatureSupport{
+			FeatureMatcher:       {Supported: true, Notes: "regex against tool name"},
+			FeatureAsync:         {Supported: false, LostLevel: CompatBroken, Notes: "hook will block execution"},
+			FeatureStatusMessage: {Supported: false, LostLevel: CompatDegraded, Notes: "no user-visible status"},
+			FeatureLLMHook:       {Supported: false, LostLevel: CompatNone},
+			FeatureTimeout:       {Supported: true, Notes: "seconds"},
+		},
+	},
 }
 
 // HookProviders returns the slugs of providers that support hooks, in display order.
 func HookProviders() []string {
-	return []string{"claude-code", "gemini-cli", "copilot-cli", "kiro", "vs-code-copilot"}
+	return []string{"claude-code", "gemini-cli", "copilot-cli", "kiro", "vs-code-copilot", "crush"}
 }
 
 // --- Structured output capabilities ---
@@ -182,6 +191,11 @@ var HookOutputCapabilities = map[string]map[HookOutputField]bool{
 	},
 	"kiro":     {}, // No structured output support
 	"windsurf": {}, // No structured output support
+	"crush": {
+		// Crush hook responses support decision (allow/deny/none) and context
+		OutputDecision: true,
+		OutputContext:  true,
+	},
 }
 
 // OutputFieldsLostWarnings compares source and target provider structured output

--- a/cli/internal/converter/compat_test.go
+++ b/cli/internal/converter/compat_test.go
@@ -171,9 +171,11 @@ func TestAnalyzeHookCompat_Async_Copilot_Broken(t *testing.T) {
 
 func TestAnalyzeHookCompat_NoMatcher_FullEverywhere(t *testing.T) {
 	t.Parallel()
-	// Hook with no matcher, no async, no statusMessage — should be Full everywhere
+	// Hook with no matcher, no async, no statusMessage — should be Full
+	// everywhere. Uses before_tool_execute: the only event every hook
+	// provider supports (crush supports nothing else).
 	hook := HookData{
-		Event: "session_start",
+		Event: "before_tool_execute",
 		Hooks: []HookEntry{{Type: "command", Command: "echo start"}},
 	}
 	for _, target := range HookProviders() {

--- a/cli/internal/converter/hookhelpers.go
+++ b/cli/internal/converter/hookhelpers.go
@@ -47,8 +47,8 @@ func TranslateTimeoutToProvider(seconds int, slug string) int {
 		return 0
 	}
 	switch slug {
-	case "copilot-cli":
-		return seconds // Copilot uses seconds natively
+	case "copilot-cli", "crush":
+		return seconds // Copilot and Crush use seconds natively
 	default:
 		return seconds * 1000 // CC, Gemini, Cursor, Kiro all use milliseconds
 	}
@@ -61,8 +61,8 @@ func TranslateTimeoutFromProvider(value int, slug string) int {
 		return 0
 	}
 	switch slug {
-	case "copilot-cli":
-		return value // Copilot already in seconds
+	case "copilot-cli", "crush":
+		return value // Copilot and Crush already in seconds
 	default:
 		return value / 1000 // CC, Gemini, Cursor, Kiro use milliseconds
 	}

--- a/cli/internal/converter/hooks.go
+++ b/cli/internal/converter/hooks.go
@@ -234,6 +234,8 @@ func (c *HooksConverter) Canonicalize(content []byte, sourceProvider string) (*R
 	switch sourceProvider {
 	case "copilot-cli":
 		return canonicalizeCopilotHooks(content)
+	case "crush":
+		return canonicalizeCrushHooks(content)
 	case "cursor":
 		// Cursor hooks use CC-style event names (mapped via HookEvents).
 		// Unique fields (failClosed, loop_limit, version) are not yet preserved.
@@ -304,6 +306,8 @@ func (c *HooksConverter) Render(content []byte, target provider.Provider) (*Resu
 	switch target.Slug {
 	case "copilot-cli":
 		return renderCopilotHooks(cfg, mode)
+	case "crush":
+		return renderCrushHooks(cfg)
 	case "kiro":
 		return renderKiroHooks(cfg, mode)
 	case "cursor":
@@ -403,6 +407,43 @@ func canonicalizeCopilotHooks(content []byte) (*Result, error) {
 			})
 		}
 		canonical.Hooks[canonicalEvent] = matchers
+	}
+
+	out, err := json.MarshalIndent(canonical, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return &Result{Content: out, Filename: "hooks.json"}, nil
+}
+
+// canonicalizeCrushHooks parses crush.json hook content. Crush entries are
+// flat ({command, matcher, timeout}) rather than CC-shape matcher groups,
+// and timeouts are seconds — already the canonical unit.
+func canonicalizeCrushHooks(content []byte) (*Result, error) {
+	var file struct {
+		Hooks map[string][]crushHookEntry `json:"hooks"`
+	}
+	if err := json.Unmarshal(content, &file); err != nil {
+		return nil, fmt.Errorf("parsing crush hooks JSON: %w", err)
+	}
+
+	canonical := hooksConfig{Hooks: make(map[string][]hookMatcher), SourceProvider: "crush"}
+	for event, entries := range file.Hooks {
+		canonicalEvent := ReverseTranslateHookEvent(event, "crush")
+		for _, e := range entries {
+			matcher := e.Matcher
+			if matcher != "" {
+				matcher = ReverseTranslateMatcher(matcher, "crush")
+			}
+			canonical.Hooks[canonicalEvent] = append(canonical.Hooks[canonicalEvent], hookMatcher{
+				Matcher: matcher,
+				Hooks: []HookEntry{{
+					Type:    "command",
+					Command: e.Command,
+					Timeout: e.Timeout,
+				}},
+			})
+		}
 	}
 
 	out, err := json.MarshalIndent(canonical, "", "  ")
@@ -595,6 +636,59 @@ func renderCopilotHooks(cfg hooksConfig, llmMode string) (*Result, error) {
 		r.ExtraFiles = extraFiles
 	}
 	return r, nil
+}
+
+// renderCrushHooks renders canonical hooks into crush's flat entry shape.
+// Only before_tool_execute maps to a crush event (PreToolUse). LLM-evaluated
+// and http hooks are dropped with a warning — crush hooks are shell commands
+// only, and syllago has no wrapper-script generation for crush.
+func renderCrushHooks(cfg hooksConfig) (*Result, error) {
+	var warnings []string
+	if cfg.SourceProvider != "" {
+		warnings = append(warnings, structuredOutputWarnings(cfg.SourceProvider, "crush")...)
+	}
+
+	out := struct {
+		Hooks map[string][]crushHookEntry `json:"hooks"`
+	}{Hooks: make(map[string][]crushHookEntry)}
+
+	for event, matchers := range cfg.Hooks {
+		targetEvent, supported := TranslateHookEvent(event, "crush")
+		if !supported {
+			warnings = append(warnings, fmt.Sprintf("hook event %q is not supported by crush (dropped)", event))
+			continue
+		}
+
+		for _, m := range matchers {
+			matcher := ""
+			if m.Matcher != "" {
+				matcher = TranslateMatcher(m.Matcher, "crush")
+			}
+
+			for _, h := range m.Hooks {
+				hType := h.Type
+				if hType == "" {
+					hType = "command"
+				}
+				if hType != "command" {
+					warnings = append(warnings, fmt.Sprintf("hook type %q is not supported by crush; dropped", hType))
+					continue
+				}
+				// Canonical timeout is seconds — crush reads seconds natively.
+				out.Hooks[targetEvent] = append(out.Hooks[targetEvent], crushHookEntry{
+					Matcher: matcher,
+					Command: h.Command,
+					Timeout: h.Timeout,
+				})
+			}
+		}
+	}
+
+	result, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return &Result{Content: result, Filename: "crush.json", Warnings: warnings}, nil
 }
 
 // --- Kiro hooks ---

--- a/cli/internal/converter/hooks_test.go
+++ b/cli/internal/converter/hooks_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/tidwall/gjson"
 )
 
 func TestClaudeHooksToGemini(t *testing.T) {
@@ -620,6 +621,87 @@ func TestRenderFlat_Copilot(t *testing.T) {
 	assertContains(t, out, "\"version\": 1")
 	// Type field
 	assertContains(t, out, "\"type\": \"command\"")
+}
+
+func TestRenderFlat_Crush(t *testing.T) {
+	t.Parallel()
+	hook := HookData{
+		Event:   "before_tool_execute",
+		Matcher: "shell",
+		Hooks:   []HookEntry{{Type: "command", Command: "echo check", Timeout: 3}},
+	}
+	conv := &HooksConverter{}
+	result, err := conv.RenderFlat(hook, provider.Crush)
+	if err != nil {
+		t.Fatalf("RenderFlat: %v", err)
+	}
+	entry := gjson.GetBytes(result.Content, "hooks.PreToolUse.0")
+	if !entry.Exists() {
+		t.Fatalf("expected hooks.PreToolUse.0, got: %s", result.Content)
+	}
+	// Crush entries are flat — command lives directly on the entry, not in a
+	// nested hooks array.
+	if got := entry.Get("command").String(); got != "echo check" {
+		t.Errorf("command: got %q, want %q", got, "echo check")
+	}
+	if entry.Get("hooks").Exists() {
+		t.Error("crush entries must not contain a nested hooks array")
+	}
+	if got := entry.Get("matcher").String(); got != "bash" {
+		t.Errorf("matcher: got %q, want bash", got)
+	}
+	// Seconds stay seconds — 3 must not become 3000.
+	if got := entry.Get("timeout").Int(); got != 3 {
+		t.Errorf("timeout: got %d, want 3", got)
+	}
+}
+
+func TestRenderCrush_UnsupportedEventDropped(t *testing.T) {
+	t.Parallel()
+	hook := HookData{
+		Event: "session_start",
+		Hooks: []HookEntry{{Type: "command", Command: "echo hi"}},
+	}
+	conv := &HooksConverter{}
+	result, err := conv.RenderFlat(hook, provider.Crush)
+	if err != nil {
+		t.Fatalf("RenderFlat: %v", err)
+	}
+	if gjson.GetBytes(result.Content, "hooks").Exists() &&
+		len(gjson.GetBytes(result.Content, "hooks").Map()) > 0 {
+		t.Errorf("unsupported event should be dropped, got: %s", result.Content)
+	}
+	if len(result.Warnings) == 0 {
+		t.Error("expected warning for unsupported event")
+	}
+}
+
+func TestCanonicalize_Crush(t *testing.T) {
+	t.Parallel()
+	input := `{"hooks":{"PreToolUse":[{"matcher":"bash","command":"echo safe","timeout":5}]}}`
+	conv := &HooksConverter{}
+	result, err := conv.Canonicalize([]byte(input), "crush")
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	var cfg hooksConfig
+	if err := json.Unmarshal(result.Content, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	matchers, ok := cfg.Hooks["before_tool_execute"]
+	if !ok || len(matchers) != 1 {
+		t.Fatalf("expected 1 before_tool_execute matcher group, got: %+v", cfg.Hooks)
+	}
+	if matchers[0].Matcher != "shell" {
+		t.Errorf("matcher: got %q, want shell", matchers[0].Matcher)
+	}
+	if len(matchers[0].Hooks) != 1 || matchers[0].Hooks[0].Command != "echo safe" {
+		t.Fatalf("hooks: got %+v", matchers[0].Hooks)
+	}
+	// Crush timeouts are seconds — canonical unit, no /1000.
+	if matchers[0].Hooks[0].Timeout != 5 {
+		t.Errorf("timeout: got %d, want 5", matchers[0].Hooks[0].Timeout)
+	}
 }
 
 func TestLoadHookData_DirectoryFormat(t *testing.T) {

--- a/cli/internal/converter/split.go
+++ b/cli/internal/converter/split.go
@@ -34,7 +34,30 @@ func SplitSettingsHooks(content []byte, sourceProvider string) ([]HookData, erro
 	for event, matchersRaw := range eventMap {
 		canonicalEvent := ReverseTranslateHookEvent(event, sourceProvider)
 
-		if sourceProvider == "copilot-cli" {
+		switch sourceProvider {
+		case "crush":
+			// Crush format: flat entries {name, matcher, command, timeout};
+			// timeouts are seconds — already the canonical unit.
+			var entries []crushHookEntry
+			if err := json.Unmarshal(matchersRaw, &entries); err != nil {
+				return nil, fmt.Errorf("parsing crush hooks for event %q: %w", event, err)
+			}
+			for _, e := range entries {
+				matcher := e.Matcher
+				if matcher != "" {
+					matcher = ReverseTranslateMatcher(matcher, "crush")
+				}
+				items = append(items, HookData{
+					Event:   canonicalEvent,
+					Matcher: matcher,
+					Hooks: []HookEntry{{
+						Type:    "command",
+						Command: e.Command,
+						Timeout: e.Timeout,
+					}},
+				})
+			}
+		case "copilot-cli":
 			// Copilot format: array of {bash, powershell, timeoutSec, comment}
 			var entries []copilotHookEntry
 			if err := json.Unmarshal(matchersRaw, &entries); err != nil {
@@ -57,7 +80,7 @@ func SplitSettingsHooks(content []byte, sourceProvider string) ([]HookData, erro
 					Hooks: []HookEntry{he},
 				})
 			}
-		} else {
+		default:
 			// Standard format (claude-code, gemini-cli, kiro): array of {matcher, hooks[]}
 			var matchers []hookMatcher
 			if err := json.Unmarshal(matchersRaw, &matchers); err != nil {

--- a/cli/internal/converter/split_test.go
+++ b/cli/internal/converter/split_test.go
@@ -40,6 +40,45 @@ func TestSplitSettingsHooks_GeminiCLI(t *testing.T) {
 	}
 }
 
+func TestSplitSettingsHooks_Crush(t *testing.T) {
+	// Crush stores flat entries ({command, matcher, timeout}) under each event
+	// key — no nested matcher groups — with timeouts in seconds.
+	input := `{"hooks":{"PreToolUse":[{"matcher":"bash","command":"echo check","timeout":5},{"command":"echo all"}]}}`
+	items, err := SplitSettingsHooks([]byte(input), "crush")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	byCmd := map[string]HookData{}
+	for _, it := range items {
+		if it.Event != "before_tool_execute" {
+			t.Errorf("expected event before_tool_execute, got %q", it.Event)
+		}
+		if len(it.Hooks) != 1 {
+			t.Fatalf("expected 1 hook entry per item, got %d", len(it.Hooks))
+		}
+		byCmd[it.Hooks[0].Command] = it
+	}
+	matched, ok := byCmd["echo check"]
+	if !ok {
+		t.Fatal("missing item for 'echo check'")
+	}
+	if matched.Matcher != "shell" {
+		t.Errorf("expected canonical matcher shell, got %q", matched.Matcher)
+	}
+	// Crush timeouts are already seconds — must NOT be divided by 1000.
+	if matched.Hooks[0].Timeout != 5 {
+		t.Errorf("expected timeout 5, got %d", matched.Hooks[0].Timeout)
+	}
+	if all, ok := byCmd["echo all"]; !ok {
+		t.Fatal("missing item for 'echo all'")
+	} else if all.Matcher != "" {
+		t.Errorf("expected empty matcher, got %q", all.Matcher)
+	}
+}
+
 func TestSplitSettingsHooks_CopilotCLI(t *testing.T) {
 	input := `{"hooks":{"preToolUse":[{"bash":"echo check","timeoutSec":5,"comment":"Safety"}]}}`
 	items, err := SplitSettingsHooks([]byte(input), "copilot-cli")

--- a/cli/internal/converter/toolmap.go
+++ b/cli/internal/converter/toolmap.go
@@ -22,6 +22,7 @@ var ToolNames = map[string]map[string]string{
 		"codex":           "read_file",
 		"factory-droid":   "Read",
 		"pi":              "read",
+		"crush":           "view",
 	},
 	"file_write": {
 		"claude-code":     "Write",
@@ -37,6 +38,7 @@ var ToolNames = map[string]map[string]string{
 		"codex":           "apply_patch",
 		"factory-droid":   "Create",
 		"pi":              "write",
+		"crush":           "write",
 	},
 	"file_edit": {
 		"claude-code":     "Edit",
@@ -52,6 +54,7 @@ var ToolNames = map[string]map[string]string{
 		"codex":           "apply_patch",
 		"factory-droid":   "Edit",
 		"pi":              "edit",
+		"crush":           "edit",
 	},
 	"shell": {
 		"claude-code":     "Bash",
@@ -67,6 +70,7 @@ var ToolNames = map[string]map[string]string{
 		"codex":           "shell",
 		"factory-droid":   "Execute",
 		"pi":              "bash",
+		"crush":           "bash",
 	},
 	"find": {
 		"claude-code":     "Glob",
@@ -82,6 +86,7 @@ var ToolNames = map[string]map[string]string{
 		"codex":           "list_dir",
 		"factory-droid":   "Glob",
 		"pi":              "find",
+		"crush":           "glob",
 	},
 	"search": {
 		"claude-code":     "Grep",
@@ -97,6 +102,7 @@ var ToolNames = map[string]map[string]string{
 		"codex":           "grep_files",
 		"factory-droid":   "Grep",
 		"pi":              "grep",
+		"crush":           "grep",
 	},
 	"web_search": {
 		"claude-code":     "WebSearch",
@@ -109,7 +115,10 @@ var ToolNames = map[string]map[string]string{
 		"codex":           "web_search",
 		"kiro":            "web_search",
 		"factory-droid":   "WebSearch",
+		"crush":           "web_search",
 	},
+	// No crush entry: crush's native "agent" equals the canonical name, and
+	// this row is pinned verbatim to ACIF Appendix A (see acif/agentitem_test.go).
 	"agent": {
 		"claude-code":     "Agent",
 		"copilot-cli":     "task",
@@ -130,6 +139,7 @@ var ToolNames = map[string]map[string]string{
 		"zed":             "fetch",
 		"windsurf":        "read_url_content",
 		"factory-droid":   "FetchUrl",
+		"crush":           "web_fetch",
 	},
 	// Pi exposes an `ls` directory-listing tool distinct from `find`
 	"list": {"pi": "ls"},
@@ -146,7 +156,7 @@ var ToolNames = map[string]map[string]string{
 // HookEvents maps canonical (provider-neutral) event names to provider-specific equivalents.
 // Keys are snake_case neutral names; every provider including claude-code has an explicit entry.
 var HookEvents = map[string]map[string]string{
-	"before_tool_execute": {"claude-code": "PreToolUse", "gemini-cli": "BeforeTool", "copilot-cli": "preToolUse", "kiro": "preToolUse", "cursor": "PreToolUse", "opencode": "tool.execute.before", "vs-code-copilot": "PreToolUse", "factory-droid": "PreToolUse", "pi": "tool_call"},
+	"before_tool_execute": {"claude-code": "PreToolUse", "gemini-cli": "BeforeTool", "copilot-cli": "preToolUse", "kiro": "preToolUse", "cursor": "PreToolUse", "opencode": "tool.execute.before", "vs-code-copilot": "PreToolUse", "factory-droid": "PreToolUse", "pi": "tool_call", "crush": "PreToolUse"},
 	"after_tool_execute":  {"claude-code": "PostToolUse", "gemini-cli": "AfterTool", "copilot-cli": "postToolUse", "kiro": "postToolUse", "cursor": "PostToolUse", "opencode": "tool.execute.after", "vs-code-copilot": "PostToolUse", "factory-droid": "PostToolUse", "pi": "tool_result"},
 	"before_prompt":       {"claude-code": "UserPromptSubmit", "gemini-cli": "BeforeAgent", "copilot-cli": "userPromptSubmitted", "kiro": "userPromptSubmit", "cursor": "UserPromptSubmit", "windsurf": "pre_user_prompt", "vs-code-copilot": "UserPromptSubmit", "factory-droid": "UserPromptSubmit", "pi": "input"},
 	"agent_stop":          {"claude-code": "Stop", "gemini-cli": "AfterAgent", "kiro": "stop", "copilot-cli": "agentStop", "cursor": "Stop", "windsurf": "post_cascade_response", "opencode": "session.idle", "vs-code-copilot": "Stop", "factory-droid": "Stop", "pi": "agent_end"},

--- a/cli/internal/installer/hooks.go
+++ b/cli/internal/installer/hooks.go
@@ -43,16 +43,17 @@ func hookSettingsPathImpl(prov provider.Provider) (string, error) {
 }
 
 // parseHookFile reads a canonical hook.json (hooks/0.1 Manifest) and returns
-// the event plus a provider-settings matcher group JSON built from the
-// single hook's handler. If path is a directory, resolves hook.json inside it.
+// the event, the manifest's optional hook name, and a provider-settings
+// matcher group JSON built from the single hook's handler. If path is a
+// directory, resolves hook.json inside it.
 //
 // The returned matcher group has shape {matcher, hooks:[entry]} — the same
 // shape provider settings.json expects. Syllago-written hook.json always
 // contains exactly one hook per Manifest (see converter.SplitSettingsHooks).
-func parseHookFile(path string) (event string, matcherGroup []byte, err error) {
+func parseHookFile(path string) (event string, hookName string, matcherGroup []byte, err error) {
 	fi, err := os.Stat(path)
 	if err != nil {
-		return "", nil, err
+		return "", "", nil, err
 	}
 	if fi.IsDir() {
 		path = filepath.Join(path, "hook.json")
@@ -60,20 +61,20 @@ func parseHookFile(path string) (event string, matcherGroup []byte, err error) {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", nil, err
+		return "", "", nil, err
 	}
 
 	manifest, err := converter.ParseManifest(data)
 	if err != nil {
-		return "", nil, err
+		return "", "", nil, err
 	}
 	if len(manifest.Hooks) != 1 {
-		return "", nil, fmt.Errorf("hook file has %d hooks; syllago hook.json must contain exactly 1", len(manifest.Hooks))
+		return "", "", nil, fmt.Errorf("hook file has %d hooks; syllago hook.json must contain exactly 1", len(manifest.Hooks))
 	}
 
 	hds, err := converter.HookDataFromManifest(manifest)
 	if err != nil {
-		return "", nil, fmt.Errorf("converting manifest: %w", err)
+		return "", "", nil, fmt.Errorf("converting manifest: %w", err)
 	}
 	hd := hds[0]
 
@@ -87,15 +88,15 @@ func parseHookFile(path string) (event string, matcherGroup []byte, err error) {
 	}
 	matcherGroup, err = json.Marshal(group)
 	if err != nil {
-		return "", nil, fmt.Errorf("building matcher group: %w", err)
+		return "", "", nil, fmt.Errorf("building matcher group: %w", err)
 	}
 
-	return hd.Event, matcherGroup, nil
+	return hd.Event, manifest.Hooks[0].Name, matcherGroup, nil
 }
 
 func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot string) (string, error) {
 	// item.Path is already absolute (set by scanner)
-	event, matcherGroup, err := parseHookFile(item.Path)
+	event, hookName, matcherGroup, err := parseHookFile(item.Path)
 	if err != nil {
 		return "", fmt.Errorf("parsing hook file: %w", err)
 	}
@@ -156,11 +157,16 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 		return "", err
 	}
 
-	// Crush stores flat hook entries ({command, matcher, timeout}) rather
-	// than CC-shape matcher groups. Flatten last so the whitelist, scanner,
-	// and script-resolution steps above all see the standard shape.
+	// Crush stores flat hook entries ({name, command, matcher, timeout})
+	// rather than CC-shape matcher groups, and fires hooks only on
+	// PreToolUse — any other event key would be dead config crush never
+	// reads. Flatten last so the whitelist, scanner, and script-resolution
+	// steps above all see the standard shape.
 	if prov.Slug == "crush" {
-		matcherGroup, err = flattenForCrush(matcherGroup)
+		if event != "PreToolUse" {
+			return "", fmt.Errorf("hook %q: crush supports only the before_tool_execute (PreToolUse) hook event; got %q", item.Name, event)
+		}
+		matcherGroup, err = flattenForCrush(matcherGroup, hookName)
 		if err != nil {
 			return "", fmt.Errorf("hook %q: %w", item.Name, err)
 		}
@@ -235,7 +241,7 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 
 func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot string) (string, error) {
 	// item.Path is already absolute (set by scanner)
-	event, _, err := parseHookFile(item.Path)
+	event, _, _, err := parseHookFile(item.Path)
 	if err != nil {
 		return "", fmt.Errorf("parsing hook file: %w", err)
 	}
@@ -333,7 +339,7 @@ func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot st
 
 func checkHookStatus(item catalog.ContentItem, prov provider.Provider, repoRoot string) Status {
 	// item.Path is already absolute (set by scanner)
-	event, _, err := parseHookFile(item.Path)
+	event, _, _, err := parseHookFile(item.Path)
 	if err != nil {
 		return StatusNotAvailable
 	}
@@ -501,10 +507,12 @@ func resolveHookScripts(matcherGroup []byte, item catalog.ContentItem, repoRoot 
 }
 
 // flattenForCrush converts a CC-shape matcher group ({matcher, hooks:[entry]})
-// into crush's flat HookConfig ({command, matcher, timeout}). Crush hooks are
-// shell commands only, its schema rejects unknown fields, and its timeouts are
-// seconds — the canonical unit, so the value passes through unchanged.
-func flattenForCrush(matcherGroup []byte) ([]byte, error) {
+// into crush's flat HookConfig ({name, matcher, command, timeout}). Crush
+// hooks are shell commands only, its schema rejects unknown fields, and its
+// timeouts are seconds — the canonical unit, so the value passes through
+// unchanged. Canonical matcher tool names translate to crush's native names
+// (crush matchers are regexes tested against the tool name).
+func flattenForCrush(matcherGroup []byte, hookName string) ([]byte, error) {
 	entry := gjson.GetBytes(matcherGroup, "hooks.0")
 	if hType := entry.Get("type").String(); hType != "" && hType != "command" {
 		return nil, fmt.Errorf("crush hooks only support command handlers (got type %q)", hType)
@@ -513,12 +521,18 @@ func flattenForCrush(matcherGroup []byte) ([]byte, error) {
 	if cmd == "" {
 		return nil, fmt.Errorf("crush hooks require a command")
 	}
+	matcher := gjson.GetBytes(matcherGroup, "matcher").String()
+	if matcher != "" {
+		matcher = converter.TranslateMatcher(matcher, "crush")
+	}
 	flat := struct {
+		Name    string `json:"name,omitempty"`
 		Matcher string `json:"matcher,omitempty"`
 		Command string `json:"command"`
 		Timeout int    `json:"timeout,omitempty"`
 	}{
-		Matcher: gjson.GetBytes(matcherGroup, "matcher").String(),
+		Name:    hookName,
+		Matcher: matcher,
 		Command: cmd,
 		Timeout: int(entry.Get("timeout").Int()),
 	}

--- a/cli/internal/installer/hooks.go
+++ b/cli/internal/installer/hooks.go
@@ -25,11 +25,19 @@ func computeGroupHash(matcherGroup []byte) string {
 	return hex.EncodeToString(hash[:])
 }
 
-// hookSettingsPath returns the path to the provider's settings.json
-func hookSettingsPath(prov provider.Provider) (string, error) {
+// hookSettingsPath returns the path to the provider's hook config file.
+// Declared as a var so tests can override it (same pattern as mcpConfigPath).
+var hookSettingsPath = hookSettingsPathImpl
+
+func hookSettingsPathImpl(prov provider.Provider) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
+	}
+	if prov.Slug == "crush" {
+		// Crush keeps hooks in its unified crush.json (global scope), not a
+		// settings.json.
+		return filepath.Join(home, ".config", "crush", "crush.json"), nil
 	}
 	return filepath.Join(home, prov.ConfigDir, "settings.json"), nil
 }
@@ -148,6 +156,16 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 		return "", err
 	}
 
+	// Crush stores flat hook entries ({command, matcher, timeout}) rather
+	// than CC-shape matcher groups. Flatten last so the whitelist, scanner,
+	// and script-resolution steps above all see the standard shape.
+	if prov.Slug == "crush" {
+		matcherGroup, err = flattenForCrush(matcherGroup)
+		if err != nil {
+			return "", fmt.Errorf("hook %q: %w", item.Name, err)
+		}
+	}
+
 	// Check installed.json for duplicate
 	inst, err := LoadInstalled(repoRoot)
 	if err != nil {
@@ -191,8 +209,12 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 		return "", fmt.Errorf("writing %s: %w", settingsPath, err)
 	}
 
-	// Extract command from the hook for tracking
-	command := gjson.GetBytes(matcherGroup, "hooks.0.command").String()
+	// Extract command from the hook for tracking (crush entries are flat)
+	commandPath := "hooks.0.command"
+	if prov.Slug == "crush" {
+		commandPath = "command"
+	}
+	command := gjson.GetBytes(matcherGroup, commandPath).String()
 
 	// Record in installed.json
 	inst.Hooks = append(inst.Hooks, InstalledHook{
@@ -476,6 +498,31 @@ func resolveHookScripts(matcherGroup []byte, item catalog.ContentItem, repoRoot 
 	}
 
 	return result, nil
+}
+
+// flattenForCrush converts a CC-shape matcher group ({matcher, hooks:[entry]})
+// into crush's flat HookConfig ({command, matcher, timeout}). Crush hooks are
+// shell commands only, its schema rejects unknown fields, and its timeouts are
+// seconds — the canonical unit, so the value passes through unchanged.
+func flattenForCrush(matcherGroup []byte) ([]byte, error) {
+	entry := gjson.GetBytes(matcherGroup, "hooks.0")
+	if hType := entry.Get("type").String(); hType != "" && hType != "command" {
+		return nil, fmt.Errorf("crush hooks only support command handlers (got type %q)", hType)
+	}
+	cmd := entry.Get("command").String()
+	if cmd == "" {
+		return nil, fmt.Errorf("crush hooks require a command")
+	}
+	flat := struct {
+		Matcher string `json:"matcher,omitempty"`
+		Command string `json:"command"`
+		Timeout int    `json:"timeout,omitempty"`
+	}{
+		Matcher: gjson.GetBytes(matcherGroup, "matcher").String(),
+		Command: cmd,
+		Timeout: int(entry.Get("timeout").Int()),
+	}
+	return json.Marshal(flat)
 }
 
 // hookMatcherGroup is a typed struct for whitelist-filtering hook matcher groups.

--- a/cli/internal/installer/hooks_crush_test.go
+++ b/cli/internal/installer/hooks_crush_test.go
@@ -1,0 +1,147 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/tidwall/gjson"
+)
+
+// TestHookSettingsPath_Crush verifies crush hooks merge into the unified
+// crush.json (XDG global config), not a settings.json.
+func TestHookSettingsPath_Crush(t *testing.T) {
+	got, err := hookSettingsPath(provider.Crush)
+	if err != nil {
+		t.Fatalf("hookSettingsPath: %v", err)
+	}
+	if !strings.HasSuffix(got, filepath.Join(".config", "crush", "crush.json")) {
+		t.Errorf("expected path ending in .config/crush/crush.json, got %q", got)
+	}
+}
+
+// overrideHookSettingsPath points hookSettingsPath at a fixed file for the
+// duration of the test. Not parallel-safe (mutates a package global).
+func overrideHookSettingsPath(t *testing.T, path string) {
+	t.Helper()
+	orig := hookSettingsPath
+	hookSettingsPath = func(prov provider.Provider) (string, error) { return path, nil }
+	t.Cleanup(func() { hookSettingsPath = orig })
+}
+
+// TestInstallHook_E2E_Crush runs the full install/uninstall pipeline against
+// crush's flat hook entry shape ({command, matcher, timeout} — seconds, no
+// nested hooks array).
+func TestInstallHook_E2E_Crush(t *testing.T) {
+	projectRoot := t.TempDir()
+	os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755)
+
+	hookDir := filepath.Join(projectRoot, "hooks", "crush-hook")
+	os.MkdirAll(hookDir, 0755)
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"before_tool_execute","matcher":".*","handler":{"type":"command","command":"echo lint","timeout":5}}]}`
+	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
+
+	item := catalog.ContentItem{
+		Name: "crush-hook",
+		Type: catalog.Hooks,
+		Path: hookDir,
+	}
+
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "crush.json")
+	os.WriteFile(configPath, []byte(`{"mcp":{"existing":{"command":"keep-me"}}}`), 0644)
+	overrideHookSettingsPath(t, configPath)
+
+	result, err := installHook(item, provider.Crush, projectRoot)
+	if err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+	if !strings.Contains(result, "hooks.PreToolUse") {
+		t.Errorf("result should mention the native event, got %q", result)
+	}
+
+	data, _ := os.ReadFile(configPath)
+	entry := gjson.GetBytes(data, "hooks.PreToolUse.0")
+	if !entry.Exists() {
+		t.Fatalf("expected hooks.PreToolUse.0 in crush.json, got: %s", data)
+	}
+	if got := entry.Get("command").String(); got != "echo lint" {
+		t.Errorf("command: got %q, want 'echo lint'", got)
+	}
+	if entry.Get("hooks").Exists() {
+		t.Errorf("crush entry must be flat, found nested hooks array: %s", entry.Raw)
+	}
+	// Canonical timeout is seconds; crush reads seconds — value unchanged.
+	if got := entry.Get("timeout").Int(); got != 5 {
+		t.Errorf("timeout: got %d, want 5", got)
+	}
+	// Sibling config keys must survive the merge.
+	if gjson.GetBytes(data, "mcp.existing.command").String() != "keep-me" {
+		t.Error("existing crush.json content was clobbered by hook install")
+	}
+
+	// installed.json tracks the hook with the extracted command.
+	inst, _ := LoadInstalled(projectRoot)
+	idx := inst.FindHook("crush-hook", "PreToolUse")
+	if idx < 0 {
+		t.Fatal("hook not found in installed.json")
+	}
+	if inst.Hooks[idx].Command != "echo lint" {
+		t.Errorf("tracked command: got %q, want 'echo lint'", inst.Hooks[idx].Command)
+	}
+
+	// Status sees it as installed.
+	if status := checkHookStatus(item, provider.Crush, projectRoot); status != StatusInstalled {
+		t.Errorf("expected StatusInstalled, got %v", status)
+	}
+
+	// Uninstall removes the entry and the tracking record.
+	if _, err := uninstallHook(item, provider.Crush, projectRoot); err != nil {
+		t.Fatalf("uninstallHook: %v", err)
+	}
+	data, _ = os.ReadFile(configPath)
+	if gjson.GetBytes(data, "hooks.PreToolUse.0").Exists() {
+		t.Errorf("hook entry should be removed, got: %s", data)
+	}
+	if gjson.GetBytes(data, "mcp.existing.command").String() != "keep-me" {
+		t.Error("existing crush.json content was clobbered by hook uninstall")
+	}
+	inst, _ = LoadInstalled(projectRoot)
+	if inst.FindHook("crush-hook", "PreToolUse") >= 0 {
+		t.Error("hook should be removed from installed.json")
+	}
+}
+
+// TestInstallHook_Crush_RejectsNonCommand: crush hooks are shell commands
+// only; a non-command handler cannot be flattened into a crush entry.
+func TestInstallHook_Crush_RejectsNonCommand(t *testing.T) {
+	projectRoot := t.TempDir()
+	os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755)
+
+	hookDir := filepath.Join(projectRoot, "hooks", "prompt-hook")
+	os.MkdirAll(hookDir, 0755)
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"before_tool_execute","handler":{"type":"prompt","prompt":"Is this safe?"}}]}`
+	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
+
+	item := catalog.ContentItem{
+		Name: "prompt-hook",
+		Type: catalog.Hooks,
+		Path: hookDir,
+	}
+
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "crush.json")
+	os.WriteFile(configPath, []byte(`{}`), 0644)
+	overrideHookSettingsPath(t, configPath)
+
+	if _, err := installHook(item, provider.Crush, projectRoot); err == nil {
+		t.Fatal("expected error installing a prompt hook to crush")
+	}
+	data, _ := os.ReadFile(configPath)
+	if gjson.GetBytes(data, "hooks").Exists() {
+		t.Errorf("no hook should have been written, got: %s", data)
+	}
+}

--- a/cli/internal/installer/hooks_crush_test.go
+++ b/cli/internal/installer/hooks_crush_test.go
@@ -41,7 +41,7 @@ func TestInstallHook_E2E_Crush(t *testing.T) {
 
 	hookDir := filepath.Join(projectRoot, "hooks", "crush-hook")
 	os.MkdirAll(hookDir, 0755)
-	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"before_tool_execute","matcher":".*","handler":{"type":"command","command":"echo lint","timeout":5}}]}`
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"name":"lint-guard","event":"before_tool_execute","matcher":"shell","handler":{"type":"command","command":"echo lint","timeout":5}}]}`
 	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
 
 	item := catalog.ContentItem{
@@ -73,6 +73,15 @@ func TestInstallHook_E2E_Crush(t *testing.T) {
 	}
 	if entry.Get("hooks").Exists() {
 		t.Errorf("crush entry must be flat, found nested hooks array: %s", entry.Raw)
+	}
+	// Canonical matcher tool names must translate to crush's native names
+	// (Codex review finding on PR #505).
+	if got := entry.Get("matcher").String(); got != "bash" {
+		t.Errorf("matcher: got %q, want %q (canonical shell -> crush bash)", got, "bash")
+	}
+	// The manifest's optional hook name maps to crush's display name field.
+	if got := entry.Get("name").String(); got != "lint-guard" {
+		t.Errorf("name: got %q, want %q", got, "lint-guard")
 	}
 	// Canonical timeout is seconds; crush reads seconds — value unchanged.
 	if got := entry.Get("timeout").Int(); got != 5 {
@@ -112,6 +121,38 @@ func TestInstallHook_E2E_Crush(t *testing.T) {
 	inst, _ = LoadInstalled(projectRoot)
 	if inst.FindHook("crush-hook", "PreToolUse") >= 0 {
 		t.Error("hook should be removed from installed.json")
+	}
+}
+
+// TestInstallHook_Crush_RejectsUnsupportedEvent: crush fires hooks only on
+// PreToolUse; installing any other event would write dead config that crush
+// never reads (Codex review finding on PR #505).
+func TestInstallHook_Crush_RejectsUnsupportedEvent(t *testing.T) {
+	projectRoot := t.TempDir()
+	os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755)
+
+	hookDir := filepath.Join(projectRoot, "hooks", "session-hook")
+	os.MkdirAll(hookDir, 0755)
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"session_start","handler":{"type":"command","command":"echo hi"}}]}`
+	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
+
+	item := catalog.ContentItem{
+		Name: "session-hook",
+		Type: catalog.Hooks,
+		Path: hookDir,
+	}
+
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "crush.json")
+	os.WriteFile(configPath, []byte(`{}`), 0644)
+	overrideHookSettingsPath(t, configPath)
+
+	if _, err := installHook(item, provider.Crush, projectRoot); err == nil {
+		t.Fatal("expected error installing a session_start hook to crush")
+	}
+	data, _ := os.ReadFile(configPath)
+	if gjson.GetBytes(data, "hooks").Exists() {
+		t.Errorf("no hook should have been written, got: %s", data)
 	}
 }
 

--- a/cli/internal/installer/hooks_test.go
+++ b/cli/internal/installer/hooks_test.go
@@ -207,7 +207,7 @@ func TestParseHookFile_Valid(t *testing.T) {
 	hookFile := filepath.Join(tmpDir, "hook.json")
 	os.WriteFile(hookFile, []byte(hookJSON), 0644)
 
-	event, matcherGroup, err := parseHookFile(hookFile)
+	event, _, matcherGroup, err := parseHookFile(hookFile)
 	if err != nil {
 		t.Fatalf("parseHookFile: %v", err)
 	}
@@ -235,7 +235,7 @@ func TestParseHookFile_DirectoryFormat(t *testing.T) {
 	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"PreToolUse","matcher":"Bash","handler":{"type":"command","command":"echo hi"}}]}`
 	os.WriteFile(filepath.Join(dir, "hook.json"), []byte(hookJSON), 0644)
 
-	event, matcherGroup, err := parseHookFile(dir)
+	event, _, matcherGroup, err := parseHookFile(dir)
 	if err != nil {
 		t.Fatalf("parseHookFile with directory: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestParseHookFile_MissingEvent(t *testing.T) {
 	hookFile := filepath.Join(tmpDir, "hook.json")
 	os.WriteFile(hookFile, []byte(hookJSON), 0644)
 
-	_, _, err := parseHookFile(hookFile)
+	_, _, _, err := parseHookFile(hookFile)
 	if err == nil {
 		t.Fatal("expected error for missing event field")
 	}
@@ -297,7 +297,7 @@ func TestInstallHook_HashComputation(t *testing.T) {
 	hookFile := filepath.Join(projectRoot, "hook.json")
 	os.WriteFile(hookFile, []byte(hookJSON), 0644)
 
-	_, matcherGroup, err := parseHookFile(hookFile)
+	_, _, matcherGroup, err := parseHookFile(hookFile)
 	if err != nil {
 		t.Fatalf("parseHookFile: %v", err)
 	}

--- a/cli/internal/provider/crush.go
+++ b/cli/internal/provider/crush.go
@@ -8,8 +8,9 @@ import (
 
 // Crush is the Charmbracelet coding agent. XDG-compliant: global config
 // lives under ~/.config/crush/. Supports rules (AGENTS.md project only),
-// skills (Agent Skills standard), and MCP. No hooks (see charmbracelet/crush#2038),
-// no user-definable agents, no custom commands.
+// skills (Agent Skills standard), MCP, and hooks (PreToolUse only, flat
+// entries in crush.json — see docs/provider-formats/crush.yaml). No
+// user-definable agents, no custom commands.
 var Crush = Provider{
 	Name:      "Crush",
 	Slug:      "crush",
@@ -22,6 +23,8 @@ var Crush = Provider{
 			return filepath.Join(homeDir, ".config", "crush", "skills")
 		case catalog.MCP:
 			return JSONMergeSentinel
+		case catalog.Hooks:
+			return JSONMergeSentinel // merged into crush.json hooks key
 		}
 		return ""
 	},
@@ -37,13 +40,15 @@ var Crush = Provider{
 			return []string{filepath.Join(projectRoot, ".crush", "skills")}
 		case catalog.MCP:
 			return []string{filepath.Join(projectRoot, "crush.json")}
+		case catalog.Hooks:
+			return []string{filepath.Join(projectRoot, "crush.json")}
 		default:
 			return nil
 		}
 	},
 	FileFormat: func(ct catalog.ContentType) Format {
 		switch ct {
-		case catalog.MCP:
+		case catalog.MCP, catalog.Hooks:
 			return FormatJSON
 		default:
 			return FormatMarkdown
@@ -54,7 +59,7 @@ var Crush = Provider{
 	},
 	SupportsType: func(ct catalog.ContentType) bool {
 		switch ct {
-		case catalog.Rules, catalog.Skills, catalog.MCP:
+		case catalog.Rules, catalog.Skills, catalog.MCP, catalog.Hooks:
 			return true
 		default:
 			return false
@@ -64,9 +69,12 @@ var Crush = Provider{
 		catalog.Rules:  true,
 		catalog.Skills: true,
 		catalog.MCP:    false, // JSON merge
+		catalog.Hooks:  false, // JSON merge
 	},
 	ConfigLocations: map[catalog.ContentType]string{
-		catalog.MCP: "crush.json",
+		catalog.MCP:   "crush.json",
+		catalog.Hooks: "crush.json",
 	},
 	MCPTransports: []string{"stdio", "http", "sse"},
+	HookTypes:     []string{"command"},
 }

--- a/cli/internal/provider/crush_test.go
+++ b/cli/internal/provider/crush_test.go
@@ -4,7 +4,43 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 )
+
+// TestCrushHooksSupport: crush.yaml graduated hooks to supported (May 2026);
+// Go must claim install support and route hooks through JSON merge into
+// crush.json (syllago-h4cmd).
+func TestCrushHooksSupport(t *testing.T) {
+	if !Crush.SupportsType(catalog.Hooks) {
+		t.Error("crush must support hooks (format YAML asserts supported)")
+	}
+	if got := Crush.InstallDir("/home/x", catalog.Hooks); got != JSONMergeSentinel {
+		t.Errorf("InstallDir(hooks): got %q, want JSON merge sentinel", got)
+	}
+	paths := Crush.DiscoveryPaths("/proj", catalog.Hooks)
+	var found bool
+	for _, p := range paths {
+		if p == filepath.Join("/proj", "crush.json") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("DiscoveryPaths(hooks) should include crush.json, got %v", paths)
+	}
+	if Crush.FileFormat(catalog.Hooks) != FormatJSON {
+		t.Error("hooks file format should be JSON")
+	}
+	if Crush.SymlinkSupport[catalog.Hooks] {
+		t.Error("hooks use JSON merge, not symlinks")
+	}
+	if loc := Crush.ConfigLocations[catalog.Hooks]; loc == "" {
+		t.Error("ConfigLocations[hooks] must be set (coverage assertion 3)")
+	}
+	if len(Crush.HookTypes) != 1 || Crush.HookTypes[0] != "command" {
+		t.Errorf("HookTypes: got %v, want [command]", Crush.HookTypes)
+	}
+}
 
 // TestCrushDetect: binary-only marker for v1.
 func TestCrushDetect(t *testing.T) {

--- a/cli/internal/provider/invariant_test.go
+++ b/cli/internal/provider/invariant_test.go
@@ -52,14 +52,18 @@ func TestCoverageInternalGoConsistency(t *testing.T) {
 	t.Fatal(b.String())
 }
 
-// TestCoverageNoDrift is the authoritative full-conformance gate. It fails
-// if ANY unaccepted drift is found across all assertions (Go internal
-// consistency, Go vs format YAMLs, Go vs the Capability Feed mirror). It
-// runs on every `make test`.
+// TestCoverageNoDrift is the authoritative conformance gate for the in-repo
+// assertions: Go internal consistency and Go vs the format YAMLs. It runs on
+// every `make test` and fails on any unaccepted drift in those axes — both
+// sides live in this repo, so drift is always fixable in the same commit.
 //
-// Drifts carrying an AcceptedReason (recorded, permanent disagreements —
-// see acceptedFeedDrift in coverage_feed.go) are logged but never fail the
-// gate, matching TestCoverageFeedDrift's semantics.
+// Two kinds of drift are logged instead of failing:
+//   - Drifts carrying an AcceptedReason (recorded, permanent disagreements —
+//     see acceptedFeedDrift in coverage_feed.go).
+//   - Capability Feed drift (go-vs-capability-feed): the feed legitimately
+//     outpaces Go, so it is contractually a signal, never a merge block —
+//     the dedicated non-required coverage-drift CI job (TestCoverageFeedDrift)
+//     surfaces it. See docs/provider-capabilities/README.md.
 func TestCoverageNoDrift(t *testing.T) {
 	repoRoot := mustFindRepoRoot(t)
 	drifts, err := CheckCoverage(repoRoot)
@@ -71,6 +75,10 @@ func TestCoverageNoDrift(t *testing.T) {
 	for _, d := range drifts {
 		if d.AcceptedReason != "" {
 			t.Logf("coverage drift (accepted): %s — %s", d, d.AcceptedReason)
+			continue
+		}
+		if d.Assertion == AssertionGoVsCapabilityFeed {
+			t.Logf("coverage drift (feed, non-blocking): %s", d)
 			continue
 		}
 		failing = append(failing, d)

--- a/cli/internal/provider/invariant_test.go
+++ b/cli/internal/provider/invariant_test.go
@@ -52,42 +52,42 @@ func TestCoverageInternalGoConsistency(t *testing.T) {
 	t.Fatal(b.String())
 }
 
-// TestCoverageNoDrift is the authoritative full-conformance gate. It fails if
-// ANY drift is found across all assertions. This is the gate that Phase 3
-// of the provider-coverage-reconciliation plan closes (by bringing
-// provider-formats/ YAMLs into sync with Go).
+// TestCoverageNoDrift is the authoritative full-conformance gate. It fails
+// if ANY unaccepted drift is found across all assertions (Go internal
+// consistency, Go vs format YAMLs, Go vs the Capability Feed mirror). It
+// runs on every `make test`.
 //
-// Gated behind SYLLAGO_COVERAGE_STRICT=1 until Phase 3 lands. Once the YAMLs
-// are reconciled, delete the env-var gate so this test runs by default on
-// every `make test`.
-//
-// Manual invocation during Phase 2/3 work:
-//
-//	SYLLAGO_COVERAGE_STRICT=1 go test ./internal/provider/... -run Coverage
+// Drifts carrying an AcceptedReason (recorded, permanent disagreements —
+// see acceptedFeedDrift in coverage_feed.go) are logged but never fail the
+// gate, matching TestCoverageFeedDrift's semantics.
 func TestCoverageNoDrift(t *testing.T) {
-	if os.Getenv("SYLLAGO_COVERAGE_STRICT") != "1" {
-		t.Skip("full Go↔YAML conformance gated behind SYLLAGO_COVERAGE_STRICT=1 until Phase 3 of provider-coverage-reconciliation lands")
-	}
-
 	repoRoot := mustFindRepoRoot(t)
 	drifts, err := CheckCoverage(repoRoot)
 	if err != nil {
 		t.Fatalf("CheckCoverage: %v", err)
 	}
 
-	if len(drifts) == 0 {
+	var failing []CoverageDrift
+	for _, d := range drifts {
+		if d.AcceptedReason != "" {
+			t.Logf("coverage drift (accepted): %s — %s", d, d.AcceptedReason)
+			continue
+		}
+		failing = append(failing, d)
+	}
+	if len(failing) == 0 {
 		return
 	}
 
 	var b strings.Builder
 	b.WriteString("provider coverage drift detected (")
-	b.WriteString(strconv.Itoa(len(drifts)))
+	b.WriteString(strconv.Itoa(len(failing)))
 	b.WriteString(" issue")
-	if len(drifts) != 1 {
+	if len(failing) != 1 {
 		b.WriteString("s")
 	}
 	b.WriteString("):\n")
-	for _, d := range drifts {
+	for _, d := range failing {
 		b.WriteString("  - ")
 		b.WriteString(d.String())
 		b.WriteString("\n")


### PR DESCRIPTION
## Summary

Three fixes to `TestCoverageNoDrift` (bead `syllago-zpg5h`):

1. **Stale comment** — the doc comment still described the gate as temporary pending "Phase 3 of provider-coverage-reconciliation"; that plan completed and shipped in v0.9.0 (2026-04-17).
2. **Honor accepted drifts** — drifts carrying an `AcceptedReason` (recorded, permanent disagreements per `acceptedFeedDrift` in coverage_feed.go) are now logged instead of failing the gate, matching `TestCoverageFeedDrift`'s semantics. The accepted zed/agents drift no longer reads as red.
3. **Always-on** — the `SYLLAGO_COVERAGE_STRICT` env-var gate is deleted, so the gate runs on every `make test`. An always-on gate would have caught the crush/hooks drift when it appeared in May 2026 instead of it being found by accident in July.

**Scope of the always-on gate** (added after codex-review): it hard-fails only the in-repo assertions — Go internal consistency and Go↔format-YAML — where both sides live in this repo and drift is fixable in the same commit. Capability Feed drift stays contractually non-blocking ("red is a signal, never a merge block" per docs/provider-capabilities/README.md); it is logged here and surfaced by the dedicated non-required `coverage-drift` CI job, unchanged.

**Stacked on #505** (crush hooks support) — that PR removes the last unaccepted format-YAML drift, which is what makes the un-gated test green. Merge #505 first.

## Testing

- `TestCoverageNoDrift` runs un-gated and passes, logging the accepted zed/agents feed drift
- Full suite passes with the gate always-on
- No CI wiring changes: no workflow references SYLLAGO_COVERAGE_STRICT; the SYLLAGO_COVERAGE_FEED Coverage Drift job is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKkjYnF9zuGSajoSVSRmz6
