### PR TITLE
chore(capmon-pull): Capability Feed mirror update

### DIFF
--- a/docs/provider-capabilities/by-content-type/agents.json
+++ b/docs/provider-capabilities/by-content-type/agents.json
@@ -358,12 +358,12 @@
           "capabilities": {
             "project": {
               "confidence": "inferred",
-              "mechanism": "project-scoped agents stored under .kiro/agents/ documented under 'Local agents (project-specific)' heading; precedence rules under 'Agent precedence'",
+              "mechanism": "project-scoped agents stored under .kiro/agents/ documented under 'Local agents (project-specific)' heading; local (project) agent takes precedence over global on name collision (with a warning), per 'Agent precedence'",
               "supported": true
             },
             "user": {
               "confidence": "inferred",
-              "mechanism": "user-scoped agents stored under ~/.kiro/agents/ documented under 'Global agents (user-wide)' heading; precedence rules under 'Agent precedence'",
+              "mechanism": "user-scoped agents stored under ~/.kiro/agents/ documented under 'Global agents (user-wide)' heading; global agent is the fallback when no local agent of the same name exists, per 'Agent precedence'",
               "supported": true
             }
           },
@@ -417,6 +417,98 @@
           },
           "key_path": "agents.tool_restrictions",
           "mechanism": "per-agent tool allowlist with exact matches, wildcard patterns, and MCP tool patterns documented under 'Tools field' / 'AllowedTools field' / 'ToolsSettings field' headings",
+          "supported": true
+        }
+      },
+      "supported": true
+    },
+    "opencode": {
+      "capabilities": {
+        "agent_scopes": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Where agent definitions can live and the priority ordering when definitions exist at multiple levels. Common scopes: project, user/personal, managed/enterprise, CLI-defined.\n",
+            "spec_ref": "ACIF-AGENT §9.2 (OUT-OF-SCOPE-AT-L1; install_scope_capabilities, ACIF-REGISTRY)",
+            "type": "object"
+          },
+          "key_path": "agents.agent_scopes",
+          "mechanism": "two scopes, both loaded and coexisting: project (.opencode/agents/ or .opencode/agent/) and user-global (~/.config/opencode/agents/)",
+          "supported": true
+        },
+        "definition_format": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "What format agent definitions use. Varies widely: Markdown with YAML frontmatter, JSON config files, TOML sections, or AGENTS.md plain markdown.\n",
+            "spec_ref": "ACIF-AGENT §9.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "string"
+          },
+          "key_path": "agents.definition_format",
+          "mechanism": "markdown with YAML frontmatter in .opencode/agents/*.md (project) and ~/.config/opencode/agents/*.md (global); the loader accepts both agent/ and agents/ directory names and recurses; frontmatter declares description/mode/model/temperature/top_p/steps/permission/color/hidden/disable/variant/prompt and the body becomes the system prompt; agents can also be defined inline in opencode.json under the agent key (documented under 'Configure' / 'Markdown' / 'Create agents')",
+          "supported": true
+        },
+        "invocation_patterns": {
+          "capabilities": {
+            "at_mention": {
+              "confidence": "confirmed",
+              "mechanism": "subagents invoked manually by @-mentioning the subagent name in a message; agent name derives from the filename (documented under 'Subagents')",
+              "supported": true
+            },
+            "natural_language": {
+              "confidence": "confirmed",
+              "mechanism": "subagents invoked automatically by primary agents for specialized tasks based on their description field (documented under 'Subagents')",
+              "supported": true
+            }
+          },
+          "key": {
+            "description": "How agents are triggered. Mechanisms include natural language detection, @-mention syntax, slash commands, CLI flags, or automatic delegation.\n",
+            "spec_ref": "ACIF-AGENT §9.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "object"
+          },
+          "key_path": "agents.invocation_patterns",
+          "supported": true
+        },
+        "model_selection": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether per-agent model overrides are supported, allowing different agents to use different AI models.\n",
+            "spec_ref": "ACIF-AGENT §9.1 (DERIVABLE)",
+            "type": "bool"
+          },
+          "key_path": "agents.model_selection",
+          "mechanism": "frontmatter model field (provider/model-id format) overrides the session default; subagents default to the invoking primary agent's model (documented under 'Model')",
+          "supported": true
+        },
+        "per_agent_mcp": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether agents can have their own MCP server configuration, scoping which external tools each agent can access.\n",
+            "spec_ref": "ACIF-AGENT §9.1 (DERIVABLE)",
+            "type": "bool"
+          },
+          "key_path": "agents.per_agent_mcp",
+          "mechanism": "no per-agent mcpServers field documented; agents inherit the workspace MCP configuration, with per-agent access gated via the permission map",
+          "supported": false
+        },
+        "subagent_spawning": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether agents can spawn, delegate to, or resume other agents. Enables multi-agent coordination patterns.\n",
+            "spec_ref": "ACIF-AGENT §9.1 (DERIVABLE; canonical spawn tool name, ACIF-CORE Appendix A)",
+            "type": "bool"
+          },
+          "key_path": "agents.subagent_spawning",
+          "mechanism": "agents with mode: subagent (or all) are invocable from other agents via the Task tool, driven by the callee's description; permission.task on the orchestrator controls which subagents it may invoke (documented under 'Task permissions')",
+          "supported": true
+        },
+        "tool_restrictions": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether agents can be restricted to specific tools via allowlists, denylists, tool categories, or per-tool configuration maps.\n",
+            "spec_ref": "ACIF-AGENT §9.1 (DERIVABLE); tool vocabulary ACIF-CORE Appendix A",
+            "type": "bool"
+          },
+          "key_path": "agents.tool_restrictions",
+          "mechanism": "permission frontmatter map configures ask/allow/deny per tool using named keys or wildcard glob patterns; fine-grained keys accept glob/pattern-to-action objects (documented under 'Permissions')",
           "supported": true
         }
       },

--- a/docs/provider-capabilities/by-content-type/commands.json
+++ b/docs/provider-capabilities/by-content-type/commands.json
@@ -49,6 +49,33 @@
       },
       "supported": true
     },
+    "opencode": {
+      "capabilities": {
+        "argument_substitution": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "How user-provided arguments are injected into command templates. Mechanisms vary: $ARGUMENTS, {{args}}, positional $1/$2/${@:N}, and other interpolation syntaxes.\n",
+            "spec_ref": "ACIF-COMMAND §9.1 (OUT-OF-SCOPE-AT-L1; placeholder vocabulary ACIF-COMMAND Appendix A, §7)",
+            "type": "object"
+          },
+          "key_path": "commands.argument_substitution",
+          "mechanism": "$ARGUMENTS carries all arguments as a single string; positional $1/$2/$3 carry individual arguments — substituted from user input at invocation time (documented under 'Arguments')",
+          "supported": true
+        },
+        "builtin_commands": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether the provider ships default/built-in commands alongside user-defined custom commands.\n",
+            "spec_ref": "ACIF-COMMAND §9.2 (OUT-OF-SCOPE-AT-L1; provider_capability_coverage row)",
+            "type": "bool"
+          },
+          "key_path": "commands.builtin_commands",
+          "mechanism": "built-in /init, /undo, /redo, /share, /help; custom commands override built-ins when given the same name (documented under 'Built-in')",
+          "supported": true
+        }
+      },
+      "supported": true
+    },
     "pi": {
       "capabilities": {
         "argument_substitution": {

--- a/docs/provider-capabilities/by-content-type/hooks.json
+++ b/docs/provider-capabilities/by-content-type/hooks.json
@@ -411,6 +411,110 @@
       },
       "supported": true
     },
+    "crush": {
+      "capabilities": {
+        "async_execution": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether hooks can run asynchronously without blocking the agent's execution loop. Fire-and-forget semantics.\n",
+            "spec_ref": "ACIF-HOOK §10.1 (DERIVABLE)",
+            "type": "bool"
+          },
+          "key_path": "hooks.async_execution",
+          "mechanism": "Matching hooks run in parallel with each other, but the tool call waits for all of them to finish (or time out) before proceeding — there is no fire-and-forget mode. A hook that exceeds its timeout is treated as a non-blocking error (\"no opinion\") and the tool call proceeds.",
+          "supported": false
+        },
+        "context_injection": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether hooks can inject messages, system prompts, or conversation context into the agent's active session.\n",
+            "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+            "type": "bool"
+          },
+          "key_path": "hooks.context_injection",
+          "mechanism": "The output envelope's context field accepts a string or an array of strings, appended to what the model sees for the current turn. Across multiple hooks, context values concatenate in config order; empty entries are dropped.",
+          "supported": true
+        },
+        "decision_control": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Which decision actions hooks can take on the triggering action. Contents: {block: bool, allow: bool, modify: bool}. Mechanisms include exit code contracts, JSON decision fields, or cancel flags. Boundary: decision_control governs whether a tool invocation proceeds; see permission_control for whether a tool is available at all.\n",
+            "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+            "type": "object"
+          },
+          "key_path": "hooks.decision_control",
+          "mechanism": "Exit code 2 blocks the tool call (stderr becomes the deny reason); exit 49 halts the whole turn; other non-zero exit codes are non-blocking errors and the tool call proceeds. On exit 0, stdout is parsed as a JSON envelope whose decision field may be allow, deny, or null. allow is affirmative pre-approval (skips the permission prompt); null/omitted means no opinion. Across multiple hooks, deny > allow > null, composed in config order.",
+          "supported": true
+        },
+        "handler_types": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "What kinds of executors hooks support beyond shell commands. May include HTTP endpoints, LLM prompt evaluation, multi-turn agent handlers, or TypeScript extensions.\n",
+            "spec_ref": "ACIF-HOOK §10.1 (DERIVABLE); handler-type enum ACIF-HOOK Appendix B, §8.2",
+            "type": "object"
+          },
+          "key_path": "hooks.handler_types",
+          "mechanism": "Crush hooks are shell commands only (command field in HookConfig) — no HTTP, LLM prompt, or agent handler types. Commands run through Crush's embedded POSIX shell (mvdan.cc/sh): inline commands and shebang-less scripts execute in-process; scripts with a #! shebang dispatch to the named interpreter via os/exec, so hook scripts can be written in any language. The contract is identical on macOS, Linux, and Windows.",
+          "supported": false
+        },
+        "hook_scopes": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Where hooks can be configured and the precedence model when multiple scopes define hooks for the same event. Common scopes: global/user, project, workspace, managed/enterprise.\n",
+            "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; install-location-determined)",
+            "type": "object"
+          },
+          "key_path": "hooks.hook_scopes",
+          "mechanism": "Hooks can be configured in crush.json (or .crush.json) at both the user-global (~/.config/crush/crush.json) and project level, with project-level hooks taking precedence. Global-config commands must use absolute paths or inline commands; relative paths resolve against the working directory.",
+          "supported": true
+        },
+        "input_modification": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether hooks can modify tool input arguments before the tool executes. Safety-critical capability — silent degradation creates false security. Minimum qualification: supported when the provider provides any mechanism to modify tool input arguments before execution (e.g., hookSpecificOutput.updatedInput, plugin-mutable args, or equivalent).\n",
+            "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+            "type": "bool"
+          },
+          "key_path": "hooks.input_modification",
+          "mechanism": "The exit-0 JSON envelope may include updated_input: a shallow-merge patch against tool_input. Included keys overwrite matching keys; omitted keys are preserved; nested objects are replaced wholesale. Patches from multiple hooks shallow-merge sequentially in config order (later hooks win on colliding keys) and are ignored if the final decision is deny or halt. Implemented as UpdatedInput in internal/hooks/hooks.go.",
+          "supported": true
+        },
+        "json_io_protocol": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether hooks communicate with the host via structured JSON on stdin/stdout rather than plain text or exit codes alone.\n",
+            "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+            "type": "bool"
+          },
+          "key_path": "hooks.json_io_protocol",
+          "mechanism": "Stdin provides a JSON payload: event, session_id, cwd, plus tool_name and tool_input (the raw JSON the model sent) for PreToolUse. On exit 0 stdout is parsed as a JSON output envelope: version (defaults to 1), decision, halt, reason, context, updated_input. Simple hooks can skip JSON entirely and use CRUSH_* environment variables plus exit codes.",
+          "supported": true
+        },
+        "matcher_patterns": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether hooks can filter which tools or events they respond to using name matching, regex patterns, or structured criteria.\n",
+            "spec_ref": "ACIF-HOOK §10.1 (DERIVABLE)",
+            "type": "bool"
+          },
+          "key_path": "hooks.matcher_patterns",
+          "mechanism": "HookConfig has an optional matcher field: a regex tested against the tool name (e.g. bash, edit, mcp_github_create_pull_request). Omitted or empty matcher matches all tools.",
+          "supported": true
+        },
+        "permission_control": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether hooks can make or influence permission decisions determining whether a tool is available for invocation. Minimum qualification: supported when the provider allows hooks to return permission decisions of any kind (grant, deny, or ask). Boundary: permission_control governs whether a tool is available; see decision_control for invocation-flow control.\n",
+            "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+            "type": "bool"
+          },
+          "key_path": "hooks.permission_control",
+          "mechanism": "Hook results apply before permission checks. An aggregated deny blocks the tool call before any permission prompt; an aggregated allow is affirmative pre-approval that skips the prompt entirely; silence (no decision) falls through to the normal permission flow.",
+          "supported": true
+        }
+      },
+      "supported": true
+    },
     "cursor": {
       "capabilities": {
         "hook_scopes": {
@@ -452,14 +556,14 @@
     "factory-droid": {
       "capabilities": {
         "decision_control": {
-          "confidence": "inferred",
+          "confidence": "confirmed",
           "key": {
             "description": "Which decision actions hooks can take on the triggering action. Contents: {block: bool, allow: bool, modify: bool}. Mechanisms include exit code contracts, JSON decision fields, or cancel flags. Boundary: decision_control governs whether a tool invocation proceeds; see permission_control for whether a tool is available at all.\n",
             "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
             "type": "object"
           },
           "key_path": "hooks.decision_control",
-          "mechanism": "hook_exit_code_behavior: Factory Droid hooks use exit codes to signal block (non-zero) or allow (zero) decisions on the triggering action; documented under per-event 'Decision Control' headings",
+          "mechanism": "PreToolUse hooks return hookSpecificOutput.permissionDecision (allow/deny/ask) with permissionDecisionReason; the flat decision/reason fields are deprecated for PreToolUse. Exit code 2 blocks with stderr fed back to Droid; non-zero non-2 shows stderr to user as non-blocking error",
           "supported": true
         }
       },
@@ -540,6 +644,9 @@
         }
       },
       "supported": true
+    },
+    "opencode": {
+      "supported": false
     },
     "pi": {
       "capabilities": {

--- a/docs/provider-capabilities/by-content-type/mcp.json
+++ b/docs/provider-capabilities/by-content-type/mcp.json
@@ -399,6 +399,66 @@
       },
       "supported": true
     },
+    "opencode": {
+      "capabilities": {
+        "enterprise_management": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether the provider supports organization-level MCP configuration management, including managed server lists, allowlists, and enterprise registries.\n",
+            "spec_ref": "ACIF-MCP §9.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "bool"
+          },
+          "key_path": "mcp.enterprise_management",
+          "mechanism": "organizations publish default MCP server configs via a .well-known/opencode endpoint; local opencode.json values override remote defaults (documented under 'Enable' / 'Overriding remote defaults')",
+          "supported": true
+        },
+        "env_var_expansion": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether MCP server configuration supports environment variable expansion. Reduces the need for hardcoded secrets in config files.\n",
+            "spec_ref": "ACIF-MCP §9.1 (DERIVABLE; pinned closed field set)",
+            "type": "bool"
+          },
+          "key_path": "mcp.env_var_expansion",
+          "mechanism": "{env:VAR_NAME} interpolation in remote server headers and oauth fields; local servers take an environment object of key-value pairs",
+          "supported": true
+        },
+        "oauth_support": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether the provider supports OAuth 2.0 authentication for remote MCP servers, including token storage and automatic refresh.\n",
+            "spec_ref": "ACIF-MCP §9.1 (DERIVABLE)",
+            "type": "bool"
+          },
+          "key_path": "mcp.oauth_support",
+          "mechanism": "OAuth 2.0 with Dynamic Client Registration (RFC 7591): 401 auto-detected, tokens stored in ~/.local/share/opencode/mcp-auth.json; oauth object for pre-registered credentials or oauth: false to disable (documented under 'OAuth' / 'Authenticating' / 'OAuth Options')",
+          "supported": true
+        },
+        "tool_filtering": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Which per-server tool filtering mechanisms the provider supports. Contents: {allowlist: bool, blocklist: bool, disable_flag: bool}. Controls which server tools are exposed to the agent. Boundary: tool_filtering governs tool visibility (what appears in the agent's available tool set); see auto_approve for execution gating of visible tools.\n",
+            "spec_ref": "ACIF-MCP §9.1 (DERIVABLE)",
+            "type": "object"
+          },
+          "key_path": "mcp.tool_filtering",
+          "mechanism": "global tools map keyed by server-name prefix with glob patterns (e.g. mymcp_*); per-agent access via the agent permission map (documented under 'Manage' / 'Global' / 'Per agent' / 'Glob patterns')",
+          "supported": true
+        },
+        "transport_types": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Which MCP transport protocols the provider supports. Common transports: stdio (local process), SSE (Server-Sent Events), HTTP/streamable-HTTP (stateless or streaming).\n",
+            "spec_ref": "ACIF-MCP §9.1 (DERIVABLE); transport enum ACIF-MCP §6.2, §7",
+            "type": "object"
+          },
+          "key_path": "mcp.transport_types",
+          "mechanism": "two types under the mcp key in opencode.json: local (stdio, launched via command array) and remote (HTTP/SSE streamable, connected via url) (documented under 'Local' / 'Remote' headings)",
+          "supported": true
+        }
+      },
+      "supported": true
+    },
     "windsurf": {
       "capabilities": {
         "enterprise_management": {

--- a/docs/provider-capabilities/by-content-type/rules.json
+++ b/docs/provider-capabilities/by-content-type/rules.json
@@ -427,7 +427,7 @@
             },
             "glob": {
               "confidence": "inferred",
-              "mechanism": "glob-based path matching activates steering files (documented under 'Conditional inclusion' inclusion mode)",
+              "mechanism": "glob-based path matching via inclusion: fileMatch with a fileMatchPattern glob field (single pattern or array) activates steering files (documented under 'Conditional inclusion' inclusion mode)",
               "supported": true
             },
             "manual": {
@@ -473,7 +473,7 @@
             "type": "bool"
           },
           "key_path": "rules.file_imports",
-          "mechanism": "steering files can reference other files (documented under 'File references' heading)",
+          "mechanism": "steering files can reference other files via '#[[file:<relative>]]' syntax (documented under 'File references' heading)",
           "supported": true
         },
         "hierarchical_loading": {
@@ -485,6 +485,76 @@
           },
           "key_path": "rules.hierarchical_loading",
           "mechanism": "three-tier scope: workspace + global + team steering (documented under 'Workspace steering' / 'Global steering' / 'Team steering')",
+          "supported": true
+        }
+      },
+      "supported": true
+    },
+    "opencode": {
+      "capabilities": {
+        "activation_mode": {
+          "confidence": "inferred",
+          "key": {
+            "description": "How rules decide when to load into context. Providers implement varying modes: always-on, conditional/glob-based, model-decision, and manual activation. Tracks which modes the provider supports and how they are configured.\n",
+            "spec_ref": "ACIF-RULE §9.1 (DERIVABLE); activation-mode vocabulary ACIF-RULE Appendix A, §10",
+            "type": "object"
+          },
+          "key_path": "rules.activation_mode",
+          "mechanism": "rule files load unconditionally as context; no conditional activation syntax documented",
+          "supported": false
+        },
+        "auto_memory": {
+          "confidence": "inferred",
+          "key": {
+            "description": "Whether the provider auto-generates persistent rules from conversation context. Distinct from user-authored rules — these are AI-created and stored separately.\n",
+            "spec_ref": "ACIF-RULE §9.2 (OUT-OF-SCOPE-AT-L1; provider_capability_coverage, ACIF-REGISTRY §8.4)",
+            "type": "bool"
+          },
+          "key_path": "rules.auto_memory",
+          "mechanism": "no runtime command documented for persisting notes into rule files",
+          "supported": false
+        },
+        "cross_provider_recognition": {
+          "capabilities": {
+            "agents_md": {
+              "confidence": "confirmed",
+              "mechanism": "AGENTS.md read from project root and parent directories; global at ~/.config/opencode/AGENTS.md (documented under 'Types' / 'Project' / 'Global' headings)",
+              "supported": true
+            },
+            "claude_md": {
+              "confidence": "confirmed",
+              "mechanism": "CLAUDE.md fallback at project root and ~/.claude/CLAUDE.md globally when no AGENTS.md exists; disable via OPENCODE_DISABLE_CLAUDE_CODE=1 (documented under 'Claude Code Compatibility')",
+              "supported": true
+            }
+          },
+          "key": {
+            "description": "Which rule file formats from other providers this provider recognizes. Contents: recognized_formats (list of filenames like AGENTS.md, .cursorrules, .windsurfrules). Minimum qualification: supported when the provider reads at least one rule-file format defined by a different provider.\n",
+            "spec_ref": "ACIF-RULE §9.2 (OUT-OF-SCOPE-AT-L1; provider_capability_coverage, ACIF-REGISTRY §8.4)",
+            "type": "object"
+          },
+          "key_path": "rules.cross_provider_recognition",
+          "supported": true
+        },
+        "file_imports": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether rules can reference or include content from other files. Mechanisms vary: @-import syntax, @file.md directives, @path/to/file references.\n",
+            "spec_ref": "ACIF-RULE §9.2 (OUT-OF-SCOPE-AT-L1; strongest requires candidate — see ACIF ROADMAP, body-content reference grammar)",
+            "type": "bool"
+          },
+          "key_path": "rules.file_imports",
+          "mechanism": "instructions array in opencode.json (or the global ~/.config/opencode/opencode.json) lists additional rule files by relative path, glob pattern, or remote URL — all combined with AGENTS.md into context (documented under 'Referencing External Files' / 'Using opencode.json')",
+          "supported": true
+        },
+        "hierarchical_loading": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether rules load from multiple directory levels with defined precedence. Enables project-root rules plus subdirectory-scoped overrides.\n",
+            "spec_ref": "ACIF-RULE §9.2 (OUT-OF-SCOPE-AT-L1; provider_capability_coverage, ACIF-REGISTRY §8.4)",
+            "type": "bool"
+          },
+          "key_path": "rules.hierarchical_loading",
+          "mechanism": "AGENTS.md (CLAUDE.md fallback) collected walking up from cwd; global ~/.config/opencode/AGENTS.md and ~/.claude/CLAUDE.md appended; all matching files combined (documented under 'Types' / 'Precedence')",
           "supported": true
         }
       },
@@ -558,7 +628,7 @@
             "type": "bool"
           },
           "key_path": "rules.hierarchical_loading",
-          "mechanism": ".windsurf/rules scanned in current workspace, sub-directories, and parent dirs up to git root (documented under 'Rules Discovery' / 'Rules Storage Locations')",
+          "mechanism": ".devin/rules/ (preferred; .windsurf/rules/ legacy fallback) scanned in current workspace, sub-directories, and parent dirs up to git root (documented under 'Rules Discovery' / 'Rules Storage Locations')",
           "supported": true
         }
       },

--- a/docs/provider-capabilities/by-content-type/skills.json
+++ b/docs/provider-capabilities/by-content-type/skills.json
@@ -442,6 +442,99 @@
       },
       "supported": true
     },
+    "opencode": {
+      "capabilities": {
+        "canonical_filename": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "The required or conventional filename for this skill type. For example, \"SKILL.md\" for Claude Code skills.\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1; discovery ACIF-SKILL §9)",
+            "type": "string"
+          },
+          "key_path": "skills.canonical_filename",
+          "mechanism": "fixed filename SKILL.md inside the skill directory (Agent Skills spec)",
+          "supported": true
+        },
+        "compatibility": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Provider compatibility constraints — which AI tool versions or providers this skill is compatible with.\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "object"
+          },
+          "key_path": "skills.compatibility",
+          "mechanism": "yaml frontmatter key: compatibility (optional)",
+          "supported": true
+        },
+        "description": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "What the skill does. Used by the AI to decide when to auto-invoke it. Also shown in skill listings and help text.\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "string"
+          },
+          "key_path": "skills.description",
+          "mechanism": "yaml frontmatter key: description (required)",
+          "supported": true
+        },
+        "display_name": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Human-readable display name for the skill. If omitted, the directory name is used. Shown in skill listings and menus.\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "string"
+          },
+          "key_path": "skills.display_name",
+          "mechanism": "yaml frontmatter key: name (required)",
+          "supported": true
+        },
+        "global_scope": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether the skill can be installed at global/personal scope (applies across all projects for the current user).\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1; install_scope_capabilities, ACIF-REGISTRY)",
+            "type": "bool"
+          },
+          "key_path": "skills.global_scope",
+          "mechanism": "cross-provider convention at ~/.config/opencode/skills/<name>/SKILL.md",
+          "supported": true
+        },
+        "license": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "SPDX license identifier for the skill content. Typically \"MIT\", \"Apache-2.0\", etc.\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "string"
+          },
+          "key_path": "skills.license",
+          "mechanism": "yaml frontmatter key: license (optional)",
+          "supported": true
+        },
+        "metadata_map": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Arbitrary key-value metadata attached to the skill. Provider-specific semantics; often used for tooling or automation metadata.\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "object"
+          },
+          "key_path": "skills.metadata_map",
+          "mechanism": "yaml frontmatter key: metadata (optional map)",
+          "supported": true
+        },
+        "project_scope": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether the skill can be installed at project scope (applies to current project only, typically committed to version control).\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1; install_scope_capabilities, ACIF-REGISTRY)",
+            "type": "bool"
+          },
+          "key_path": "skills.project_scope",
+          "mechanism": "cross-provider SKILL.md convention at .opencode/skill/<name>/SKILL.md",
+          "supported": true
+        }
+      },
+      "supported": true
+    },
     "pi": {
       "capabilities": {
         "canonical_filename": {

--- a/docs/provider-capabilities/capabilities/all.json
+++ b/docs/provider-capabilities/capabilities/all.json
@@ -1481,6 +1481,110 @@
     },
     "crush": {
       "content_types": {
+        "hooks": {
+          "capabilities": {
+            "async_execution": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether hooks can run asynchronously without blocking the agent's execution loop. Fire-and-forget semantics.\n",
+                "spec_ref": "ACIF-HOOK §10.1 (DERIVABLE)",
+                "type": "bool"
+              },
+              "key_path": "hooks.async_execution",
+              "mechanism": "Matching hooks run in parallel with each other, but the tool call waits for all of them to finish (or time out) before proceeding — there is no fire-and-forget mode. A hook that exceeds its timeout is treated as a non-blocking error (\"no opinion\") and the tool call proceeds.",
+              "supported": false
+            },
+            "context_injection": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether hooks can inject messages, system prompts, or conversation context into the agent's active session.\n",
+                "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+                "type": "bool"
+              },
+              "key_path": "hooks.context_injection",
+              "mechanism": "The output envelope's context field accepts a string or an array of strings, appended to what the model sees for the current turn. Across multiple hooks, context values concatenate in config order; empty entries are dropped.",
+              "supported": true
+            },
+            "decision_control": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Which decision actions hooks can take on the triggering action. Contents: {block: bool, allow: bool, modify: bool}. Mechanisms include exit code contracts, JSON decision fields, or cancel flags. Boundary: decision_control governs whether a tool invocation proceeds; see permission_control for whether a tool is available at all.\n",
+                "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+                "type": "object"
+              },
+              "key_path": "hooks.decision_control",
+              "mechanism": "Exit code 2 blocks the tool call (stderr becomes the deny reason); exit 49 halts the whole turn; other non-zero exit codes are non-blocking errors and the tool call proceeds. On exit 0, stdout is parsed as a JSON envelope whose decision field may be allow, deny, or null. allow is affirmative pre-approval (skips the permission prompt); null/omitted means no opinion. Across multiple hooks, deny > allow > null, composed in config order.",
+              "supported": true
+            },
+            "handler_types": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "What kinds of executors hooks support beyond shell commands. May include HTTP endpoints, LLM prompt evaluation, multi-turn agent handlers, or TypeScript extensions.\n",
+                "spec_ref": "ACIF-HOOK §10.1 (DERIVABLE); handler-type enum ACIF-HOOK Appendix B, §8.2",
+                "type": "object"
+              },
+              "key_path": "hooks.handler_types",
+              "mechanism": "Crush hooks are shell commands only (command field in HookConfig) — no HTTP, LLM prompt, or agent handler types. Commands run through Crush's embedded POSIX shell (mvdan.cc/sh): inline commands and shebang-less scripts execute in-process; scripts with a #! shebang dispatch to the named interpreter via os/exec, so hook scripts can be written in any language. The contract is identical on macOS, Linux, and Windows.",
+              "supported": false
+            },
+            "hook_scopes": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Where hooks can be configured and the precedence model when multiple scopes define hooks for the same event. Common scopes: global/user, project, workspace, managed/enterprise.\n",
+                "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; install-location-determined)",
+                "type": "object"
+              },
+              "key_path": "hooks.hook_scopes",
+              "mechanism": "Hooks can be configured in crush.json (or .crush.json) at both the user-global (~/.config/crush/crush.json) and project level, with project-level hooks taking precedence. Global-config commands must use absolute paths or inline commands; relative paths resolve against the working directory.",
+              "supported": true
+            },
+            "input_modification": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether hooks can modify tool input arguments before the tool executes. Safety-critical capability — silent degradation creates false security. Minimum qualification: supported when the provider provides any mechanism to modify tool input arguments before execution (e.g., hookSpecificOutput.updatedInput, plugin-mutable args, or equivalent).\n",
+                "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+                "type": "bool"
+              },
+              "key_path": "hooks.input_modification",
+              "mechanism": "The exit-0 JSON envelope may include updated_input: a shallow-merge patch against tool_input. Included keys overwrite matching keys; omitted keys are preserved; nested objects are replaced wholesale. Patches from multiple hooks shallow-merge sequentially in config order (later hooks win on colliding keys) and are ignored if the final decision is deny or halt. Implemented as UpdatedInput in internal/hooks/hooks.go.",
+              "supported": true
+            },
+            "json_io_protocol": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether hooks communicate with the host via structured JSON on stdin/stdout rather than plain text or exit codes alone.\n",
+                "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+                "type": "bool"
+              },
+              "key_path": "hooks.json_io_protocol",
+              "mechanism": "Stdin provides a JSON payload: event, session_id, cwd, plus tool_name and tool_input (the raw JSON the model sent) for PreToolUse. On exit 0 stdout is parsed as a JSON output envelope: version (defaults to 1), decision, halt, reason, context, updated_input. Simple hooks can skip JSON entirely and use CRUSH_* environment variables plus exit codes.",
+              "supported": true
+            },
+            "matcher_patterns": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether hooks can filter which tools or events they respond to using name matching, regex patterns, or structured criteria.\n",
+                "spec_ref": "ACIF-HOOK §10.1 (DERIVABLE)",
+                "type": "bool"
+              },
+              "key_path": "hooks.matcher_patterns",
+              "mechanism": "HookConfig has an optional matcher field: a regex tested against the tool name (e.g. bash, edit, mcp_github_create_pull_request). Omitted or empty matcher matches all tools.",
+              "supported": true
+            },
+            "permission_control": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether hooks can make or influence permission decisions determining whether a tool is available for invocation. Minimum qualification: supported when the provider allows hooks to return permission decisions of any kind (grant, deny, or ask). Boundary: permission_control governs whether a tool is available; see decision_control for invocation-flow control.\n",
+                "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+                "type": "bool"
+              },
+              "key_path": "hooks.permission_control",
+              "mechanism": "Hook results apply before permission checks. An aggregated deny blocks the tool call before any permission prompt; an aggregated allow is affirmative pre-approval that skips the prompt entirely; silence (no decision) falls through to the normal permission flow.",
+              "supported": true
+            }
+          },
+          "supported": true
+        },
         "skills": {
           "capabilities": {
             "canonical_filename": {
@@ -2027,14 +2131,14 @@
         "hooks": {
           "capabilities": {
             "decision_control": {
-              "confidence": "inferred",
+              "confidence": "confirmed",
               "key": {
                 "description": "Which decision actions hooks can take on the triggering action. Contents: {block: bool, allow: bool, modify: bool}. Mechanisms include exit code contracts, JSON decision fields, or cancel flags. Boundary: decision_control governs whether a tool invocation proceeds; see permission_control for whether a tool is available at all.\n",
                 "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
                 "type": "object"
               },
               "key_path": "hooks.decision_control",
-              "mechanism": "hook_exit_code_behavior: Factory Droid hooks use exit codes to signal block (non-zero) or allow (zero) decisions on the triggering action; documented under per-event 'Decision Control' headings",
+              "mechanism": "PreToolUse hooks return hookSpecificOutput.permissionDecision (allow/deny/ask) with permissionDecisionReason; the flat decision/reason fields are deprecated for PreToolUse. Exit code 2 blocks with stderr fed back to Droid; non-zero non-2 shows stderr to user as non-blocking error",
               "supported": true
             }
           },
@@ -2423,12 +2527,12 @@
               "capabilities": {
                 "project": {
                   "confidence": "inferred",
-                  "mechanism": "project-scoped agents stored under .kiro/agents/ documented under 'Local agents (project-specific)' heading; precedence rules under 'Agent precedence'",
+                  "mechanism": "project-scoped agents stored under .kiro/agents/ documented under 'Local agents (project-specific)' heading; local (project) agent takes precedence over global on name collision (with a warning), per 'Agent precedence'",
                   "supported": true
                 },
                 "user": {
                   "confidence": "inferred",
-                  "mechanism": "user-scoped agents stored under ~/.kiro/agents/ documented under 'Global agents (user-wide)' heading; precedence rules under 'Agent precedence'",
+                  "mechanism": "user-scoped agents stored under ~/.kiro/agents/ documented under 'Global agents (user-wide)' heading; global agent is the fallback when no local agent of the same name exists, per 'Agent precedence'",
                   "supported": true
                 }
               },
@@ -2574,7 +2678,7 @@
                 },
                 "glob": {
                   "confidence": "inferred",
-                  "mechanism": "glob-based path matching activates steering files (documented under 'Conditional inclusion' inclusion mode)",
+                  "mechanism": "glob-based path matching via inclusion: fileMatch with a fileMatchPattern glob field (single pattern or array) activates steering files (documented under 'Conditional inclusion' inclusion mode)",
                   "supported": true
                 },
                 "manual": {
@@ -2620,7 +2724,7 @@
                 "type": "bool"
               },
               "key_path": "rules.file_imports",
-              "mechanism": "steering files can reference other files (documented under 'File references' heading)",
+              "mechanism": "steering files can reference other files via '#[[file:<relative>]]' syntax (documented under 'File references' heading)",
               "supported": true
             },
             "hierarchical_loading": {
@@ -2709,8 +2813,355 @@
       "status": "live"
     },
     "opencode": {
-      "display_name": "OpenCode",
-      "provider_status": "archived",
+      "content_types": {
+        "agents": {
+          "capabilities": {
+            "agent_scopes": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Where agent definitions can live and the priority ordering when definitions exist at multiple levels. Common scopes: project, user/personal, managed/enterprise, CLI-defined.\n",
+                "spec_ref": "ACIF-AGENT §9.2 (OUT-OF-SCOPE-AT-L1; install_scope_capabilities, ACIF-REGISTRY)",
+                "type": "object"
+              },
+              "key_path": "agents.agent_scopes",
+              "mechanism": "two scopes, both loaded and coexisting: project (.opencode/agents/ or .opencode/agent/) and user-global (~/.config/opencode/agents/)",
+              "supported": true
+            },
+            "definition_format": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "What format agent definitions use. Varies widely: Markdown with YAML frontmatter, JSON config files, TOML sections, or AGENTS.md plain markdown.\n",
+                "spec_ref": "ACIF-AGENT §9.2 (OUT-OF-SCOPE-AT-L1)",
+                "type": "string"
+              },
+              "key_path": "agents.definition_format",
+              "mechanism": "markdown with YAML frontmatter in .opencode/agents/*.md (project) and ~/.config/opencode/agents/*.md (global); the loader accepts both agent/ and agents/ directory names and recurses; frontmatter declares description/mode/model/temperature/top_p/steps/permission/color/hidden/disable/variant/prompt and the body becomes the system prompt; agents can also be defined inline in opencode.json under the agent key (documented under 'Configure' / 'Markdown' / 'Create agents')",
+              "supported": true
+            },
+            "invocation_patterns": {
+              "capabilities": {
+                "at_mention": {
+                  "confidence": "confirmed",
+                  "mechanism": "subagents invoked manually by @-mentioning the subagent name in a message; agent name derives from the filename (documented under 'Subagents')",
+                  "supported": true
+                },
+                "natural_language": {
+                  "confidence": "confirmed",
+                  "mechanism": "subagents invoked automatically by primary agents for specialized tasks based on their description field (documented under 'Subagents')",
+                  "supported": true
+                }
+              },
+              "key": {
+                "description": "How agents are triggered. Mechanisms include natural language detection, @-mention syntax, slash commands, CLI flags, or automatic delegation.\n",
+                "spec_ref": "ACIF-AGENT §9.2 (OUT-OF-SCOPE-AT-L1)",
+                "type": "object"
+              },
+              "key_path": "agents.invocation_patterns",
+              "supported": true
+            },
+            "model_selection": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether per-agent model overrides are supported, allowing different agents to use different AI models.\n",
+                "spec_ref": "ACIF-AGENT §9.1 (DERIVABLE)",
+                "type": "bool"
+              },
+              "key_path": "agents.model_selection",
+              "mechanism": "frontmatter model field (provider/model-id format) overrides the session default; subagents default to the invoking primary agent's model (documented under 'Model')",
+              "supported": true
+            },
+            "per_agent_mcp": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether agents can have their own MCP server configuration, scoping which external tools each agent can access.\n",
+                "spec_ref": "ACIF-AGENT §9.1 (DERIVABLE)",
+                "type": "bool"
+              },
+              "key_path": "agents.per_agent_mcp",
+              "mechanism": "no per-agent mcpServers field documented; agents inherit the workspace MCP configuration, with per-agent access gated via the permission map",
+              "supported": false
+            },
+            "subagent_spawning": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether agents can spawn, delegate to, or resume other agents. Enables multi-agent coordination patterns.\n",
+                "spec_ref": "ACIF-AGENT §9.1 (DERIVABLE; canonical spawn tool name, ACIF-CORE Appendix A)",
+                "type": "bool"
+              },
+              "key_path": "agents.subagent_spawning",
+              "mechanism": "agents with mode: subagent (or all) are invocable from other agents via the Task tool, driven by the callee's description; permission.task on the orchestrator controls which subagents it may invoke (documented under 'Task permissions')",
+              "supported": true
+            },
+            "tool_restrictions": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether agents can be restricted to specific tools via allowlists, denylists, tool categories, or per-tool configuration maps.\n",
+                "spec_ref": "ACIF-AGENT §9.1 (DERIVABLE); tool vocabulary ACIF-CORE Appendix A",
+                "type": "bool"
+              },
+              "key_path": "agents.tool_restrictions",
+              "mechanism": "permission frontmatter map configures ask/allow/deny per tool using named keys or wildcard glob patterns; fine-grained keys accept glob/pattern-to-action objects (documented under 'Permissions')",
+              "supported": true
+            }
+          },
+          "supported": true
+        },
+        "commands": {
+          "capabilities": {
+            "argument_substitution": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "How user-provided arguments are injected into command templates. Mechanisms vary: $ARGUMENTS, {{args}}, positional $1/$2/${@:N}, and other interpolation syntaxes.\n",
+                "spec_ref": "ACIF-COMMAND §9.1 (OUT-OF-SCOPE-AT-L1; placeholder vocabulary ACIF-COMMAND Appendix A, §7)",
+                "type": "object"
+              },
+              "key_path": "commands.argument_substitution",
+              "mechanism": "$ARGUMENTS carries all arguments as a single string; positional $1/$2/$3 carry individual arguments — substituted from user input at invocation time (documented under 'Arguments')",
+              "supported": true
+            },
+            "builtin_commands": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether the provider ships default/built-in commands alongside user-defined custom commands.\n",
+                "spec_ref": "ACIF-COMMAND §9.2 (OUT-OF-SCOPE-AT-L1; provider_capability_coverage row)",
+                "type": "bool"
+              },
+              "key_path": "commands.builtin_commands",
+              "mechanism": "built-in /init, /undo, /redo, /share, /help; custom commands override built-ins when given the same name (documented under 'Built-in')",
+              "supported": true
+            }
+          },
+          "supported": true
+        },
+        "hooks": {
+          "supported": false
+        },
+        "mcp": {
+          "capabilities": {
+            "enterprise_management": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether the provider supports organization-level MCP configuration management, including managed server lists, allowlists, and enterprise registries.\n",
+                "spec_ref": "ACIF-MCP §9.2 (OUT-OF-SCOPE-AT-L1)",
+                "type": "bool"
+              },
+              "key_path": "mcp.enterprise_management",
+              "mechanism": "organizations publish default MCP server configs via a .well-known/opencode endpoint; local opencode.json values override remote defaults (documented under 'Enable' / 'Overriding remote defaults')",
+              "supported": true
+            },
+            "env_var_expansion": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether MCP server configuration supports environment variable expansion. Reduces the need for hardcoded secrets in config files.\n",
+                "spec_ref": "ACIF-MCP §9.1 (DERIVABLE; pinned closed field set)",
+                "type": "bool"
+              },
+              "key_path": "mcp.env_var_expansion",
+              "mechanism": "{env:VAR_NAME} interpolation in remote server headers and oauth fields; local servers take an environment object of key-value pairs",
+              "supported": true
+            },
+            "oauth_support": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether the provider supports OAuth 2.0 authentication for remote MCP servers, including token storage and automatic refresh.\n",
+                "spec_ref": "ACIF-MCP §9.1 (DERIVABLE)",
+                "type": "bool"
+              },
+              "key_path": "mcp.oauth_support",
+              "mechanism": "OAuth 2.0 with Dynamic Client Registration (RFC 7591): 401 auto-detected, tokens stored in ~/.local/share/opencode/mcp-auth.json; oauth object for pre-registered credentials or oauth: false to disable (documented under 'OAuth' / 'Authenticating' / 'OAuth Options')",
+              "supported": true
+            },
+            "tool_filtering": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Which per-server tool filtering mechanisms the provider supports. Contents: {allowlist: bool, blocklist: bool, disable_flag: bool}. Controls which server tools are exposed to the agent. Boundary: tool_filtering governs tool visibility (what appears in the agent's available tool set); see auto_approve for execution gating of visible tools.\n",
+                "spec_ref": "ACIF-MCP §9.1 (DERIVABLE)",
+                "type": "object"
+              },
+              "key_path": "mcp.tool_filtering",
+              "mechanism": "global tools map keyed by server-name prefix with glob patterns (e.g. mymcp_*); per-agent access via the agent permission map (documented under 'Manage' / 'Global' / 'Per agent' / 'Glob patterns')",
+              "supported": true
+            },
+            "transport_types": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Which MCP transport protocols the provider supports. Common transports: stdio (local process), SSE (Server-Sent Events), HTTP/streamable-HTTP (stateless or streaming).\n",
+                "spec_ref": "ACIF-MCP §9.1 (DERIVABLE); transport enum ACIF-MCP §6.2, §7",
+                "type": "object"
+              },
+              "key_path": "mcp.transport_types",
+              "mechanism": "two types under the mcp key in opencode.json: local (stdio, launched via command array) and remote (HTTP/SSE streamable, connected via url) (documented under 'Local' / 'Remote' headings)",
+              "supported": true
+            }
+          },
+          "supported": true
+        },
+        "rules": {
+          "capabilities": {
+            "activation_mode": {
+              "confidence": "inferred",
+              "key": {
+                "description": "How rules decide when to load into context. Providers implement varying modes: always-on, conditional/glob-based, model-decision, and manual activation. Tracks which modes the provider supports and how they are configured.\n",
+                "spec_ref": "ACIF-RULE §9.1 (DERIVABLE); activation-mode vocabulary ACIF-RULE Appendix A, §10",
+                "type": "object"
+              },
+              "key_path": "rules.activation_mode",
+              "mechanism": "rule files load unconditionally as context; no conditional activation syntax documented",
+              "supported": false
+            },
+            "auto_memory": {
+              "confidence": "inferred",
+              "key": {
+                "description": "Whether the provider auto-generates persistent rules from conversation context. Distinct from user-authored rules — these are AI-created and stored separately.\n",
+                "spec_ref": "ACIF-RULE §9.2 (OUT-OF-SCOPE-AT-L1; provider_capability_coverage, ACIF-REGISTRY §8.4)",
+                "type": "bool"
+              },
+              "key_path": "rules.auto_memory",
+              "mechanism": "no runtime command documented for persisting notes into rule files",
+              "supported": false
+            },
+            "cross_provider_recognition": {
+              "capabilities": {
+                "agents_md": {
+                  "confidence": "confirmed",
+                  "mechanism": "AGENTS.md read from project root and parent directories; global at ~/.config/opencode/AGENTS.md (documented under 'Types' / 'Project' / 'Global' headings)",
+                  "supported": true
+                },
+                "claude_md": {
+                  "confidence": "confirmed",
+                  "mechanism": "CLAUDE.md fallback at project root and ~/.claude/CLAUDE.md globally when no AGENTS.md exists; disable via OPENCODE_DISABLE_CLAUDE_CODE=1 (documented under 'Claude Code Compatibility')",
+                  "supported": true
+                }
+              },
+              "key": {
+                "description": "Which rule file formats from other providers this provider recognizes. Contents: recognized_formats (list of filenames like AGENTS.md, .cursorrules, .windsurfrules). Minimum qualification: supported when the provider reads at least one rule-file format defined by a different provider.\n",
+                "spec_ref": "ACIF-RULE §9.2 (OUT-OF-SCOPE-AT-L1; provider_capability_coverage, ACIF-REGISTRY §8.4)",
+                "type": "object"
+              },
+              "key_path": "rules.cross_provider_recognition",
+              "supported": true
+            },
+            "file_imports": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether rules can reference or include content from other files. Mechanisms vary: @-import syntax, @file.md directives, @path/to/file references.\n",
+                "spec_ref": "ACIF-RULE §9.2 (OUT-OF-SCOPE-AT-L1; strongest requires candidate — see ACIF ROADMAP, body-content reference grammar)",
+                "type": "bool"
+              },
+              "key_path": "rules.file_imports",
+              "mechanism": "instructions array in opencode.json (or the global ~/.config/opencode/opencode.json) lists additional rule files by relative path, glob pattern, or remote URL — all combined with AGENTS.md into context (documented under 'Referencing External Files' / 'Using opencode.json')",
+              "supported": true
+            },
+            "hierarchical_loading": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether rules load from multiple directory levels with defined precedence. Enables project-root rules plus subdirectory-scoped overrides.\n",
+                "spec_ref": "ACIF-RULE §9.2 (OUT-OF-SCOPE-AT-L1; provider_capability_coverage, ACIF-REGISTRY §8.4)",
+                "type": "bool"
+              },
+              "key_path": "rules.hierarchical_loading",
+              "mechanism": "AGENTS.md (CLAUDE.md fallback) collected walking up from cwd; global ~/.config/opencode/AGENTS.md and ~/.claude/CLAUDE.md appended; all matching files combined (documented under 'Types' / 'Precedence')",
+              "supported": true
+            }
+          },
+          "supported": true
+        },
+        "skills": {
+          "capabilities": {
+            "canonical_filename": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "The required or conventional filename for this skill type. For example, \"SKILL.md\" for Claude Code skills.\n",
+                "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1; discovery ACIF-SKILL §9)",
+                "type": "string"
+              },
+              "key_path": "skills.canonical_filename",
+              "mechanism": "fixed filename SKILL.md inside the skill directory (Agent Skills spec)",
+              "supported": true
+            },
+            "compatibility": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Provider compatibility constraints — which AI tool versions or providers this skill is compatible with.\n",
+                "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+                "type": "object"
+              },
+              "key_path": "skills.compatibility",
+              "mechanism": "yaml frontmatter key: compatibility (optional)",
+              "supported": true
+            },
+            "description": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "What the skill does. Used by the AI to decide when to auto-invoke it. Also shown in skill listings and help text.\n",
+                "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+                "type": "string"
+              },
+              "key_path": "skills.description",
+              "mechanism": "yaml frontmatter key: description (required)",
+              "supported": true
+            },
+            "display_name": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Human-readable display name for the skill. If omitted, the directory name is used. Shown in skill listings and menus.\n",
+                "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+                "type": "string"
+              },
+              "key_path": "skills.display_name",
+              "mechanism": "yaml frontmatter key: name (required)",
+              "supported": true
+            },
+            "global_scope": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether the skill can be installed at global/personal scope (applies across all projects for the current user).\n",
+                "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1; install_scope_capabilities, ACIF-REGISTRY)",
+                "type": "bool"
+              },
+              "key_path": "skills.global_scope",
+              "mechanism": "cross-provider convention at ~/.config/opencode/skills/<name>/SKILL.md",
+              "supported": true
+            },
+            "license": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "SPDX license identifier for the skill content. Typically \"MIT\", \"Apache-2.0\", etc.\n",
+                "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+                "type": "string"
+              },
+              "key_path": "skills.license",
+              "mechanism": "yaml frontmatter key: license (optional)",
+              "supported": true
+            },
+            "metadata_map": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Arbitrary key-value metadata attached to the skill. Provider-specific semantics; often used for tooling or automation metadata.\n",
+                "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+                "type": "object"
+              },
+              "key_path": "skills.metadata_map",
+              "mechanism": "yaml frontmatter key: metadata (optional map)",
+              "supported": true
+            },
+            "project_scope": {
+              "confidence": "confirmed",
+              "key": {
+                "description": "Whether the skill can be installed at project scope (applies to current project only, typically committed to version control).\n",
+                "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1; install_scope_capabilities, ACIF-REGISTRY)",
+                "type": "bool"
+              },
+              "key_path": "skills.project_scope",
+              "mechanism": "cross-provider SKILL.md convention at .opencode/skill/<name>/SKILL.md",
+              "supported": true
+            }
+          },
+          "supported": true
+        }
+      },
+      "display_name": "opencode",
+      "provider_status": "active",
       "schema_version": "2",
       "slug": "opencode",
       "status": "live"
@@ -3181,14 +3632,14 @@
                 "type": "bool"
               },
               "key_path": "rules.hierarchical_loading",
-              "mechanism": ".windsurf/rules scanned in current workspace, sub-directories, and parent dirs up to git root (documented under 'Rules Discovery' / 'Rules Storage Locations')",
+              "mechanism": ".devin/rules/ (preferred; .windsurf/rules/ legacy fallback) scanned in current workspace, sub-directories, and parent dirs up to git root (documented under 'Rules Discovery' / 'Rules Storage Locations')",
               "supported": true
             }
           },
           "supported": true
         }
       },
-      "display_name": "Windsurf",
+      "display_name": "Devin Desktop",
       "provider_status": "active",
       "schema_version": "2",
       "slug": "windsurf",

--- a/docs/provider-capabilities/capabilities/crush.json
+++ b/docs/provider-capabilities/capabilities/crush.json
@@ -1,5 +1,109 @@
 {
   "content_types": {
+    "hooks": {
+      "capabilities": {
+        "async_execution": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether hooks can run asynchronously without blocking the agent's execution loop. Fire-and-forget semantics.\n",
+            "spec_ref": "ACIF-HOOK §10.1 (DERIVABLE)",
+            "type": "bool"
+          },
+          "key_path": "hooks.async_execution",
+          "mechanism": "Matching hooks run in parallel with each other, but the tool call waits for all of them to finish (or time out) before proceeding — there is no fire-and-forget mode. A hook that exceeds its timeout is treated as a non-blocking error (\"no opinion\") and the tool call proceeds.",
+          "supported": false
+        },
+        "context_injection": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether hooks can inject messages, system prompts, or conversation context into the agent's active session.\n",
+            "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+            "type": "bool"
+          },
+          "key_path": "hooks.context_injection",
+          "mechanism": "The output envelope's context field accepts a string or an array of strings, appended to what the model sees for the current turn. Across multiple hooks, context values concatenate in config order; empty entries are dropped.",
+          "supported": true
+        },
+        "decision_control": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Which decision actions hooks can take on the triggering action. Contents: {block: bool, allow: bool, modify: bool}. Mechanisms include exit code contracts, JSON decision fields, or cancel flags. Boundary: decision_control governs whether a tool invocation proceeds; see permission_control for whether a tool is available at all.\n",
+            "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+            "type": "object"
+          },
+          "key_path": "hooks.decision_control",
+          "mechanism": "Exit code 2 blocks the tool call (stderr becomes the deny reason); exit 49 halts the whole turn; other non-zero exit codes are non-blocking errors and the tool call proceeds. On exit 0, stdout is parsed as a JSON envelope whose decision field may be allow, deny, or null. allow is affirmative pre-approval (skips the permission prompt); null/omitted means no opinion. Across multiple hooks, deny > allow > null, composed in config order.",
+          "supported": true
+        },
+        "handler_types": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "What kinds of executors hooks support beyond shell commands. May include HTTP endpoints, LLM prompt evaluation, multi-turn agent handlers, or TypeScript extensions.\n",
+            "spec_ref": "ACIF-HOOK §10.1 (DERIVABLE); handler-type enum ACIF-HOOK Appendix B, §8.2",
+            "type": "object"
+          },
+          "key_path": "hooks.handler_types",
+          "mechanism": "Crush hooks are shell commands only (command field in HookConfig) — no HTTP, LLM prompt, or agent handler types. Commands run through Crush's embedded POSIX shell (mvdan.cc/sh): inline commands and shebang-less scripts execute in-process; scripts with a #! shebang dispatch to the named interpreter via os/exec, so hook scripts can be written in any language. The contract is identical on macOS, Linux, and Windows.",
+          "supported": false
+        },
+        "hook_scopes": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Where hooks can be configured and the precedence model when multiple scopes define hooks for the same event. Common scopes: global/user, project, workspace, managed/enterprise.\n",
+            "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; install-location-determined)",
+            "type": "object"
+          },
+          "key_path": "hooks.hook_scopes",
+          "mechanism": "Hooks can be configured in crush.json (or .crush.json) at both the user-global (~/.config/crush/crush.json) and project level, with project-level hooks taking precedence. Global-config commands must use absolute paths or inline commands; relative paths resolve against the working directory.",
+          "supported": true
+        },
+        "input_modification": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether hooks can modify tool input arguments before the tool executes. Safety-critical capability — silent degradation creates false security. Minimum qualification: supported when the provider provides any mechanism to modify tool input arguments before execution (e.g., hookSpecificOutput.updatedInput, plugin-mutable args, or equivalent).\n",
+            "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+            "type": "bool"
+          },
+          "key_path": "hooks.input_modification",
+          "mechanism": "The exit-0 JSON envelope may include updated_input: a shallow-merge patch against tool_input. Included keys overwrite matching keys; omitted keys are preserved; nested objects are replaced wholesale. Patches from multiple hooks shallow-merge sequentially in config order (later hooks win on colliding keys) and are ignored if the final decision is deny or halt. Implemented as UpdatedInput in internal/hooks/hooks.go.",
+          "supported": true
+        },
+        "json_io_protocol": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether hooks communicate with the host via structured JSON on stdin/stdout rather than plain text or exit codes alone.\n",
+            "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+            "type": "bool"
+          },
+          "key_path": "hooks.json_io_protocol",
+          "mechanism": "Stdin provides a JSON payload: event, session_id, cwd, plus tool_name and tool_input (the raw JSON the model sent) for PreToolUse. On exit 0 stdout is parsed as a JSON output envelope: version (defaults to 1), decision, halt, reason, context, updated_input. Simple hooks can skip JSON entirely and use CRUSH_* environment variables plus exit codes.",
+          "supported": true
+        },
+        "matcher_patterns": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether hooks can filter which tools or events they respond to using name matching, regex patterns, or structured criteria.\n",
+            "spec_ref": "ACIF-HOOK §10.1 (DERIVABLE)",
+            "type": "bool"
+          },
+          "key_path": "hooks.matcher_patterns",
+          "mechanism": "HookConfig has an optional matcher field: a regex tested against the tool name (e.g. bash, edit, mcp_github_create_pull_request). Omitted or empty matcher matches all tools.",
+          "supported": true
+        },
+        "permission_control": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether hooks can make or influence permission decisions determining whether a tool is available for invocation. Minimum qualification: supported when the provider allows hooks to return permission decisions of any kind (grant, deny, or ask). Boundary: permission_control governs whether a tool is available; see decision_control for invocation-flow control.\n",
+            "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
+            "type": "bool"
+          },
+          "key_path": "hooks.permission_control",
+          "mechanism": "Hook results apply before permission checks. An aggregated deny blocks the tool call before any permission prompt; an aggregated allow is affirmative pre-approval that skips the prompt entirely; silence (no decision) falls through to the normal permission flow.",
+          "supported": true
+        }
+      },
+      "supported": true
+    },
     "skills": {
       "capabilities": {
         "canonical_filename": {

--- a/docs/provider-capabilities/capabilities/factory-droid.json
+++ b/docs/provider-capabilities/capabilities/factory-droid.json
@@ -57,14 +57,14 @@
     "hooks": {
       "capabilities": {
         "decision_control": {
-          "confidence": "inferred",
+          "confidence": "confirmed",
           "key": {
             "description": "Which decision actions hooks can take on the triggering action. Contents: {block: bool, allow: bool, modify: bool}. Mechanisms include exit code contracts, JSON decision fields, or cancel flags. Boundary: decision_control governs whether a tool invocation proceeds; see permission_control for whether a tool is available at all.\n",
             "spec_ref": "ACIF-HOOK §10.2 (OUT-OF-SCOPE-AT-L1; script-body-opaque)",
             "type": "object"
           },
           "key_path": "hooks.decision_control",
-          "mechanism": "hook_exit_code_behavior: Factory Droid hooks use exit codes to signal block (non-zero) or allow (zero) decisions on the triggering action; documented under per-event 'Decision Control' headings",
+          "mechanism": "PreToolUse hooks return hookSpecificOutput.permissionDecision (allow/deny/ask) with permissionDecisionReason; the flat decision/reason fields are deprecated for PreToolUse. Exit code 2 blocks with stderr fed back to Droid; non-zero non-2 shows stderr to user as non-blocking error",
           "supported": true
         }
       },

--- a/docs/provider-capabilities/capabilities/kiro.json
+++ b/docs/provider-capabilities/capabilities/kiro.json
@@ -6,12 +6,12 @@
           "capabilities": {
             "project": {
               "confidence": "inferred",
-              "mechanism": "project-scoped agents stored under .kiro/agents/ documented under 'Local agents (project-specific)' heading; precedence rules under 'Agent precedence'",
+              "mechanism": "project-scoped agents stored under .kiro/agents/ documented under 'Local agents (project-specific)' heading; local (project) agent takes precedence over global on name collision (with a warning), per 'Agent precedence'",
               "supported": true
             },
             "user": {
               "confidence": "inferred",
-              "mechanism": "user-scoped agents stored under ~/.kiro/agents/ documented under 'Global agents (user-wide)' heading; precedence rules under 'Agent precedence'",
+              "mechanism": "user-scoped agents stored under ~/.kiro/agents/ documented under 'Global agents (user-wide)' heading; global agent is the fallback when no local agent of the same name exists, per 'Agent precedence'",
               "supported": true
             }
           },
@@ -157,7 +157,7 @@
             },
             "glob": {
               "confidence": "inferred",
-              "mechanism": "glob-based path matching activates steering files (documented under 'Conditional inclusion' inclusion mode)",
+              "mechanism": "glob-based path matching via inclusion: fileMatch with a fileMatchPattern glob field (single pattern or array) activates steering files (documented under 'Conditional inclusion' inclusion mode)",
               "supported": true
             },
             "manual": {
@@ -203,7 +203,7 @@
             "type": "bool"
           },
           "key_path": "rules.file_imports",
-          "mechanism": "steering files can reference other files (documented under 'File references' heading)",
+          "mechanism": "steering files can reference other files via '#[[file:<relative>]]' syntax (documented under 'File references' heading)",
           "supported": true
         },
         "hierarchical_loading": {

--- a/docs/provider-capabilities/capabilities/opencode.json
+++ b/docs/provider-capabilities/capabilities/opencode.json
@@ -1,6 +1,353 @@
 {
-  "display_name": "OpenCode",
-  "provider_status": "archived",
+  "content_types": {
+    "agents": {
+      "capabilities": {
+        "agent_scopes": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Where agent definitions can live and the priority ordering when definitions exist at multiple levels. Common scopes: project, user/personal, managed/enterprise, CLI-defined.\n",
+            "spec_ref": "ACIF-AGENT §9.2 (OUT-OF-SCOPE-AT-L1; install_scope_capabilities, ACIF-REGISTRY)",
+            "type": "object"
+          },
+          "key_path": "agents.agent_scopes",
+          "mechanism": "two scopes, both loaded and coexisting: project (.opencode/agents/ or .opencode/agent/) and user-global (~/.config/opencode/agents/)",
+          "supported": true
+        },
+        "definition_format": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "What format agent definitions use. Varies widely: Markdown with YAML frontmatter, JSON config files, TOML sections, or AGENTS.md plain markdown.\n",
+            "spec_ref": "ACIF-AGENT §9.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "string"
+          },
+          "key_path": "agents.definition_format",
+          "mechanism": "markdown with YAML frontmatter in .opencode/agents/*.md (project) and ~/.config/opencode/agents/*.md (global); the loader accepts both agent/ and agents/ directory names and recurses; frontmatter declares description/mode/model/temperature/top_p/steps/permission/color/hidden/disable/variant/prompt and the body becomes the system prompt; agents can also be defined inline in opencode.json under the agent key (documented under 'Configure' / 'Markdown' / 'Create agents')",
+          "supported": true
+        },
+        "invocation_patterns": {
+          "capabilities": {
+            "at_mention": {
+              "confidence": "confirmed",
+              "mechanism": "subagents invoked manually by @-mentioning the subagent name in a message; agent name derives from the filename (documented under 'Subagents')",
+              "supported": true
+            },
+            "natural_language": {
+              "confidence": "confirmed",
+              "mechanism": "subagents invoked automatically by primary agents for specialized tasks based on their description field (documented under 'Subagents')",
+              "supported": true
+            }
+          },
+          "key": {
+            "description": "How agents are triggered. Mechanisms include natural language detection, @-mention syntax, slash commands, CLI flags, or automatic delegation.\n",
+            "spec_ref": "ACIF-AGENT §9.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "object"
+          },
+          "key_path": "agents.invocation_patterns",
+          "supported": true
+        },
+        "model_selection": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether per-agent model overrides are supported, allowing different agents to use different AI models.\n",
+            "spec_ref": "ACIF-AGENT §9.1 (DERIVABLE)",
+            "type": "bool"
+          },
+          "key_path": "agents.model_selection",
+          "mechanism": "frontmatter model field (provider/model-id format) overrides the session default; subagents default to the invoking primary agent's model (documented under 'Model')",
+          "supported": true
+        },
+        "per_agent_mcp": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether agents can have their own MCP server configuration, scoping which external tools each agent can access.\n",
+            "spec_ref": "ACIF-AGENT §9.1 (DERIVABLE)",
+            "type": "bool"
+          },
+          "key_path": "agents.per_agent_mcp",
+          "mechanism": "no per-agent mcpServers field documented; agents inherit the workspace MCP configuration, with per-agent access gated via the permission map",
+          "supported": false
+        },
+        "subagent_spawning": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether agents can spawn, delegate to, or resume other agents. Enables multi-agent coordination patterns.\n",
+            "spec_ref": "ACIF-AGENT §9.1 (DERIVABLE; canonical spawn tool name, ACIF-CORE Appendix A)",
+            "type": "bool"
+          },
+          "key_path": "agents.subagent_spawning",
+          "mechanism": "agents with mode: subagent (or all) are invocable from other agents via the Task tool, driven by the callee's description; permission.task on the orchestrator controls which subagents it may invoke (documented under 'Task permissions')",
+          "supported": true
+        },
+        "tool_restrictions": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether agents can be restricted to specific tools via allowlists, denylists, tool categories, or per-tool configuration maps.\n",
+            "spec_ref": "ACIF-AGENT §9.1 (DERIVABLE); tool vocabulary ACIF-CORE Appendix A",
+            "type": "bool"
+          },
+          "key_path": "agents.tool_restrictions",
+          "mechanism": "permission frontmatter map configures ask/allow/deny per tool using named keys or wildcard glob patterns; fine-grained keys accept glob/pattern-to-action objects (documented under 'Permissions')",
+          "supported": true
+        }
+      },
+      "supported": true
+    },
+    "commands": {
+      "capabilities": {
+        "argument_substitution": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "How user-provided arguments are injected into command templates. Mechanisms vary: $ARGUMENTS, {{args}}, positional $1/$2/${@:N}, and other interpolation syntaxes.\n",
+            "spec_ref": "ACIF-COMMAND §9.1 (OUT-OF-SCOPE-AT-L1; placeholder vocabulary ACIF-COMMAND Appendix A, §7)",
+            "type": "object"
+          },
+          "key_path": "commands.argument_substitution",
+          "mechanism": "$ARGUMENTS carries all arguments as a single string; positional $1/$2/$3 carry individual arguments — substituted from user input at invocation time (documented under 'Arguments')",
+          "supported": true
+        },
+        "builtin_commands": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether the provider ships default/built-in commands alongside user-defined custom commands.\n",
+            "spec_ref": "ACIF-COMMAND §9.2 (OUT-OF-SCOPE-AT-L1; provider_capability_coverage row)",
+            "type": "bool"
+          },
+          "key_path": "commands.builtin_commands",
+          "mechanism": "built-in /init, /undo, /redo, /share, /help; custom commands override built-ins when given the same name (documented under 'Built-in')",
+          "supported": true
+        }
+      },
+      "supported": true
+    },
+    "hooks": {
+      "supported": false
+    },
+    "mcp": {
+      "capabilities": {
+        "enterprise_management": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether the provider supports organization-level MCP configuration management, including managed server lists, allowlists, and enterprise registries.\n",
+            "spec_ref": "ACIF-MCP §9.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "bool"
+          },
+          "key_path": "mcp.enterprise_management",
+          "mechanism": "organizations publish default MCP server configs via a .well-known/opencode endpoint; local opencode.json values override remote defaults (documented under 'Enable' / 'Overriding remote defaults')",
+          "supported": true
+        },
+        "env_var_expansion": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether MCP server configuration supports environment variable expansion. Reduces the need for hardcoded secrets in config files.\n",
+            "spec_ref": "ACIF-MCP §9.1 (DERIVABLE; pinned closed field set)",
+            "type": "bool"
+          },
+          "key_path": "mcp.env_var_expansion",
+          "mechanism": "{env:VAR_NAME} interpolation in remote server headers and oauth fields; local servers take an environment object of key-value pairs",
+          "supported": true
+        },
+        "oauth_support": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether the provider supports OAuth 2.0 authentication for remote MCP servers, including token storage and automatic refresh.\n",
+            "spec_ref": "ACIF-MCP §9.1 (DERIVABLE)",
+            "type": "bool"
+          },
+          "key_path": "mcp.oauth_support",
+          "mechanism": "OAuth 2.0 with Dynamic Client Registration (RFC 7591): 401 auto-detected, tokens stored in ~/.local/share/opencode/mcp-auth.json; oauth object for pre-registered credentials or oauth: false to disable (documented under 'OAuth' / 'Authenticating' / 'OAuth Options')",
+          "supported": true
+        },
+        "tool_filtering": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Which per-server tool filtering mechanisms the provider supports. Contents: {allowlist: bool, blocklist: bool, disable_flag: bool}. Controls which server tools are exposed to the agent. Boundary: tool_filtering governs tool visibility (what appears in the agent's available tool set); see auto_approve for execution gating of visible tools.\n",
+            "spec_ref": "ACIF-MCP §9.1 (DERIVABLE)",
+            "type": "object"
+          },
+          "key_path": "mcp.tool_filtering",
+          "mechanism": "global tools map keyed by server-name prefix with glob patterns (e.g. mymcp_*); per-agent access via the agent permission map (documented under 'Manage' / 'Global' / 'Per agent' / 'Glob patterns')",
+          "supported": true
+        },
+        "transport_types": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Which MCP transport protocols the provider supports. Common transports: stdio (local process), SSE (Server-Sent Events), HTTP/streamable-HTTP (stateless or streaming).\n",
+            "spec_ref": "ACIF-MCP §9.1 (DERIVABLE); transport enum ACIF-MCP §6.2, §7",
+            "type": "object"
+          },
+          "key_path": "mcp.transport_types",
+          "mechanism": "two types under the mcp key in opencode.json: local (stdio, launched via command array) and remote (HTTP/SSE streamable, connected via url) (documented under 'Local' / 'Remote' headings)",
+          "supported": true
+        }
+      },
+      "supported": true
+    },
+    "rules": {
+      "capabilities": {
+        "activation_mode": {
+          "confidence": "inferred",
+          "key": {
+            "description": "How rules decide when to load into context. Providers implement varying modes: always-on, conditional/glob-based, model-decision, and manual activation. Tracks which modes the provider supports and how they are configured.\n",
+            "spec_ref": "ACIF-RULE §9.1 (DERIVABLE); activation-mode vocabulary ACIF-RULE Appendix A, §10",
+            "type": "object"
+          },
+          "key_path": "rules.activation_mode",
+          "mechanism": "rule files load unconditionally as context; no conditional activation syntax documented",
+          "supported": false
+        },
+        "auto_memory": {
+          "confidence": "inferred",
+          "key": {
+            "description": "Whether the provider auto-generates persistent rules from conversation context. Distinct from user-authored rules — these are AI-created and stored separately.\n",
+            "spec_ref": "ACIF-RULE §9.2 (OUT-OF-SCOPE-AT-L1; provider_capability_coverage, ACIF-REGISTRY §8.4)",
+            "type": "bool"
+          },
+          "key_path": "rules.auto_memory",
+          "mechanism": "no runtime command documented for persisting notes into rule files",
+          "supported": false
+        },
+        "cross_provider_recognition": {
+          "capabilities": {
+            "agents_md": {
+              "confidence": "confirmed",
+              "mechanism": "AGENTS.md read from project root and parent directories; global at ~/.config/opencode/AGENTS.md (documented under 'Types' / 'Project' / 'Global' headings)",
+              "supported": true
+            },
+            "claude_md": {
+              "confidence": "confirmed",
+              "mechanism": "CLAUDE.md fallback at project root and ~/.claude/CLAUDE.md globally when no AGENTS.md exists; disable via OPENCODE_DISABLE_CLAUDE_CODE=1 (documented under 'Claude Code Compatibility')",
+              "supported": true
+            }
+          },
+          "key": {
+            "description": "Which rule file formats from other providers this provider recognizes. Contents: recognized_formats (list of filenames like AGENTS.md, .cursorrules, .windsurfrules). Minimum qualification: supported when the provider reads at least one rule-file format defined by a different provider.\n",
+            "spec_ref": "ACIF-RULE §9.2 (OUT-OF-SCOPE-AT-L1; provider_capability_coverage, ACIF-REGISTRY §8.4)",
+            "type": "object"
+          },
+          "key_path": "rules.cross_provider_recognition",
+          "supported": true
+        },
+        "file_imports": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether rules can reference or include content from other files. Mechanisms vary: @-import syntax, @file.md directives, @path/to/file references.\n",
+            "spec_ref": "ACIF-RULE §9.2 (OUT-OF-SCOPE-AT-L1; strongest requires candidate — see ACIF ROADMAP, body-content reference grammar)",
+            "type": "bool"
+          },
+          "key_path": "rules.file_imports",
+          "mechanism": "instructions array in opencode.json (or the global ~/.config/opencode/opencode.json) lists additional rule files by relative path, glob pattern, or remote URL — all combined with AGENTS.md into context (documented under 'Referencing External Files' / 'Using opencode.json')",
+          "supported": true
+        },
+        "hierarchical_loading": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether rules load from multiple directory levels with defined precedence. Enables project-root rules plus subdirectory-scoped overrides.\n",
+            "spec_ref": "ACIF-RULE §9.2 (OUT-OF-SCOPE-AT-L1; provider_capability_coverage, ACIF-REGISTRY §8.4)",
+            "type": "bool"
+          },
+          "key_path": "rules.hierarchical_loading",
+          "mechanism": "AGENTS.md (CLAUDE.md fallback) collected walking up from cwd; global ~/.config/opencode/AGENTS.md and ~/.claude/CLAUDE.md appended; all matching files combined (documented under 'Types' / 'Precedence')",
+          "supported": true
+        }
+      },
+      "supported": true
+    },
+    "skills": {
+      "capabilities": {
+        "canonical_filename": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "The required or conventional filename for this skill type. For example, \"SKILL.md\" for Claude Code skills.\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1; discovery ACIF-SKILL §9)",
+            "type": "string"
+          },
+          "key_path": "skills.canonical_filename",
+          "mechanism": "fixed filename SKILL.md inside the skill directory (Agent Skills spec)",
+          "supported": true
+        },
+        "compatibility": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Provider compatibility constraints — which AI tool versions or providers this skill is compatible with.\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "object"
+          },
+          "key_path": "skills.compatibility",
+          "mechanism": "yaml frontmatter key: compatibility (optional)",
+          "supported": true
+        },
+        "description": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "What the skill does. Used by the AI to decide when to auto-invoke it. Also shown in skill listings and help text.\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "string"
+          },
+          "key_path": "skills.description",
+          "mechanism": "yaml frontmatter key: description (required)",
+          "supported": true
+        },
+        "display_name": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Human-readable display name for the skill. If omitted, the directory name is used. Shown in skill listings and menus.\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "string"
+          },
+          "key_path": "skills.display_name",
+          "mechanism": "yaml frontmatter key: name (required)",
+          "supported": true
+        },
+        "global_scope": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether the skill can be installed at global/personal scope (applies across all projects for the current user).\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1; install_scope_capabilities, ACIF-REGISTRY)",
+            "type": "bool"
+          },
+          "key_path": "skills.global_scope",
+          "mechanism": "cross-provider convention at ~/.config/opencode/skills/<name>/SKILL.md",
+          "supported": true
+        },
+        "license": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "SPDX license identifier for the skill content. Typically \"MIT\", \"Apache-2.0\", etc.\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "string"
+          },
+          "key_path": "skills.license",
+          "mechanism": "yaml frontmatter key: license (optional)",
+          "supported": true
+        },
+        "metadata_map": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Arbitrary key-value metadata attached to the skill. Provider-specific semantics; often used for tooling or automation metadata.\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1)",
+            "type": "object"
+          },
+          "key_path": "skills.metadata_map",
+          "mechanism": "yaml frontmatter key: metadata (optional map)",
+          "supported": true
+        },
+        "project_scope": {
+          "confidence": "confirmed",
+          "key": {
+            "description": "Whether the skill can be installed at project scope (applies to current project only, typically committed to version control).\n",
+            "spec_ref": "ACIF-SKILL §10.2 (OUT-OF-SCOPE-AT-L1; install_scope_capabilities, ACIF-REGISTRY)",
+            "type": "bool"
+          },
+          "key_path": "skills.project_scope",
+          "mechanism": "cross-provider SKILL.md convention at .opencode/skill/<name>/SKILL.md",
+          "supported": true
+        }
+      },
+      "supported": true
+    }
+  },
+  "display_name": "opencode",
+  "provider_status": "active",
   "schema_version": "2",
   "slug": "opencode",
   "status": "live"

--- a/docs/provider-capabilities/capabilities/windsurf.json
+++ b/docs/provider-capabilities/capabilities/windsurf.json
@@ -158,14 +158,14 @@
             "type": "bool"
           },
           "key_path": "rules.hierarchical_loading",
-          "mechanism": ".windsurf/rules scanned in current workspace, sub-directories, and parent dirs up to git root (documented under 'Rules Discovery' / 'Rules Storage Locations')",
+          "mechanism": ".devin/rules/ (preferred; .windsurf/rules/ legacy fallback) scanned in current workspace, sub-directories, and parent dirs up to git root (documented under 'Rules Discovery' / 'Rules Storage Locations')",
           "supported": true
         }
       },
       "supported": true
     }
   },
-  "display_name": "Windsurf",
+  "display_name": "Devin Desktop",
   "provider_status": "active",
   "schema_version": "2",
   "slug": "windsurf",

--- a/docs/provider-capabilities/provenance.json
+++ b/docs/provider-capabilities/provenance.json
@@ -1,4 +1,4 @@
 {
-  "data_revision": "a4e39255b6a81a41d788fbb42eb5e6f697745415420873c34cb0c99311e1fb85",
-  "generated_at": "2026-07-14T09:38:07Z"
+  "data_revision": "697f28f27cf38e3c1dc2099fc9ed75ec36d680be0cff731512e4c29688b5b97b",
+  "generated_at": "2026-07-16T09:44:38Z"
 }


### PR DESCRIPTION
Automated mirror of the [Capability Feed](https://openscribbler.github.io/capmon/) — verified fail-closed (SLSA provenance + per-file sha256) before anything was written.

| | |
|---|---|
| `data_revision` | `697f28f27cf38e3c1dc2099fc9ed75ec36d680be0cff731512e4c29688b5b97b` |
| `generated_at` | `2026-07-16T09:44:38Z` |

**Changed providers:**
- crush
- factory-droid
- kiro
- opencode
- windsurf

_This PR rolls: each new `data_revision` force-updates the same branch. Intermediate unreviewed snapshots are superseded by design; history lives in the capmon repo._
