### PR TITLE
Fix TestExternalScanner ETXTBSY flake: warm-exec scripts in test helper (syllago-0rzuy)

### DIFF
--- a/cli/internal/converter/scanner_test.go
+++ b/cli/internal/converter/scanner_test.go
@@ -222,21 +222,28 @@ func writeExternalScanner(t *testing.T, name, body string, exitCode int) string 
 	// process and uses a shell-internal temp fd) and writes body directly
 	// to stdout. Body must not contain single quotes.
 	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' '%s'\nexit %d\n", body, exitCode)
+	writeScannerScript(t, path, script)
+	return path
+}
+
+// writeScannerScript writes an executable script at path, then warm-execs it
+// until one exec succeeds. These tests run parallel, so another test's fork
+// can inherit the write fd from os.WriteFile during the window before it
+// closes; exec'ing the script then fails with ETXTBSY until that child execs
+// or exits (golang/go#22315). Nothing reopens the file for writing after this
+// point, so one successful exec proves all later execs are safe. The warmed
+// process is killed immediately after Start, so slow scripts (e.g. sleep)
+// don't stall the helper and the extra run has no observable effect.
+func writeScannerScript(t *testing.T, path, script string) {
+	t.Helper()
 	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
-		t.Fatalf("write scanner: %v", err)
+		t.Fatalf("write scanner script: %v", err)
 	}
-	// These tests run parallel, so another test's fork can inherit the
-	// write fd from os.WriteFile during the window before it closes;
-	// exec'ing the script then fails with ETXTBSY until that child execs
-	// or exits (golang/go#22315). Nothing reopens the file for writing
-	// after this point, so one successful exec proves all later execs are
-	// safe — warm-exec with bounded retries before handing the path to
-	// the test. The script is a pure printf+exit, so the extra run is
-	// side-effect free.
 	for i := 0; ; i++ {
 		cmd := exec.Command(path)
 		err := cmd.Start()
 		if err == nil {
+			_ = cmd.Process.Kill()
 			_ = cmd.Wait()
 			break
 		}
@@ -245,7 +252,6 @@ func writeExternalScanner(t *testing.T, name, body string, exitCode int) string 
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	return path
 }
 
 // TestExternalScanner_ValidOutput — scanner prints valid ScanResult JSON,
@@ -316,10 +322,7 @@ func TestExternalScanner_ExitCode2(t *testing.T) {
 	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "broken")
-	script := "#!/bin/sh\necho 'boom' 1>&2\nexit 2\n"
-	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
-		t.Fatal(err)
-	}
+	writeScannerScript(t, path, "#!/bin/sh\necho 'boom' 1>&2\nexit 2\n")
 
 	res, err := (&ExternalScanner{Path: path}).Scan(dir)
 	if err != nil {
@@ -343,10 +346,7 @@ func TestExternalScanner_Timeout(t *testing.T) {
 	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "slow")
-	script := "#!/bin/sh\nsleep 5\n"
-	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
-		t.Fatal(err)
-	}
+	writeScannerScript(t, path, "#!/bin/sh\nsleep 5\n")
 
 	s := &ExternalScanner{Path: path, Timeout: 100 * time.Millisecond}
 	start := time.Now()

--- a/cli/internal/converter/scanner_test.go
+++ b/cli/internal/converter/scanner_test.go
@@ -2,10 +2,13 @@ package converter
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -221,6 +224,26 @@ func writeExternalScanner(t *testing.T, name, body string, exitCode int) string 
 	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' '%s'\nexit %d\n", body, exitCode)
 	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
 		t.Fatalf("write scanner: %v", err)
+	}
+	// These tests run parallel, so another test's fork can inherit the
+	// write fd from os.WriteFile during the window before it closes;
+	// exec'ing the script then fails with ETXTBSY until that child execs
+	// or exits (golang/go#22315). Nothing reopens the file for writing
+	// after this point, so one successful exec proves all later execs are
+	// safe — warm-exec with bounded retries before handing the path to
+	// the test. The script is a pure printf+exit, so the extra run is
+	// side-effect free.
+	for i := 0; ; i++ {
+		cmd := exec.Command(path)
+		err := cmd.Start()
+		if err == nil {
+			_ = cmd.Wait()
+			break
+		}
+		if !errors.Is(err, syscall.ETXTBSY) || i >= 10 {
+			t.Fatalf("warm-exec scanner script: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 	return path
 }


### PR DESCRIPTION
## Summary

- `TestExternalScanner_EmptyFindings` failed once on WSL2 with `fork/exec /tmp/.../clean: text file busy`. The tests run with `t.Parallel()`, so a concurrent test's fork can inherit the briefly-open write fd from `os.WriteFile`; exec of the just-written script then fails ETXTBSY until that child execs or exits (golang/go#22315 class).
- Fix is confined to the tests: a new `writeScannerScript` helper writes the script, then warm-execs it with bounded ETXTBSY retries (10 × 10ms). ETXTBSY requires someone holding a write fd, and the helper's `os.WriteFile` is the only writer ever — forked children can inherit that fd but never create new ones — so one successful exec proves every later exec is safe. The warmed process is killed immediately after `Start`, so slow scripts (the timeout test's `sleep 5`) don't stall the helper and the extra run has no observable effect.
- All three script-writing sites route through the helper: `writeExternalScanner`, `TestExternalScanner_ExitCode2`, and `TestExternalScanner_Timeout` (the latter two were flagged by codex review of the first commit).
- `ExternalScanner` itself is untouched: real scanners aren't written moments before exec. `syscall.ETXTBSY` is defined on Windows (tests already runtime-skip there); `GOOS=windows go vet` passes.

Closes bead `syllago-0rzuy`.

## Test plan

- `go test ./internal/converter/ -run TestExternalScanner -count=30` — pass.
- Full converter package `-count=2` and `-count=3` across both commits — pass.
- `go vet` + `GOOS=windows go vet` on the package — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKkjYnF9zuGSajoSVSRmz6