### PR TITLE
capmon: refresh zed skills and crush hooks format docs (syllago-zluqf)

### DIFF
--- a/cli/internal/converter/capabilities.go
+++ b/cli/internal/converter/capabilities.go
@@ -154,7 +154,7 @@ var providerHookCapabilities = map[string]ProviderCapabilities{
 		SupportsMatchers:         true,
 		SupportsAsync:            false,
 		SupportsStatusMessage:    false,
-		SupportsStructuredOutput: true, // JSON response: decision + context
+		SupportsStructuredOutput: true, // JSON response: decision + context + updated_input
 		SupportsBlocking:         true,
 		TimeoutUnit:              "seconds",
 		SupportsPlatform:         false,

--- a/cli/internal/converter/compat.go
+++ b/cli/internal/converter/compat.go
@@ -192,9 +192,12 @@ var HookOutputCapabilities = map[string]map[HookOutputField]bool{
 	"kiro":     {}, // No structured output support
 	"windsurf": {}, // No structured output support
 	"crush": {
-		// Crush hook responses support decision (allow/deny/none) and context
-		OutputDecision: true,
-		OutputContext:  true,
+		// Crush hook responses support decision (allow/deny/null), context,
+		// and updated_input (a shallow-merge patch against tool_input; see
+		// charmbracelet/crush docs/hooks/README.md "Output envelope").
+		OutputDecision:     true,
+		OutputContext:      true,
+		OutputUpdatedInput: true,
 	},
 }
 

--- a/cli/internal/converter/hooks_test.go
+++ b/cli/internal/converter/hooks_test.go
@@ -1585,6 +1585,8 @@ func TestOutputFieldsLostWarnings(t *testing.T) {
 		{"claude->gemini: 4 lost (decision+system_message kept)", "claude-code", "gemini-cli", 4},
 		{"claude->copilot: 5 lost (decision kept)", "claude-code", "copilot-cli", 5},
 		{"claude->cursor: 5 lost (decision kept)", "claude-code", "cursor", 5},
+		{"claude->crush: 3 lost (updated_input+decision+context kept)", "claude-code", "crush", 3},
+		{"crush->claude: none lost", "crush", "claude-code", 0},
 		{"claude->claude: none lost", "claude-code", "claude-code", 0},
 		{"gemini->claude: none lost", "gemini-cli", "claude-code", 0},
 		{"copilot->gemini: none lost", "copilot-cli", "gemini-cli", 0},

--- a/cli/internal/converter/hooks_test.go
+++ b/cli/internal/converter/hooks_test.go
@@ -1602,6 +1602,22 @@ func TestOutputFieldsLostWarnings(t *testing.T) {
 			}
 		})
 	}
+
+	// Exact-field check for crush: a count alone would pass with the wrong
+	// three fields kept. updated_input must be among the kept fields
+	// (crush shallow-merges it; see charmbracelet/crush docs/hooks/README.md).
+	t.Run("claude->crush exact lost fields", func(t *testing.T) {
+		lost := OutputFieldsLostWarnings("claude-code", "crush")
+		want := []string{"suppress_output", "system_message", "continue"}
+		if len(lost) != len(want) {
+			t.Fatalf("lost = %v, want %v", lost, want)
+		}
+		for i, f := range want {
+			if lost[i] != f {
+				t.Errorf("lost[%d] = %q, want %q (full: %v)", i, lost[i], f, lost)
+			}
+		}
+	})
 }
 
 func TestStructuredOutputWarnings_FlatFormat(t *testing.T) {

--- a/docs/provider-formats/crush.yaml
+++ b/docs/provider-formats/crush.yaml
@@ -18,7 +18,7 @@ category: cli
 #   3. Analogy with the preceding OpenCode format (the archived ancestor and
 #      Crush's sibling successor sst/opencode).
 # Confirmed facts are backed by direct upstream source references.
-last_fetched_at: "2026-05-06T12:57:00Z"
+last_fetched_at: "2026-07-15T03:36:49Z"
 last_changed_at: "2026-05-06T00:00:00Z"
 generation_method: subagent
 
@@ -234,83 +234,121 @@ content_types:
   hooks:
     status: supported
     sources:
+      - uri: "https://raw.githubusercontent.com/charmbracelet/crush/main/docs/hooks/README.md"
+        type: documentation
+        fetch_method: gh_raw
+        content_hash: "sha256:0871ecba435c774b38650046a10341cccf07661c78a4bf803ce585c8740f4d38"
+        fetched_at: "2026-07-15T03:36:49Z"
       - uri: "https://raw.githubusercontent.com/charmbracelet/crush/main/schema.json"
         type: source_code
         fetch_method: gh_raw
-        content_hash: "sha256:1ed71c8a69ce5a9a87855fb2a6abc78af23b821e7a6597727590849c52b45b88"
-        fetched_at: "2026-05-06T12:57:00Z"
+        content_hash: "sha256:003a7e66fb928e9df8de5316ba9381fde8668f92ac908fff45f7918f27c6fe2e"
+        fetched_at: "2026-07-15T03:36:49Z"
       - uri: "https://raw.githubusercontent.com/charmbracelet/crush/main/AGENTS.md"
         type: source_code
         fetch_method: gh_raw
-        content_hash: "sha256:ed343888cadd36ea75edd18bdb0d53afd3ffec17eda3e1213fc9662fdff6cf58"
-        fetched_at: "2026-05-06T12:57:00Z"
+        content_hash: "sha256:49d307d00f042927acb7d0803de4be39e624bab6c87027d028bd5d36e26b74f3"
+        fetched_at: "2026-07-15T03:36:49Z"
       - uri: "https://raw.githubusercontent.com/charmbracelet/crush/main/internal/skills/builtin/crush-config/SKILL.md"
         type: source_code
         fetch_method: gh_raw
-        content_hash: "sha256:877215de75b74d808cd69b666790aa3b8c852d2343b2d75ea9504f25e91d2fa0"
-        fetched_at: "2026-05-06T12:57:00Z"
+        content_hash: "sha256:37b7354933cf27eb4748e07844f677bda2ed5275a5c3af3043f70e7e4dd64f1d"
+        fetched_at: "2026-07-15T03:36:49Z"
     canonical_mappings:
       handler_types:
         supported: true
-        mechanism: "Hooks are shell commands (command field in HookConfig). Each hook fires a subprocess with the tool context passed on stdin."
+        mechanism: "Hooks are shell commands (command field in HookConfig), run through Crush's embedded POSIX shell (mvdan.cc/sh). Inline commands and shebang-less scripts execute in-process; scripts with a #! shebang dispatch to the named interpreter via os/exec, so hooks can be written in any language. The contract is identical on macOS, Linux, and Windows."
         confidence: confirmed
       matcher_patterns:
         supported: true
         provider_field: "matcher"
-        mechanism: "HookConfig has a matcher field: a regex pattern tested against the tool name. An empty matcher matches all tools."
+        mechanism: "HookConfig has an optional matcher field: a regex tested against the tool name (e.g. bash, edit, mcp_github_create_pull_request). Omitted or empty matcher matches all tools."
         confidence: confirmed
       decision_control:
         supported: true
-        mechanism: "Hook subprocess exit code controls tool execution: exit code 2 blocks the tool call (deny). Other exit codes allow it. The hook may also return a JSON decision field with values allow, deny, or none."
+        provider_field: "decision"
+        mechanism: "Exit code 2 blocks the tool call (stderr becomes the deny reason); exit 49 halts the whole turn; other non-zero exit codes are non-blocking errors and the tool call proceeds. On exit 0, stdout is parsed as a JSON envelope whose decision field may be allow, deny, or null. allow is affirmative pre-approval (skips the permission prompt); null/omitted means no opinion. Across multiple hooks, deny > allow > null, composed in config order."
         confidence: confirmed
       input_modification:
-        supported: false
-        mechanism: "Hooks receive tool context on stdin and can return context to the agent, but modifying tool input parameters is not documented."
-        confidence: inferred
+        supported: true
+        provider_field: "updated_input"
+        mechanism: "The exit-0 JSON envelope may include updated_input: a shallow-merge patch against tool_input. Included keys overwrite matching keys; omitted keys are preserved; nested objects are replaced wholesale. Patches from multiple hooks shallow-merge sequentially in config order (later hooks win on colliding keys) and are ignored if the final decision is deny or halt. Implemented as UpdatedInput in internal/hooks/hooks.go."
+        confidence: confirmed
       async_execution:
         supported: false
-        mechanism: "Hooks are synchronous; each fires before the tool executes and must complete within the configured timeout."
+        mechanism: "Matching hooks run in parallel with each other, but the tool call waits for all of them to finish (or time out) before proceeding — there is no fire-and-forget mode. A hook that exceeds its timeout is treated as a non-blocking error (\"no opinion\") and the tool call proceeds."
         confidence: confirmed
       hook_scopes:
         supported: true
-        mechanism: "Hooks are configured in crush.json under the hooks key, which applies at the project or user-global config level (same config file scope as MCP and other settings)."
+        mechanism: "Hooks can be configured in crush.json (or .crush.json) at both the user-global (~/.config/crush/crush.json) and project level, with project-level hooks taking precedence. Global-config commands must use absolute paths or inline commands; relative paths resolve against the working directory."
         confidence: confirmed
       json_io_protocol:
         supported: true
-        mechanism: "Hooks receive a JSON object on stdin containing tool name and parameters. The hook subprocess may return a JSON object with decision (allow/deny/none) and optional context fields."
+        mechanism: "Stdin provides a JSON payload: event, session_id, cwd, plus tool_name and tool_input (the raw JSON the model sent) for PreToolUse. On exit 0 stdout is parsed as a JSON output envelope: version (defaults to 1), decision, halt, reason, context, updated_input. Simple hooks can skip JSON entirely and use CRUSH_* environment variables plus exit codes."
         confidence: confirmed
       context_injection:
         supported: true
         provider_field: "context"
-        mechanism: "The hook JSON response may include an optional context field; this content is injected into the agent context for the current turn."
+        mechanism: "The output envelope's context field accepts a string or an array of strings, appended to what the model sees for the current turn. Across multiple hooks, context values concatenate in config order; empty entries are dropped."
         confidence: confirmed
       permission_control:
         supported: true
-        mechanism: "Hooks run before permission checks. Exit code 2 blocks the tool call entirely, taking effect before the built-in permission gate."
+        mechanism: "Hook results apply before permission checks. An aggregated deny blocks the tool call before any permission prompt; an aggregated allow is affirmative pre-approval that skips the prompt entirely; silence (no decision) falls through to the normal permission flow."
         confidence: confirmed
     provider_extensions:
       - id: event_keyed_map
         name: Event-keyed hook map
-        summary: The hooks config key is an object keyed by event name (e.g. PreToolUse), with each value being an array of HookConfig objects. This allows multiple hooks per event and per-tool matcher filtering.
-        source_ref: "https://raw.githubusercontent.com/charmbracelet/crush/main/schema.json"
+        summary: "The hooks config key is an object keyed by event name, with each value an array of HookConfig objects — multiple hooks per event with per-tool matcher filtering. Event names are case insensitive and snake-caseable: PreToolUse, pretooluse, and pre_tool_use all work."
+        source_ref: "https://raw.githubusercontent.com/charmbracelet/crush/main/docs/hooks/README.md"
         graduation_candidate: false
         conversion: translated
         provider_field: hooks
+      - id: hook_name
+        name: Friendly hook display name
+        summary: "HookConfig has an optional name field: a friendly display name shown in the TUI, falling back to the command when omitted. Maps from the canonical hook manifest's name field on install."
+        source_ref: "https://raw.githubusercontent.com/charmbracelet/crush/main/schema.json"
+        graduation_candidate: false
+        conversion: translated
+        provider_field: name
       - id: hook_timeout
         name: Per-hook timeout
-        summary: Each HookConfig entry has a timeout field (integer, seconds, default 30) that limits how long the hook subprocess may run before being killed.
-        source_ref: "https://raw.githubusercontent.com/charmbracelet/crush/main/schema.json"
+        summary: "Each HookConfig entry has a timeout field (integer, seconds, default 30). On timeout, Crush cancels the hook's context, waits a short grace period, then treats the result as a non-blocking error so the tool call proceeds — a timed-out hook cannot block."
+        source_ref: "https://raw.githubusercontent.com/charmbracelet/crush/main/docs/hooks/README.md"
         graduation_candidate: false
         conversion: not-portable
         provider_field: timeout
       - id: pre_permission_execution
         name: Hooks fire before permission checks
-        summary: Crush's hookedTool decorator runs hook commands before the built-in permission gate, giving hooks full veto power over tool calls independent of configured permissions.
-        source_ref: "https://raw.githubusercontent.com/charmbracelet/crush/main/AGENTS.md"
+        summary: "Hooks run before Crush's built-in permission gate: deny blocks the tool call before any prompt appears, and allow is affirmative pre-approval that skips the prompt — hooks can both veto and auto-approve independent of configured permissions."
+        source_ref: "https://raw.githubusercontent.com/charmbracelet/crush/main/docs/hooks/README.md"
         graduation_candidate: false
         conversion: not-portable
-    loading_model: "Hooks are configured in crush.json under the hooks key as an object keyed by event name (e.g. PreToolUse). Each key maps to an array of HookConfig objects. Each HookConfig specifies a command (required shell command), an optional matcher (regex against tool name; empty matches all tools), and an optional timeout (seconds, default 30). At tool execution time, Crush fires matching hooks in order, passing JSON on stdin (tool name and parameters). The hook may return JSON with a decision (allow/deny/none) and optional context. Exit code 2 blocks the tool call. Hooks run before Crush's built-in permission checks."
-    notes: "Hook event key naming follows provider-native conventions (e.g. PreToolUse) in the crush.json config. Canonical syllago event names (before_tool_execute) must be translated to provider-native keys during install/export. The hookedTool implementation is in internal/agent/hooked_tool.go."
+      - id: turn_halt
+        name: Turn halt (exit 49 / halt field)
+        summary: "A hook can end the whole turn, not just block one tool call: exit code 49 (stderr becomes the halt reason) or halt: true in the JSON envelope. The agent doesn't respond further; the user takes over. Halt is sticky across multiple hooks."
+        source_ref: "https://raw.githubusercontent.com/charmbracelet/crush/main/docs/hooks/README.md"
+        graduation_candidate: false
+        conversion: not-portable
+      - id: parallel_config_order
+        name: Parallel execution, config-order composition
+        summary: "Matching hooks run in parallel for speed, deduplicated by identical command, and their results compose deterministically in config order: deny wins over allow, reasons and context concatenate in order, updated_input patches merge in order. Timing never determines the outcome."
+        source_ref: "https://raw.githubusercontent.com/charmbracelet/crush/main/docs/hooks/README.md"
+        graduation_candidate: false
+        conversion: not-portable
+      - id: env_var_input
+        name: Environment-variable input
+        summary: "Alongside stdin JSON, every hook receives environment variables: CRUSH=1, AGENT=crush, AI_AGENT=crush, CRUSH_EVENT, CRUSH_TOOL_NAME, CRUSH_SESSION_ID, CRUSH_CWD, CRUSH_PROJECT_DIR, and per-tool shortcuts CRUSH_TOOL_INPUT_COMMAND (bash) and CRUSH_TOOL_INPUT_FILE_PATH (file tools) — simple hooks never need to parse JSON."
+        source_ref: "https://raw.githubusercontent.com/charmbracelet/crush/main/docs/hooks/README.md"
+        graduation_candidate: false
+        conversion: not-portable
+      - id: subagent_exemption
+        name: Top-level-agent-only scope
+        summary: "PreToolUse fires only on the top-level agent's tool calls; sub-agents (the agent task tool, agentic_fetch) run without hook interception so one delegated turn doesn't fire a hook N times. The outer sub-agent tool call itself is hooked."
+        source_ref: "https://raw.githubusercontent.com/charmbracelet/crush/main/docs/hooks/README.md"
+        graduation_candidate: false
+        conversion: not-portable
+    loading_model: "Hooks are configured in crush.json (or .crush.json) under the hooks key as an object keyed by event name (case insensitive, snake-caseable; PreToolUse is currently the only event). Each key maps to an array of HookConfig objects: command (required shell command), plus optional name (TUI display name), matcher (regex against tool name; omit to match all), and timeout (seconds, default 30). Global and project configs both load, with project hooks taking precedence. At tool-call time Crush filters hooks by matcher, dedupes by command, runs them in parallel through its embedded POSIX shell, passing JSON on stdin (event, session_id, cwd, tool_name, tool_input) and CRUSH_* environment variables. Results compose in config order and apply before permission checks: exit 2 or decision: deny blocks the call, exit 49 or halt: true ends the turn, decision: allow pre-approves and skips the permission prompt, context strings append to model context, and updated_input shallow-merge patches rewrite the tool input."
+    notes: "Official hooks documentation now lives at docs/hooks/README.md in the crush repo (the earlier entry predated it and was inferred from schema.json). Crush states its hooks are broadly Claude Code-compatible — config shape, stdin payload, output envelope, and exit codes line up — with one intentional divergence: updated_input is a shallow-merge patch against tool_input rather than a full replacement. Hook event key naming follows provider-native conventions (e.g. PreToolUse); canonical syllago event names (before_tool_execute) must be translated to provider-native keys during install/export. Hook aggregation and UpdatedInput handling are implemented in internal/hooks/hooks.go."
 
   agents:
     status: unsupported

--- a/docs/provider-formats/crush.yaml
+++ b/docs/provider-formats/crush.yaml
@@ -256,8 +256,8 @@ content_types:
         fetched_at: "2026-07-15T03:36:49Z"
     canonical_mappings:
       handler_types:
-        supported: true
-        mechanism: "Hooks are shell commands (command field in HookConfig), run through Crush's embedded POSIX shell (mvdan.cc/sh). Inline commands and shebang-less scripts execute in-process; scripts with a #! shebang dispatch to the named interpreter via os/exec, so hooks can be written in any language. The contract is identical on macOS, Linux, and Windows."
+        supported: false
+        mechanism: "Crush hooks are shell commands only (command field in HookConfig) — no HTTP, LLM prompt, or agent handler types. Commands run through Crush's embedded POSIX shell (mvdan.cc/sh): inline commands and shebang-less scripts execute in-process; scripts with a #! shebang dispatch to the named interpreter via os/exec, so hook scripts can be written in any language. The contract is identical on macOS, Linux, and Windows."
         confidence: confirmed
       matcher_patterns:
         supported: true

--- a/docs/provider-formats/zed.yaml
+++ b/docs/provider-formats/zed.yaml
@@ -5,7 +5,7 @@ category: standalone-app
 # - required: true | false | null (null = source doesn't say)
 # - value_type: see allow-list in formatdoc_validate.go
 # - examples: [{title?, lang, code, note?}]
-last_fetched_at: "2026-05-06T12:57:00Z"
+last_fetched_at: "2026-07-14T01:49:10Z"
 last_changed_at: "2026-05-06T00:00:00Z"
 generation_method: subagent
 
@@ -180,38 +180,153 @@ content_types:
     sources:
       - uri: "https://zed.dev/docs/ai/skills"
         type: documentation
-        fetch_method: web
-        fetched_at: "2026-07-14T00:00:00Z"
+        fetch_method: gh_raw
+        fetched_at: "2026-07-14T01:49:10Z"
+        content_hash: "sha256:bbbc98f66c3f213976f6fc7e7e16b2122e748793d2ad217a9175c951f2eacaab"
     canonical_mappings:
-      canonical_filename:
-        supported: true
-        mechanism: "SKILL.md (required, fixed name per the Agent Skills standard)"
-        confidence: confirmed
-      project_scope:
-        supported: true
-        mechanism: ".agents/skills/<name>/SKILL.md — the cross-provider convention is Zed's only skills location; there is no zed-native directory"
-        paths:
-          - ".agents/skills/<name>/SKILL.md"
-        confidence: confirmed
-      global_scope:
-        supported: true
-        mechanism: "~/.agents/skills/<name>/SKILL.md (cross-provider convention)"
-        paths:
-          - "~/.agents/skills/<name>/SKILL.md"
-        confidence: confirmed
       display_name:
         supported: true
         provider_field: "name"
-        mechanism: "yaml frontmatter key: name (required) per the Agent Skills standard"
+        mechanism: "yaml frontmatter key: name (required). Lowercase letters, numbers, and hyphens only; 1-64 characters; no leading/trailing or consecutive hyphens. Should match the skill's folder name and doubles as the skill identifier; skills with invalid names fail to load."
         confidence: confirmed
       description:
         supported: true
         provider_field: "description"
-        mechanism: "yaml frontmatter key: description (required) per the Agent Skills standard"
+        mechanism: "yaml frontmatter key: description (required). States what the skill does and when to use it; the agent uses it to decide when to auto-invoke. Keep under 1024 bytes — longer descriptions still load but surface a warning."
         confidence: confirmed
-    provider_extensions: []
-    loading_model: "A skill is a directory containing a SKILL.md file. Zed discovers skills exclusively through the cross-provider Agent Skills convention: .agents/skills/<name>/SKILL.md (project scope) and ~/.agents/skills/<name>/SKILL.md (user global scope). There is no zed-native skills directory."
-    notes: "Zed shipped Agent Skills support in 2026 (https://zed.dev/docs/ai/skills); Go support landed in PR #503. This entry reconciles the stale unsupported assertion; the full capmon formatdoc refresh (source content hashes, complete canonical mappings) is tracked separately."
+      disable_model_invocation:
+        supported: true
+        provider_field: "disable-model-invocation"
+        mechanism: "yaml frontmatter key: disable-model-invocation (optional bool, default false). When true the skill is hidden from the agent's autonomous catalog but stays invocable by the user via slash command or @-mention — useful for deploy/release procedures you do not want the agent triggering."
+        confidence: confirmed
+      auto_invocable:
+        supported: true
+        mechanism: "By default the agent picks up skills autonomously: it sees a catalog of every installed skill (name + description) in its system prompt and calls the skill tool when a task matches a skill's description. Semantic description matching, opt-out via disable-model-invocation — functionally the canonical auto_invocable capability."
+        confidence: confirmed
+      user_invocable:
+        supported: true
+        mechanism: "All installed skills are user-invocable: type / in the message editor and select a skill by name, or @skill to pick one from the completion menu. Both inject the skill's instructions as context (shown as a clickable crease button). disable-model-invocation: true removes only the model's autonomous invocation, leaving the skill user-invocable."
+        confidence: confirmed
+      project_scope:
+        supported: true
+        mechanism: "Project-local skills live in <worktree>/.agents/skills/<name>/SKILL.md and apply only to the current project. They load only from trusted worktrees — skills from a freshly cloned or untrusted project are excluded from the catalog and slash commands until trust is granted."
+        paths:
+          - "<worktree>/.agents/skills/<name>/SKILL.md"
+        confidence: confirmed
+      global_scope:
+        supported: true
+        mechanism: "Global skills live in ~/.agents/skills/<name>/SKILL.md and apply to every project. The agent can read global skill resources even though they are outside the current project."
+        paths:
+          - "~/.agents/skills/<name>/SKILL.md"
+        confidence: confirmed
+      shared_scope:
+        supported: false
+        mechanism: "Zed loads skills from exactly two locations (global ~/.agents/skills/ and project-local <worktree>/.agents/skills/); no organization/enterprise scope is documented, and 'No remote registry' — Zed does not discover or load skills from remote locations at runtime."
+        confidence: confirmed
+      canonical_filename:
+        supported: true
+        mechanism: "SKILL.md is the required fixed filename inside each skill folder (starts with YAML frontmatter, followed by Markdown instructions)."
+        confidence: confirmed
+      custom_filename:
+        supported: false
+        mechanism: "The skill file name is fixed as SKILL.md; only the containing folder name varies (and serves as the skill identifier). No custom filename is supported."
+        confidence: confirmed
+      skill_bundled_resources:
+        supported: true
+        mechanism: "A skill folder may co-locate scripts/ (scripts the agent can run), references/ (additional documentation), and assets/ (templates and static files) alongside SKILL.md. The agent loads them on demand via the read_file and list_directory tools; the SKILL.md body links to them (progressive disclosure)."
+        confidence: confirmed
+      license:
+        supported: false
+        mechanism: "Not currently a frontmatter field. The docs list only name, description, and disable-model-invocation, and state further Agent Skills spec fields are planned 'in the near future'."
+        confidence: confirmed
+      compatibility:
+        supported: false
+        mechanism: "Not currently a frontmatter field (only name, description, disable-model-invocation are recognized today; further Agent Skills spec fields are planned)."
+        confidence: confirmed
+      metadata_map:
+        supported: false
+        mechanism: "Not currently a frontmatter field (only name, description, disable-model-invocation are recognized today; further Agent Skills spec fields are planned)."
+        confidence: confirmed
+      version:
+        supported: false
+        mechanism: "Not currently a frontmatter field (only name, description, disable-model-invocation are recognized today; further Agent Skills spec fields are planned)."
+        confidence: confirmed
+    provider_extensions:
+      - id: skills_sh_registry
+        name: skills.sh community registry
+        summary: "Skills can be installed from skills.sh, a community registry of open-source skills (e.g. find-skills, frontend-design, pdf). Install by copying the skill's folder into ~/.agents/skills/ (global) or the project's .agents/skills/ (project-local). The built-in find-skills skill discovers and installs skills from the open ecosystem."
+        source_ref: "https://zed.dev/docs/ai/skills#from-the-skills.sh-registry"
+        conversion: not-portable
+        graduation_candidate: false
+      - id: share_link
+        name: zed://skill share links
+        summary: "The Skills settings page can copy a self-contained zed://skill?data=... link that embeds the full SKILL.md contents (base64url-encoded). A recipient opening the link gets a pre-filled 'Create Skill' page; nothing is written to disk until they explicitly save, so a shared link can never silently install instructions."
+        source_ref: "https://zed.dev/docs/ai/skills#sharing-skills"
+        conversion: not-portable
+        graduation_candidate: false
+      - id: skill_creator_ui
+        name: Built-in skill creator and URL import
+        summary: "Zed ships a built-in create-skill skill (invoke via /create-skill) that walks you through authoring, plus a Skills Manager (cmd-alt-l|ctrl-alt-l) and an 'agent: create skill from url' command that imports a skill from a supported GitHub Markdown URL. The creator saves to the scope of the selected settings tab (User = global, Project = project-local)."
+        source_ref: "https://zed.dev/docs/ai/skills#adding-skills"
+        conversion: not-portable
+        graduation_candidate: false
+      - id: manual_invocation
+        name: Slash-command and @-mention invocation
+        summary: "Beyond autonomous invocation, a skill can be loaded manually: type / and select it by name, or type @skill and pick it from the completion menu. Both inject the skill's instructions as context; the loaded skill appears as a crease button in the thread that opens the skill file when clicked."
+        source_ref: "https://zed.dev/docs/ai/skills#manual-invocation"
+        conversion: not-portable
+        graduation_candidate: false
+      - id: project_trust
+        name: Project-local trust gating
+        summary: "Project-local skills load only from trusted worktrees. Skills from a freshly cloned or untrusted project are excluded from the catalog and slash commands until you grant trust — preventing a malicious project from injecting instructions into the agent's system prompt before you have reviewed what it ships."
+        source_ref: "https://zed.dev/docs/ai/skills#project-local-skills-and-trust"
+        conversion: not-portable
+        graduation_candidate: false
+      - id: override_precedence
+        name: Project-over-global name override
+        summary: "If a global and a project-local skill share the same name, the project-local skill takes precedence — letting a project customize or replace a global skill for its own context."
+        source_ref: "https://zed.dev/docs/ai/skills#override-behavior"
+        conversion: not-portable
+        graduation_candidate: false
+      - id: agent_edit_protection
+        name: Agent edit protection for skill files
+        summary: "The agent cannot edit SKILL.md files or their bundled resources without explicit user authorization, even in a trusted project. This prevents a compromised conversation from modifying the skills that govern future conversations."
+        source_ref: "https://zed.dev/docs/ai/skills#editing-skill-files"
+        conversion: not-portable
+        graduation_candidate: false
+      - id: permission_prompt
+        name: Per-skill tool-permission prompt
+        summary: "When the agent invokes a user-created or installed skill, Zed prompts allow/deny using the same permission flow as other tools; skills built into Zed do not prompt. Per-skill defaults can be set in Tool Permissions to avoid repeated prompts for trusted skills."
+        source_ref: "https://zed.dev/docs/ai/skills#using-skills"
+        conversion: not-portable
+        graduation_candidate: false
+      - id: live_reload
+        name: Live reload of skill files
+        summary: "Adding, removing, or editing a SKILL.md takes effect immediately without restarting the session. Changing a skill's name or description invalidates the model's prompt cache for the current session."
+        source_ref: "https://zed.dev/docs/ai/skills#limitations"
+        conversion: not-portable
+        graduation_candidate: false
+      - id: flat_layout
+        name: Flat skills layout (no nesting)
+        summary: "Each skill must be a direct child of the skills root. Nested folders like ~/.agents/skills/group/my-skill/ are not discovered — a stricter layout than providers that walk nested skill directories."
+        source_ref: "https://zed.dev/docs/ai/skills#where-skills-live"
+        conversion: not-portable
+        graduation_candidate: false
+      - id: catalog_budget
+        name: 50KB catalog budget
+        summary: "The total size of all skill names and descriptions is capped at 50KB. Skills that do not fit are dropped from the catalog with a UI warning, so descriptions must stay concise (individual descriptions are also soft-capped at 1024 bytes)."
+        source_ref: "https://zed.dev/docs/ai/skills#limitations"
+        conversion: not-portable
+        graduation_candidate: false
+      - id: agent_path_boundaries
+        name: Zed Agent path boundary
+        summary: "Zed Skills apply to the Zed Agent only. External Agents (over the Agent Client Protocol) and Terminal Threads (native CLIs/TUIs) may have their own native skills, prompts, or instruction systems, configured in the external agent or CLI rather than here."
+        source_ref: "https://zed.dev/docs/ai/skills#agent-path-boundaries"
+        conversion: not-portable
+        graduation_candidate: false
+    loading_model: "Progressive disclosure: the agent sees only each skill's name and description (subject to the 50KB catalog budget) until it activates a skill, then loads the full SKILL.md body and any bundled resources on demand via read_file/list_directory. Skills load from ~/.agents/skills/<name>/SKILL.md (global, every project) and <worktree>/.agents/skills/<name>/SKILL.md (project-local, trusted worktrees only); a project-local skill overrides a global skill of the same name. Each skill is a direct child of the skills root — nested folders are not discovered. By default the agent auto-invokes skills whose description matches the task; disable-model-invocation: true limits a skill to explicit user invocation. Adding/removing/editing a SKILL.md takes effect live."
+    notes: "Zed onboarded Skills in the 2026-07 docs restructure that replaced the Rules Library: reusable, on-demand Library rules became Skills, always-on rules became AGENTS.md instructions. Zed implements a subset of the Agent Skills open standard — frontmatter is currently limited to name, description, and disable-model-invocation, with further spec fields (license, compatibility, metadata, version, etc.) planned 'in the near future'. Distinctive Zed concepts: self-contained zed://skill share links, a built-in create-skill skill plus GitHub-URL import, project-local trust gating, agent edit protection on skill files, and a strictly flat skills layout. No enterprise scope and no runtime remote registry (skills.sh installs are a one-time copy/import)."
+
 
   hooks:
     status: unsupported


### PR DESCRIPTION
## Summary

Formatdoc refresh pass for two stale provider format docs (bead `syllago-zluqf`).

- **Zed skills** (`docs/provider-formats/zed.yaml`): PR #507 flipped the status to supported with a minimal entry to unblock the coverage gate. This replaces it with the complete section mirrored from capmon's format doc: source content hash, all 15 canonical skills keys mapped (frontmatter is currently limited to `name`, `description`, `disable-model-invocation`; license/compatibility/metadata/version are unsupported pending Zed's planned spec fields), and 12 provider extensions (skills.sh registry, zed://skill share links, project trust gating, flat layout, 50KB catalog budget, agent edit protection, ...).
- **Crush hooks** (`docs/provider-formats/crush.yaml`): the section (last fetched 2026-05-06) predated upstream's official hook docs at `charmbracelet/crush docs/hooks/README.md` and was inferred from schema.json. Refreshed against upstream fetched today: `input_modification` flips to supported/confirmed (`updated_input` shallow-merge patch; `UpdatedInput` in `internal/hooks/hooks.go`), decision semantics corrected (exit 49 halts the turn, other non-zero exit codes are non-blocking, `decision: allow` affirmatively skips the permission prompt), `handler_types` corrected to unsupported (shell commands only — the canonical key means executors *beyond* shell commands; the old entry had this wrong), README added as a documentation source, all hashes refreshed, and new extensions documented (hook `name` field, turn halt, parallel config-order composition, `CRUSH_*` env-var input, sub-agent exemption).
- **Go follow-up**: `HookOutputCapabilities["crush"]` gains `OutputUpdatedInput`, so converting a Claude Code hook that uses `updated_input` to crush no longer emits a false "field lost" warning. Count-based test rows plus an exact-field subtest (TDD).
- **Seeder spec retired**: the stale `.develop/seeder-specs/zed-skills.yaml` negative result was deleted locally (that directory is gitignored, so no diff here).

Coverage-gate `status` values are unchanged; `go test ./internal/provider/` passes.

Note: capmon's own crush.yaml hooks section is stale on the same points (fetched 2026-07-14 but still `input_modification: false/inferred`, `handler_types: true`, no README source, no `name` field) — flagged for the next capmon session, not fixable from this repo.

Closes bead `syllago-zluqf`.

## Test plan

- New `TestOutputFieldsLostWarnings` rows: claude→crush now loses exactly `suppress_output`, `system_message`, `continue` (updated_input kept); crush→claude loses none.
- Both YAMLs parse; full `make test` (including the always-on `TestCoverageNoDrift`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKkjYnF9zuGSajoSVSRmz6