### PR TITLE
Fix hook install: translate matcher tool names to provider-native (syllago-9qgwt)

### DIFF
--- a/cli/internal/installer/hooks.go
+++ b/cli/internal/installer/hooks.go
@@ -122,6 +122,22 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 		return "", fmt.Errorf("filtering matcher group: %w", err)
 	}
 
+	// Translate canonical matcher tool names (e.g. "shell") to the
+	// provider-native names the provider tests its hook regexes against
+	// (e.g. "Bash" for claude-code). Library hook.json stores canonical
+	// matchers, so without this the merged regex silently never fires.
+	// Wildcards, MCP-style patterns, and already-native names pass
+	// through TranslateMatcher unchanged.
+	if matcher := gjson.GetBytes(matcherGroup, "matcher").String(); matcher != "" {
+		translated := converter.TranslateMatcher(matcher, prov.Slug)
+		if translated != matcher {
+			matcherGroup, err = sjson.SetBytes(matcherGroup, "matcher", translated)
+			if err != nil {
+				return "", fmt.Errorf("translating matcher: %w", err)
+			}
+		}
+	}
+
 	// M2: Run the pluggable scanner chain (builtin + any --hook-scanner paths)
 	// against the source hook directory. The builtin scanner examines hook.json
 	// and any recognized script files; external scanners run as subprocesses
@@ -510,8 +526,8 @@ func resolveHookScripts(matcherGroup []byte, item catalog.ContentItem, repoRoot 
 // into crush's flat HookConfig ({name, matcher, command, timeout}). Crush
 // hooks are shell commands only, its schema rejects unknown fields, and its
 // timeouts are seconds — the canonical unit, so the value passes through
-// unchanged. Canonical matcher tool names translate to crush's native names
-// (crush matchers are regexes tested against the tool name).
+// unchanged. The matcher arrives already translated to crush's native tool
+// names (installHook translates for every provider before this step).
 func flattenForCrush(matcherGroup []byte, hookName string) ([]byte, error) {
 	entry := gjson.GetBytes(matcherGroup, "hooks.0")
 	if hType := entry.Get("type").String(); hType != "" && hType != "command" {
@@ -522,9 +538,6 @@ func flattenForCrush(matcherGroup []byte, hookName string) ([]byte, error) {
 		return nil, fmt.Errorf("crush hooks require a command")
 	}
 	matcher := gjson.GetBytes(matcherGroup, "matcher").String()
-	if matcher != "" {
-		matcher = converter.TranslateMatcher(matcher, "crush")
-	}
 	flat := struct {
 		Name    string `json:"name,omitempty"`
 		Matcher string `json:"matcher,omitempty"`

--- a/cli/internal/installer/hooks_matcher_test.go
+++ b/cli/internal/installer/hooks_matcher_test.go
@@ -1,0 +1,132 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/tidwall/gjson"
+)
+
+// writeHookItem writes a canonical hook.json with the given matcher into a
+// fresh project root and returns the item plus the project root.
+func writeHookItem(t *testing.T, matcher string) (catalog.ContentItem, string) {
+	t.Helper()
+	projectRoot := t.TempDir()
+	os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755)
+
+	hookDir := filepath.Join(projectRoot, "hooks", "matcher-hook")
+	os.MkdirAll(hookDir, 0755)
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"name":"guard","event":"before_tool_execute","matcher":"` + matcher + `","handler":{"type":"command","command":"echo guard"}}]}`
+	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
+
+	return catalog.ContentItem{
+		Name: "matcher-hook",
+		Type: catalog.Hooks,
+		Path: hookDir,
+	}, projectRoot
+}
+
+// TestInstallHook_TranslatesMatcher verifies installHook translates canonical
+// matcher tool names to each provider's native names before the JSON merge
+// (syllago-9qgwt). Library hook.json stores canonical matchers ("shell");
+// providers match their hook regexes against native tool names ("Bash"), so
+// an untranslated matcher silently never fires. Crush is covered separately
+// in hooks_crush_test.go via its flat-entry path.
+//
+// The full install -> status -> uninstall cycle runs per provider to verify
+// hash matching stays consistent with the translated group.
+func TestInstallHook_TranslatesMatcher(t *testing.T) {
+	tests := []struct {
+		prov        provider.Provider
+		eventKey    string // provider-native settings key the hook lands under
+		wantMatcher string // native translation of canonical "shell"
+	}{
+		{provider.ClaudeCode, "PreToolUse", "Bash"},
+		{provider.GeminiCLI, "BeforeTool", "run_shell_command"},
+		{provider.Cursor, "PreToolUse", "run_terminal_cmd"},
+		// Windsurf has no native before_tool_execute mapping, so the event
+		// key stays canonical (event-support enforcement is out of scope
+		// here) — but the matcher must still translate for the slug.
+		{provider.Windsurf, "before_tool_execute", "run_command"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.prov.Slug, func(t *testing.T) {
+			item, projectRoot := writeHookItem(t, "shell")
+
+			configDir := t.TempDir()
+			settingsPath := filepath.Join(configDir, "settings.json")
+			os.WriteFile(settingsPath, []byte(`{}`), 0644)
+			overrideHookSettingsPath(t, settingsPath)
+
+			if _, err := installHook(item, tt.prov, projectRoot); err != nil {
+				t.Fatalf("installHook: %v", err)
+			}
+
+			data, _ := os.ReadFile(settingsPath)
+			entry := gjson.GetBytes(data, "hooks."+tt.eventKey+".0")
+			if !entry.Exists() {
+				t.Fatalf("expected hooks.%s.0 in settings, got: %s", tt.eventKey, data)
+			}
+			if got := entry.Get("matcher").String(); got != tt.wantMatcher {
+				t.Errorf("matcher: got %q, want %q (canonical shell -> %s native)", got, tt.wantMatcher, tt.prov.Slug)
+			}
+			if got := entry.Get("hooks.0.command").String(); got != "echo guard" {
+				t.Errorf("command: got %q, want 'echo guard'", got)
+			}
+
+			// Hash matching is computed over the merged (translated) group —
+			// status and uninstall must still line up.
+			if status := checkHookStatus(item, tt.prov, projectRoot); status != StatusInstalled {
+				t.Errorf("expected StatusInstalled, got %v", status)
+			}
+			if _, err := uninstallHook(item, tt.prov, projectRoot); err != nil {
+				t.Fatalf("uninstallHook: %v", err)
+			}
+			data, _ = os.ReadFile(settingsPath)
+			if gjson.GetBytes(data, "hooks."+tt.eventKey+".0").Exists() {
+				t.Errorf("hook entry should be removed, got: %s", data)
+			}
+		})
+	}
+}
+
+// TestInstallHook_MatcherPatterns covers the matcher shapes TranslateMatcher
+// must handle during install: regex alternations translate per component,
+// wildcards and already-native names pass through unchanged.
+func TestInstallHook_MatcherPatterns(t *testing.T) {
+	tests := []struct {
+		name        string
+		matcher     string
+		wantMatcher string
+	}{
+		{"alternation", "file_edit|file_write", "Edit|Write"},
+		{"wildcard", ".*", ".*"},
+		{"already native", "Bash", "Bash"},
+		{"mcp pattern", "mcp__github__.*", "mcp__github__.*"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item, projectRoot := writeHookItem(t, tt.matcher)
+
+			configDir := t.TempDir()
+			settingsPath := filepath.Join(configDir, "settings.json")
+			os.WriteFile(settingsPath, []byte(`{}`), 0644)
+			overrideHookSettingsPath(t, settingsPath)
+
+			if _, err := installHook(item, provider.ClaudeCode, projectRoot); err != nil {
+				t.Fatalf("installHook: %v", err)
+			}
+
+			data, _ := os.ReadFile(settingsPath)
+			got := gjson.GetBytes(data, "hooks.PreToolUse.0.matcher").String()
+			if got != tt.wantMatcher {
+				t.Errorf("matcher: got %q, want %q", got, tt.wantMatcher)
+			}
+		})
+	}
+}

--- a/cli/internal/loadout/apply.go
+++ b/cli/internal/loadout/apply.go
@@ -255,12 +255,30 @@ func applyHook(ref ResolvedRef, prov provider.Provider, homeDir string, resolver
 	hd := hds[0]
 	event := hd.Event
 
+	// Validate before using the event as an sjson key (mirrors installHook M3:
+	// prevents key injection via dots in crafted event names).
+	if !converter.IsValidHookEvent(event) {
+		return fmt.Errorf("unknown hook event %q: must be a known canonical or provider event name", event)
+	}
+
+	// Translate canonical names to provider-native before the merge (mirrors
+	// installHook): the event becomes the settings key the provider actually
+	// reads, and matcher tool names become the names the provider tests its
+	// hook regexes against. Already-native names pass through unchanged.
+	if nativeEvent, ok := converter.TranslateHookEvent(event, prov.Slug); ok {
+		event = nativeEvent
+	}
+	matcher := hd.Matcher
+	if matcher != "" {
+		matcher = converter.TranslateMatcher(matcher, prov.Slug)
+	}
+
 	// Build the provider-shape matcher group for merging into settings.json.
 	group := struct {
 		Matcher string                `json:"matcher,omitempty"`
 		Hooks   []converter.HookEntry `json:"hooks"`
 	}{
-		Matcher: hd.Matcher,
+		Matcher: matcher,
 		Hooks:   hd.Hooks,
 	}
 	matcherGroup, err := json.Marshal(group)

--- a/cli/internal/loadout/apply_test.go
+++ b/cli/internal/loadout/apply_test.go
@@ -202,6 +202,62 @@ func TestApply_KeepMode_MergesHooks(t *testing.T) {
 	}
 }
 
+// TestApply_KeepMode_TranslatesCanonicalHook verifies applyHook translates
+// canonical event names AND matcher tool names to provider-native before the
+// settings merge (syllago-9qgwt, loadout path). Library hook.json stores
+// canonical names ("before_tool_execute", "shell"); merging them verbatim
+// writes config the provider never reads (wrong key) or never matches
+// (wrong tool name regex).
+func TestApply_KeepMode_TranslatesCanonicalHook(t *testing.T) {
+	t.Parallel()
+	homeDir, projectRoot, manifest, cat, prov := setupTestEnv(t)
+
+	// Replace the fixture hook with a fully canonical one.
+	hookDir := filepath.Join(projectRoot, "content", "hooks", "claude-code", "my-hook")
+	hookJSON := `{
+  "spec": "hooks/0.1",
+  "hooks": [
+    {
+      "event": "before_tool_execute",
+      "matcher": "shell",
+      "handler": {"type": "command", "command": "echo guard"}
+    }
+  ]
+}`
+	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
+
+	manifest.Rules = nil
+	cat.Items = cat.Items[1:] // only the hook
+
+	opts := ApplyOptions{
+		Mode:        "keep",
+		ProjectRoot: projectRoot,
+		HomeDir:     homeDir,
+		RepoRoot:    projectRoot,
+	}
+
+	if _, err := Apply(manifest, cat, prov, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("reading settings.json: %v", err)
+	}
+
+	entry := gjson.GetBytes(data, "hooks.PreToolUse.0")
+	if !entry.Exists() {
+		t.Fatalf("expected hook under native key hooks.PreToolUse, got: %s", data)
+	}
+	if got := entry.Get("matcher").String(); got != "Bash" {
+		t.Errorf("matcher: got %q, want %q (canonical shell -> claude-code Bash)", got, "Bash")
+	}
+	if gjson.GetBytes(data, "hooks.before_tool_execute").Exists() {
+		t.Errorf("canonical event key must not appear in settings, got: %s", data)
+	}
+}
+
 func TestApply_TryMode_InjectsSessionEndHook(t *testing.T) {
 	t.Parallel()
 	homeDir, projectRoot, manifest, cat, prov := setupTestEnv(t)


### PR DESCRIPTION
## Summary

- `installHook` translated the hook **event** to the provider-native key but merged the **matcher** verbatim. Library `hook.json` stores canonical matcher tool names (e.g. `shell`), so installing a hook to any hooks JSON-merge provider wrote a regex that never matches the provider's native tool names (`Bash`, `run_shell_command`, `run_terminal_cmd`, `run_command`) — the hook silently never fired. Wildcard matchers (`.*`) were unaffected, which is why this went unreported.
- Fix: translate the matcher via `converter.TranslateMatcher(matcher, prov.Slug)` in `installHook` before the merge, for every provider. The crush-specific translation inside `flattenForCrush` (added in #505) is now redundant and removed — one translation point.
- The group hash is computed after translation, so uninstall/status hash matching stays consistent.
- **Second path (codex review finding):** loadout apply's `applyHook` duplicates the merge logic and translated **neither the event nor the matcher** — a canonical loadout hook landed under `hooks.before_tool_execute` with matcher `shell`, config the provider never reads. Now mirrors `installHook`: event validation (sjson key-injection guard), `TranslateHookEvent`, `TranslateMatcher`. Loadout remove is snapshot-based (whole-file restore), so the translated key cannot break removal.

Closes bead `syllago-9qgwt`.

## Test plan

- New `hooks_matcher_test.go`: per-provider install → status → uninstall cycle asserting native matcher translation for claude-code, gemini-cli, cursor, and windsurf (crush covered by its existing flat-entry tests), plus matcher-shape cases (alternation `file_edit|file_write` → `Edit|Write`, wildcard, already-native, `mcp__*` pattern passthrough).
- New `TestApply_KeepMode_TranslatesCanonicalHook` in loadout: fully canonical hook applies under the native event key with the native matcher; canonical key absent.
- Full `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKkjYnF9zuGSajoSVSRmz6