### PR TITLE
Reject hooks for events the target provider can't read (syllago-xqlc1)

### DIFF
--- a/cli/cmd/syllago/loadout_apply.go
+++ b/cli/cmd/syllago/loadout_apply.go
@@ -52,6 +52,7 @@ func init() {
 	loadoutApplyCmd.Flags().String("base-dir", "", "Override base directory for content installation")
 	loadoutApplyCmd.Flags().String("to", "", "Target provider (overrides manifest provider; defaults to claude-code if unset)")
 	loadoutApplyCmd.Flags().String("method", "symlink", "Install method: symlink (default) or copy")
+	loadoutApplyCmd.Flags().Bool("skip-unsupported", false, "Skip hooks whose events the target provider does not support instead of failing")
 	loadoutCmd.AddCommand(loadoutApplyCmd)
 }
 
@@ -179,13 +180,15 @@ func runLoadoutApply(cmd *cobra.Command, args []string) error {
 	if methodStr == "copy" {
 		method = installer.MethodCopy
 	}
+	skipUnsupported, _ := cmd.Flags().GetBool("skip-unsupported")
 
 	opts := loadout.ApplyOptions{
-		Mode:        mode,
-		Method:      method,
-		ProjectRoot: projectRoot,
-		RepoRoot:    root,
-		Resolver:    resolver,
+		Mode:            mode,
+		Method:          method,
+		ProjectRoot:     projectRoot,
+		RepoRoot:        root,
+		Resolver:        resolver,
+		SkipUnsupported: skipUnsupported,
 	}
 
 	// Multi-provider path: manifest declares providers[] and --to is not set.
@@ -193,46 +196,61 @@ func runLoadoutApply(cmd *cobra.Command, args []string) error {
 	// Run 'syllago loadout remove' once per provider to undo.
 	effectiveProviders := manifest.EffectiveProviders()
 	if toSlug == "" && len(effectiveProviders) > 1 {
-		totalActions := 0
-		for _, slug := range effectiveProviders {
-			p := findProviderBySlug(slug)
-			if p == nil {
-				fmt.Fprintf(output.ErrWriter, "Warning: unknown provider %q in loadout manifest — skipping\n", slug)
-				continue
-			}
-			result, err := loadout.Apply(manifest, cat, *p, opts)
-			if err != nil {
-				return output.NewStructuredErrorDetail(output.ErrInstallConflict,
-					fmt.Sprintf("applying loadout to %s", slug),
-					"Check error details and resolve conflicts", err.Error())
-			}
-			if !output.JSON {
-				if mode == "preview" {
-					fmt.Fprintf(output.Writer, "[%s] Preview:\n", slug)
-				} else {
-					fmt.Fprintf(output.Writer, "[%s] Applied (%s mode):\n", slug, mode)
-				}
-				printLoadoutActions(result.Actions)
-				for _, w := range result.Warnings {
-					fmt.Fprintf(output.ErrWriter, "  Warning: %s\n", w)
-				}
-				fmt.Fprintln(output.Writer)
-			} else {
-				output.Print(result)
-			}
-			totalActions += len(result.Actions)
-		}
-		if mode == "try" {
-			fmt.Fprintln(output.Writer, "This loadout is temporary. It will auto-revert when the session ends.")
-			fmt.Fprintln(output.Writer, "If auto-revert fails, run: syllago loadout remove")
-		}
-		telemetry.Enrich("provider", strings.Join(effectiveProviders, ","))
-		telemetry.Enrich("mode", mode)
-		telemetry.Enrich("action_count", totalActions)
-		return nil
+		return applyLoadoutMultiProvider(manifest, cat, opts, effectiveProviders, mode, skipUnsupported)
 	}
+	return applyLoadoutSingleProvider(manifest, cat, opts, toSlug, effectiveProviders, mode, skipUnsupported)
+}
 
-	// Single-provider path: --to flag > manifest.Providers[0] > manifest.Provider > default claude-code
+// applyLoadoutMultiProvider applies a loadout to each provider the manifest
+// lists, each with its own snapshot, and prints a per-provider summary.
+func applyLoadoutMultiProvider(manifest *loadout.Manifest, cat *catalog.Catalog, opts loadout.ApplyOptions, effectiveProviders []string, mode string, skipUnsupported bool) error {
+	totalActions := 0
+	allAutoRevertArmed := true
+	for _, slug := range effectiveProviders {
+		p := findProviderBySlug(slug)
+		if p == nil {
+			fmt.Fprintf(output.ErrWriter, "Warning: unknown provider %q in loadout manifest — skipping\n", slug)
+			continue
+		}
+		result, err := loadout.Apply(manifest, cat, *p, opts)
+		if err != nil {
+			return output.NewStructuredErrorDetail(output.ErrInstallConflict,
+				fmt.Sprintf("applying loadout to %s", slug),
+				loadoutApplyHint(err), err.Error())
+		}
+		if mode == "try" && !result.AutoRevertArmed {
+			allAutoRevertArmed = false
+		}
+		if !output.JSON {
+			if mode == "preview" {
+				fmt.Fprintf(output.Writer, "[%s] Preview:\n", slug)
+			} else {
+				fmt.Fprintf(output.Writer, "[%s] Applied (%s mode):\n", slug, mode)
+			}
+			printLoadoutActions(result.Actions)
+			for _, w := range result.Warnings {
+				fmt.Fprintf(output.ErrWriter, "  Warning: %s\n", w)
+			}
+			fmt.Fprintln(output.Writer)
+		} else {
+			output.Print(result)
+		}
+		totalActions += len(result.Actions)
+	}
+	if mode == "try" {
+		printTryModeFooter(allAutoRevertArmed, "at least one provider")
+	}
+	telemetry.Enrich("provider", strings.Join(effectiveProviders, ","))
+	telemetry.Enrich("mode", mode)
+	telemetry.Enrich("action_count", totalActions)
+	telemetry.Enrich("skip_unsupported", skipUnsupported)
+	return nil
+}
+
+// applyLoadoutSingleProvider resolves the single target provider (--to flag >
+// manifest.Providers[0] > manifest.Provider > default claude-code) and applies
+// the loadout to it.
+func applyLoadoutSingleProvider(manifest *loadout.Manifest, cat *catalog.Catalog, opts loadout.ApplyOptions, toSlug string, effectiveProviders []string, mode string, skipUnsupported bool) error {
 	var prov provider.Provider
 	targetSlug := toSlug
 	if targetSlug == "" && len(effectiveProviders) == 1 {
@@ -252,7 +270,7 @@ func runLoadoutApply(cmd *cobra.Command, args []string) error {
 
 	result, err := loadout.Apply(manifest, cat, prov, opts)
 	if err != nil {
-		return output.NewStructuredErrorDetail(output.ErrInstallConflict, "applying loadout", "Check error details and resolve conflicts", err.Error())
+		return output.NewStructuredErrorDetail(output.ErrInstallConflict, "applying loadout", loadoutApplyHint(err), err.Error())
 	}
 
 	if output.JSON {
@@ -273,14 +291,38 @@ func runLoadoutApply(cmd *cobra.Command, args []string) error {
 	}
 
 	if mode == "try" {
-		fmt.Fprintln(output.Writer, "\nThis loadout is temporary. It will auto-revert when the session ends.")
-		fmt.Fprintln(output.Writer, "If auto-revert fails, run: syllago loadout remove")
+		fmt.Fprintln(output.Writer)
+		printTryModeFooter(result.AutoRevertArmed, prov.Name)
 	}
 
 	telemetry.Enrich("provider", prov.Slug)
 	telemetry.Enrich("mode", mode)
 	telemetry.Enrich("action_count", len(result.Actions))
+	telemetry.Enrich("skip_unsupported", skipUnsupported)
 	return nil
+}
+
+// printTryModeFooter prints the try-mode temporary-loadout notice, telling the
+// user whether auto-revert is armed. subject names what cannot auto-revert
+// when it isn't (a provider name, or "at least one provider").
+func printTryModeFooter(autoRevertArmed bool, subject string) {
+	if autoRevertArmed {
+		fmt.Fprintln(output.Writer, "This loadout is temporary. It will auto-revert when the session ends.")
+		fmt.Fprintln(output.Writer, "If auto-revert fails, run: syllago loadout remove")
+		return
+	}
+	fmt.Fprintf(output.Writer, "This loadout is temporary, but %s cannot auto-revert.\n", subject)
+	fmt.Fprintln(output.Writer, "Run 'syllago loadout remove' to undo it.")
+}
+
+// loadoutApplyHint picks the actionable hint for a failed apply: unsupported
+// hooks have a dedicated escape hatch, everything else is a conflict.
+func loadoutApplyHint(err error) string {
+	var uhErr *loadout.UnsupportedHooksError
+	if errors.As(err, &uhErr) {
+		return "Re-run with --skip-unsupported to apply the compatible items"
+	}
+	return "Check error details and resolve conflicts"
 }
 
 // printLoadoutActions prints a formatted list of planned actions.
@@ -292,7 +334,7 @@ func printLoadoutActions(actions []loadout.PlannedAction) {
 			symbol = "+ "
 		case "merge-hook", "merge-mcp":
 			symbol = "* "
-		case "skip-exists":
+		case "skip-exists", "skip-unsupported":
 			symbol = "= "
 		case "error-conflict":
 			symbol = "! "

--- a/cli/commands.json
+++ b/cli/commands.json
@@ -1831,6 +1831,14 @@
           "description": "Install method: symlink (default) or copy"
         },
         {
+          "name": "--skip-unsupported",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Skip hooks whose events the target provider does not support instead of failing"
+        },
+        {
           "name": "--to",
           "shorthand": null,
           "type": "string",

--- a/cli/internal/converter/toolmap.go
+++ b/cli/internal/converter/toolmap.go
@@ -246,6 +246,28 @@ func TranslateHookEvent(event, targetSlug string) (string, bool) {
 	return translated, true
 }
 
+// ProviderSupportsHookEvent reports whether the target provider can actually
+// read a hook merged under this event: either a canonical event with a
+// mapping for the provider, or the provider's own native event name.
+// TranslateHookEvent's ok=false cannot distinguish "already native" from
+// "known canonical event with no key for this provider" — merge paths use
+// this predicate to reject the latter instead of writing dead config
+// (syllago-xqlc1). Another provider's native name is equally unreadable and
+// is likewise unsupported.
+func ProviderSupportsHookEvent(event, targetSlug string) bool {
+	if m, ok := HookEvents[event]; ok {
+		if _, mapped := m[targetSlug]; mapped {
+			return true
+		}
+	}
+	for _, m := range HookEvents {
+		if m[targetSlug] == event {
+			return true
+		}
+	}
+	return false
+}
+
 // IsValidHookEvent reports whether the event name is a known canonical or
 // provider-native hook event. This prevents sjson key injection via dots or
 // other special characters in crafted event names.

--- a/cli/internal/converter/toolmap_test.go
+++ b/cli/internal/converter/toolmap_test.go
@@ -797,3 +797,37 @@ func TestTranslateTool_VSCodeCopilot(t *testing.T) {
 		})
 	}
 }
+
+// TestProviderSupportsHookEvent verifies the support predicate that merge
+// paths use to reject dead config (syllago-xqlc1). TranslateHookEvent's
+// ok=false conflates "already provider-native" with "known canonical event
+// this provider has no key for"; this predicate separates them: an event is
+// supported iff it is canonical with a mapping for the provider, or it is
+// the provider's OWN native name. Another provider's native name is dead
+// config just like an unmapped canonical.
+func TestProviderSupportsHookEvent(t *testing.T) {
+	tests := []struct {
+		name  string
+		event string
+		slug  string
+		want  bool
+	}{
+		{"canonical with mapping", "before_tool_execute", "claude-code", true},
+		{"canonical without mapping", "before_tool_execute", "windsurf", false},
+		{"canonical without mapping for crush", "session_end", "crush", false},
+		{"own native name", "PreToolUse", "claude-code", true},
+		{"own native name windsurf", "pre_user_prompt", "windsurf", true},
+		{"own native name crush", "PreToolUse", "crush", true},
+		{"another provider's native name", "PreToolUse", "windsurf", false},
+		{"another provider's native name gemini", "BeforeTool", "claude-code", false},
+		{"unknown event", "not_a_real_event", "claude-code", false},
+		{"unknown provider slug", "before_tool_execute", "no-such-provider", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ProviderSupportsHookEvent(tt.event, tt.slug); got != tt.want {
+				t.Errorf("ProviderSupportsHookEvent(%q, %q) = %v, want %v", tt.event, tt.slug, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/internal/installer/hooks.go
+++ b/cli/internal/installer/hooks.go
@@ -106,6 +106,14 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 		return "", fmt.Errorf("unknown hook event %q: must be a known canonical or provider event name", event)
 	}
 
+	// Reject events the provider has no settings key for (canonical events
+	// with no mapping for this provider, or another provider's native name).
+	// Merging those writes config under a key the provider never reads —
+	// silently dead, reported as success (syllago-xqlc1).
+	if !converter.ProviderSupportsHookEvent(event, prov.Slug) {
+		return "", fmt.Errorf("hook %q: %s does not support hook event %q", item.Name, prov.Name, event)
+	}
+
 	// Translate canonical event names (e.g. "before_tool_execute") to the
 	// provider-native key (e.g. "PreToolUse") so the hook lands under the
 	// JSON path the provider actually reads. If the event is already
@@ -174,15 +182,13 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 	}
 
 	// Crush stores flat hook entries ({name, command, matcher, timeout})
-	// rather than CC-shape matcher groups, and fires hooks only on
-	// PreToolUse — any other event key would be dead config crush never
-	// reads. Flatten last so the whitelist, scanner, and script-resolution
-	// steps above all see the standard shape.
+	// rather than CC-shape matcher groups. The event is necessarily
+	// PreToolUse here: crush's only HookEvents entry is before_tool_execute,
+	// so the support check above already rejected everything else. Flatten
+	// last so the whitelist, scanner, and script-resolution steps above all
+	// see the standard shape.
 	if prov.Slug == "crush" {
-		if event != "PreToolUse" {
-			return "", fmt.Errorf("hook %q: crush supports only the before_tool_execute (PreToolUse) hook event; got %q", item.Name, event)
-		}
-		matcherGroup, err = flattenForCrush(matcherGroup, hookName)
+		matcherGroup, err = FlattenForCrush(matcherGroup, hookName)
 		if err != nil {
 			return "", fmt.Errorf("hook %q: %w", item.Name, err)
 		}
@@ -522,13 +528,15 @@ func resolveHookScripts(matcherGroup []byte, item catalog.ContentItem, repoRoot 
 	return result, nil
 }
 
-// flattenForCrush converts a CC-shape matcher group ({matcher, hooks:[entry]})
+// FlattenForCrush converts a CC-shape matcher group ({matcher, hooks:[entry]})
 // into crush's flat HookConfig ({name, matcher, command, timeout}). Crush
 // hooks are shell commands only, its schema rejects unknown fields, and its
 // timeouts are seconds — the canonical unit, so the value passes through
-// unchanged. The matcher arrives already translated to crush's native tool
-// names (installHook translates for every provider before this step).
-func flattenForCrush(matcherGroup []byte, hookName string) ([]byte, error) {
+// unchanged. The matcher must arrive already translated to crush's native
+// tool names (both installHook and loadout applyHook translate for every
+// provider before this step). Exported so the loadout merge path can share
+// the same flattening.
+func FlattenForCrush(matcherGroup []byte, hookName string) ([]byte, error) {
 	entry := gjson.GetBytes(matcherGroup, "hooks.0")
 	if hType := entry.Get("type").String(); hType != "" && hType != "command" {
 		return nil, fmt.Errorf("crush hooks only support command handlers (got type %q)", hType)

--- a/cli/internal/installer/hooks_e2e_test.go
+++ b/cli/internal/installer/hooks_e2e_test.go
@@ -41,7 +41,7 @@ func TestInstallHook_E2E_InlineCommand(t *testing.T) {
 
 	prov := provider.Provider{
 		Name:      "test-provider",
-		Slug:      "test",
+		Slug:      "claude-code", // real slug: unknown slugs now fail the event-support check
 		ConfigDir: filepath.Base(configDir),
 	}
 
@@ -105,7 +105,7 @@ func TestInstallHook_E2E_WithScript(t *testing.T) {
 
 	prov := provider.Provider{
 		Name:      "test-provider",
-		Slug:      "test",
+		Slug:      "claude-code", // real slug: unknown slugs now fail the event-support check
 		ConfigDir: filepath.Base(configDir),
 	}
 
@@ -176,7 +176,7 @@ func TestInstallHook_E2E_Uninstall(t *testing.T) {
 
 	prov := provider.Provider{
 		Name:      "test-provider",
-		Slug:      "test",
+		Slug:      "claude-code", // real slug: unknown slugs now fail the event-support check
 		ConfigDir: filepath.Base(configDir),
 	}
 

--- a/cli/internal/installer/hooks_event_support_test.go
+++ b/cli/internal/installer/hooks_event_support_test.go
@@ -1,0 +1,90 @@
+package installer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/tidwall/gjson"
+)
+
+// writeEventHookItem writes a canonical hook.json with the given event into a
+// fresh project root and returns the item plus the project root.
+func writeEventHookItem(t *testing.T, event string) (catalog.ContentItem, string) {
+	t.Helper()
+	projectRoot := t.TempDir()
+	os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755)
+
+	hookDir := filepath.Join(projectRoot, "hooks", "event-hook")
+	os.MkdirAll(hookDir, 0755)
+	hookJSON := fmt.Sprintf(`{"spec":"hooks/0.1","hooks":[{"event":%q,"handler":{"type":"command","command":"echo hi"}}]}`, event)
+	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
+
+	return catalog.ContentItem{
+		Name: "event-hook",
+		Type: catalog.Hooks,
+		Path: hookDir,
+	}, projectRoot
+}
+
+// TestInstallHook_RejectsUnsupportedEvent: a hook whose event the target
+// provider has no settings key for must fail the install instead of merging
+// dead config under a key the provider never reads (syllago-xqlc1). Covers
+// both doors into the bug: a canonical event with no mapping for the
+// provider, and another provider's native event name.
+func TestInstallHook_RejectsUnsupportedEvent(t *testing.T) {
+	tests := []struct {
+		name  string
+		event string
+		prov  provider.Provider
+	}{
+		{"canonical event unmapped for provider", "before_tool_execute", provider.Windsurf},
+		{"another provider's native name", "PreToolUse", provider.Windsurf},
+		{"canonical event unmapped for crush", "session_end", provider.Crush},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item, projectRoot := writeEventHookItem(t, tt.event)
+
+			settingsPath := filepath.Join(t.TempDir(), "settings.json")
+			os.WriteFile(settingsPath, []byte(`{}`), 0644)
+			overrideHookSettingsPath(t, settingsPath)
+
+			_, err := installHook(item, tt.prov, projectRoot)
+			if err == nil {
+				t.Fatalf("expected error installing %q hook to %s", tt.event, tt.prov.Slug)
+			}
+			if !strings.Contains(err.Error(), "does not support hook event") {
+				t.Errorf("error should name the unsupported event, got: %v", err)
+			}
+			data, _ := os.ReadFile(settingsPath)
+			if gjson.GetBytes(data, "hooks").Exists() {
+				t.Errorf("no hook should have been written, got: %s", data)
+			}
+		})
+	}
+}
+
+// TestInstallHook_OwnNativeEventPassesThrough: a provider's OWN native event
+// name is not translated but must still install — the strict support check
+// only rejects events the provider cannot read.
+func TestInstallHook_OwnNativeEventPassesThrough(t *testing.T) {
+	item, projectRoot := writeEventHookItem(t, "pre_user_prompt")
+
+	settingsPath := filepath.Join(t.TempDir(), "settings.json")
+	os.WriteFile(settingsPath, []byte(`{}`), 0644)
+	overrideHookSettingsPath(t, settingsPath)
+
+	if _, err := installHook(item, provider.Windsurf, projectRoot); err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+	data, _ := os.ReadFile(settingsPath)
+	if !gjson.GetBytes(data, "hooks.pre_user_prompt.0").Exists() {
+		t.Errorf("expected hooks.pre_user_prompt.0 in settings, got: %s", data)
+	}
+}

--- a/cli/internal/installer/hooks_matcher_test.go
+++ b/cli/internal/installer/hooks_matcher_test.go
@@ -47,10 +47,9 @@ func TestInstallHook_TranslatesMatcher(t *testing.T) {
 		{provider.ClaudeCode, "PreToolUse", "Bash"},
 		{provider.GeminiCLI, "BeforeTool", "run_shell_command"},
 		{provider.Cursor, "PreToolUse", "run_terminal_cmd"},
-		// Windsurf has no native before_tool_execute mapping, so the event
-		// key stays canonical (event-support enforcement is out of scope
-		// here) — but the matcher must still translate for the slug.
-		{provider.Windsurf, "before_tool_execute", "run_command"},
+		// Windsurf is absent: it has no before_tool_execute mapping, so the
+		// install is rejected outright — see
+		// TestInstallHook_RejectsUnsupportedEvent (syllago-xqlc1).
 	}
 
 	for _, tt := range tests {

--- a/cli/internal/installer/hooks_test.go
+++ b/cli/internal/installer/hooks_test.go
@@ -159,7 +159,7 @@ func TestCheckHookStatus_UsesInstalledJSON(t *testing.T) {
 
 	prov := provider.Provider{
 		Name:      "test-provider",
-		Slug:      "test",
+		Slug:      "claude-code", // real slug: unknown slugs now fail the event-support check
 		ConfigDir: filepath.Base(configDir),
 	}
 
@@ -419,7 +419,7 @@ func TestInstallHook_RejectsDuplicate(t *testing.T) {
 
 	prov := provider.Provider{
 		Name:      "test-provider",
-		Slug:      "test",
+		Slug:      "claude-code", // real slug: unknown slugs now fail the event-support check
 		ConfigDir: filepath.Base(configDir),
 	}
 
@@ -636,7 +636,7 @@ func setupScannerTestProvider(t *testing.T, tag string) (projectRoot string, pro
 
 	prov = provider.Provider{
 		Name:      "scan-test-provider",
-		Slug:      "scan-test",
+		Slug:      "claude-code", // real slug: unknown slugs now fail the event-support check
 		ConfigDir: filepath.Base(configDir),
 	}
 

--- a/cli/internal/loadout/apply.go
+++ b/cli/internal/loadout/apply.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
@@ -27,6 +28,24 @@ type ApplyOptions struct {
 	HomeDir     string               // defaults to os.UserHomeDir() if empty
 	RepoRoot    string               // catalog repo root for symlink source resolution
 	Resolver    *config.PathResolver // optional path resolver for custom locations
+
+	// SkipUnsupported applies the loadout without the hooks whose events the
+	// target provider has no settings key for, instead of failing. Skipped
+	// hooks are reported in ApplyResult.Warnings.
+	SkipUnsupported bool
+}
+
+// UnsupportedHooksError rejects an apply because the loadout contains hooks
+// whose events the target provider cannot read (syllago-xqlc1). Callers can
+// detect it with errors.As to suggest --skip-unsupported.
+type UnsupportedHooksError struct {
+	Provider string
+	Problems []string // one "name — problem" line per rejected hook
+}
+
+func (e *UnsupportedHooksError) Error() string {
+	return fmt.Sprintf("%d hook(s) cannot be applied to %s:\n  %s",
+		len(e.Problems), e.Provider, strings.Join(e.Problems, "\n  "))
 }
 
 // ApplyResult describes what happened during apply.
@@ -34,6 +53,11 @@ type ApplyResult struct {
 	Actions     []PlannedAction // what was done (or planned, for preview)
 	SnapshotDir string          // set on success for try/keep modes
 	Warnings    []string
+
+	// AutoRevertArmed reports whether a session-end auto-revert hook was
+	// injected (try mode only). False when the provider has no session_end
+	// event — the CLI must not then promise auto-revert.
+	AutoRevertArmed bool
 }
 
 // Apply resolves, validates, and applies a loadout to the provider.
@@ -93,6 +117,18 @@ func Apply(manifest *Manifest, cat *catalog.Catalog, prov provider.Provider, opt
 		}
 	}
 
+	// Hooks the provider can't read fail the whole apply unless the caller
+	// opted into a partial one — no silent partial coverage (syllago-xqlc1).
+	var unsupported []string
+	for _, a := range actions {
+		if a.Action == "skip-unsupported" {
+			unsupported = append(unsupported, fmt.Sprintf("%s — %s", a.Name, a.Problem))
+		}
+	}
+	if len(unsupported) > 0 && !opts.SkipUnsupported {
+		return nil, &UnsupportedHooksError{Provider: prov.Name, Problems: unsupported}
+	}
+
 	// Step 4: Collect files to back up and create snapshot
 	filesToBackup := collectBackupFiles(actions, prov, opts)
 	var symlinkRecords []snapshot.SymlinkRecord
@@ -119,6 +155,11 @@ func Apply(manifest *Manifest, cat *catalog.Catalog, prov provider.Provider, opt
 
 	// Step 5: Apply each action. On failure, rollback.
 	var warnings []string
+	for _, a := range actions {
+		if a.Action == "skip-unsupported" {
+			warnings = append(warnings, fmt.Sprintf("skipped %s: %s", a.Name, a.Problem))
+		}
+	}
 	applyErr := applyActions(actions, refs, prov, opts, manifest.Name)
 	if applyErr != nil {
 		// Rollback: restore snapshot and clean up
@@ -134,17 +175,23 @@ func Apply(manifest *Manifest, cat *catalog.Catalog, prov provider.Provider, opt
 		return nil, fmt.Errorf("applying loadout (rolled back): %w", applyErr)
 	}
 
-	// Step 6 (C7): For "try" mode, inject SessionEnd hook for auto-revert
+	// Step 6 (C7): For "try" mode, inject a session-end hook for auto-revert.
+	autoRevertArmed := false
 	if opts.Mode == "try" {
-		if err := injectSessionEndHook(prov, opts.HomeDir, opts.Resolver); err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to inject SessionEnd hook: %v", err))
+		injected, err := injectSessionEndHook(prov, opts.HomeDir, opts.Resolver)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to inject session-end hook: %v", err))
+		} else if !injected {
+			warnings = append(warnings, fmt.Sprintf("%s has no session-end hook event, so this loadout cannot auto-revert; run 'syllago loadout remove' to undo it", prov.Name))
 		}
+		autoRevertArmed = injected
 	}
 
 	return &ApplyResult{
-		Actions:     actions,
-		SnapshotDir: snapshotDir,
-		Warnings:    warnings,
+		Actions:         actions,
+		SnapshotDir:     snapshotDir,
+		Warnings:        warnings,
+		AutoRevertArmed: autoRevertArmed,
 	}, nil
 }
 
@@ -158,7 +205,7 @@ func applyActions(actions []PlannedAction, refs []ResolvedRef, prov provider.Pro
 	source := "loadout:" + loadoutName
 
 	for _, a := range actions {
-		if a.Action == "skip-exists" {
+		if a.Action == "skip-exists" || a.Action == "skip-unsupported" {
 			continue
 		}
 
@@ -209,12 +256,20 @@ func applyActions(actions []PlannedAction, refs []ResolvedRef, prov provider.Pro
 // settingsPathFor computes the settings.json path for a provider, using the
 // resolver's base dir if configured, otherwise falling back to homeDir.
 func settingsPathFor(prov provider.Provider, homeDir string, resolver *config.PathResolver) string {
+	base := homeDir
 	if resolver != nil {
 		if bd := resolver.BaseDir(prov.Slug); bd != "" {
-			return filepath.Join(bd, prov.ConfigDir, "settings.json")
+			base = bd
 		}
 	}
-	return filepath.Join(homeDir, prov.ConfigDir, "settings.json")
+	// Crush keeps hooks in its unified crush.json, not a settings.json
+	// (mirrors installer.hookSettingsPathImpl). Routing here also covers the
+	// snapshot backup list and remove, which build paths via this function.
+	filename := "settings.json"
+	if prov.Slug == "crush" {
+		filename = "crush.json"
+	}
+	return filepath.Join(base, prov.ConfigDir, filename)
 }
 
 // applyHook reads a hook JSON file and appends it to settings.json.
@@ -261,6 +316,14 @@ func applyHook(ref ResolvedRef, prov provider.Provider, homeDir string, resolver
 		return fmt.Errorf("unknown hook event %q: must be a known canonical or provider event name", event)
 	}
 
+	// Reject events the provider has no settings key for (mirrors installHook,
+	// syllago-xqlc1). Apply already gates these via the skip-unsupported
+	// preview action; this is the defense-in-depth backstop at the actual
+	// merge point so dead config can never slip through if the two diverge.
+	if !converter.ProviderSupportsHookEvent(event, prov.Slug) {
+		return fmt.Errorf("hook %q: %s does not support hook event %q", ref.Name, prov.Name, event)
+	}
+
 	// Translate canonical names to provider-native before the merge (mirrors
 	// installHook): the event becomes the settings key the provider actually
 	// reads, and matcher tool names become the names the provider tests its
@@ -289,14 +352,26 @@ func applyHook(ref ResolvedRef, prov provider.Provider, homeDir string, resolver
 	// Resolve relative command paths to absolute
 	matcherGroup = resolveHookCommands(matcherGroup, ref.Item.Path)
 
-	// Append to settings.json
+	// Crush stores flat hook entries ({name, matcher, command, timeout}) in
+	// crush.json rather than CC-shape matcher groups (mirrors installHook).
+	// Flatten last so command resolution above sees the standard shape.
+	commandPath := "hooks.0.command"
+	if prov.Slug == "crush" {
+		matcherGroup, err = installer.FlattenForCrush(matcherGroup, manifest.Hooks[0].Name)
+		if err != nil {
+			return fmt.Errorf("hook %q: %w", ref.Name, err)
+		}
+		commandPath = "command"
+	}
+
+	// Append to the provider's hook config file
 	settingsPath := settingsPathFor(prov, homeDir, resolver)
 	if err := appendHookEntry(settingsPath, event, matcherGroup); err != nil {
 		return err
 	}
 
-	// Extract command for tracking
-	command := gjson.GetBytes(matcherGroup, "hooks.0.command").String()
+	// Extract command for tracking (crush entries are flat)
+	command := gjson.GetBytes(matcherGroup, commandPath).String()
 
 	inst.Hooks = append(inst.Hooks, installer.InstalledHook{
 		Name:        ref.Name,
@@ -381,13 +456,26 @@ func applyMCP(ref ResolvedRef, prov provider.Provider, projectRoot string, inst 
 	return nil
 }
 
-// injectSessionEndHook appends a SessionEnd hook that runs "syllago loadout remove --auto".
-// This hook is NOT tracked in installed.json -- it gets reverted when the snapshot restores
-// settings.json.
-func injectSessionEndHook(prov provider.Provider, homeDir string, resolver *config.PathResolver) error {
+// injectSessionEndHook appends a session-end hook that runs
+// "syllago loadout remove --auto" for try-mode auto-revert. The hook is NOT
+// tracked in installed.json — it gets reverted when the snapshot restores the
+// settings file.
+//
+// Returns injected=false (no error) when the provider has no session_end
+// event: the key would be dead config the provider never reads, and for crush
+// it would corrupt the real crush.json (wrong key and CC-shape group). Callers
+// warn the user to revert manually in that case.
+func injectSessionEndHook(prov provider.Provider, homeDir string, resolver *config.PathResolver) (injected bool, err error) {
+	// Translate to the provider-native event key; skip if unsupported so we
+	// never write a key the provider can't read (syllago-xqlc1).
+	event, ok := converter.TranslateHookEvent("session_end", prov.Slug)
+	if !ok {
+		return false, nil
+	}
+
 	settingsPath := settingsPathFor(prov, homeDir, resolver)
 
-	// Build the SessionEnd hook entry
+	// Build the session-end hook entry
 	hookEntry := map[string]interface{}{
 		"matcher": "",
 		"hooks": []map[string]interface{}{
@@ -400,10 +488,13 @@ func injectSessionEndHook(prov provider.Provider, homeDir string, resolver *conf
 
 	hookJSON, err := json.Marshal(hookEntry)
 	if err != nil {
-		return fmt.Errorf("marshaling SessionEnd hook: %w", err)
+		return false, fmt.Errorf("marshaling session-end hook: %w", err)
 	}
 
-	return appendHookEntry(settingsPath, "SessionEnd", hookJSON)
+	if err := appendHookEntry(settingsPath, event, hookJSON); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // collectBackupFiles determines which files need backing up before apply.

--- a/cli/internal/loadout/apply.go
+++ b/cli/internal/loadout/apply.go
@@ -512,8 +512,13 @@ func collectBackupFiles(actions []PlannedAction, prov provider.Provider, opts Ap
 		}
 	}
 
-	// "try" mode always backs up settings.json (for SessionEnd hook injection)
-	if opts.Mode == "try" {
+	// "try" mode backs up the settings file only when a session-end auto-revert
+	// hook will actually be injected — i.e. the provider has a session_end
+	// event. Backing it up otherwise means loadout remove would restore (and
+	// so clobber) a file this apply never wrote to; for crush the settings
+	// file is the real crush.json (syllago-xqlc1). Hooks in the loadout have
+	// already set needsSettings via their merge-hook actions above.
+	if opts.Mode == "try" && converter.ProviderSupportsHookEvent("session_end", prov.Slug) {
 		needsSettings = true
 	}
 

--- a/cli/internal/loadout/apply_test.go
+++ b/cli/internal/loadout/apply_test.go
@@ -733,3 +733,38 @@ func TestApply_TryMode_CrushNoSessionEndCorruption(t *testing.T) {
 		t.Errorf("expected a no-auto-revert warning, got warnings: %v", result.Warnings)
 	}
 }
+
+// TestCollectBackupFiles_TryModeSkipsSettingsWithoutSessionEnd is a regression
+// test for the codex-review finding on PR #512: try mode used to back up the
+// provider settings file unconditionally "for SessionEnd injection", but since
+// injectSessionEndHook now skips providers with no session_end event, backing
+// up their settings file means loadout remove would restore (clobber) a file
+// this apply never wrote to. For crush that file is the real crush.json.
+func TestCollectBackupFiles_TryModeSkipsSettingsWithoutSessionEnd(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+
+	crush := provider.Provider{Name: "Crush", Slug: "crush", ConfigDir: ".config/crush"}
+	cc := provider.Provider{Name: "Claude Code", Slug: "claude-code", ConfigDir: ".claude"}
+
+	// Rules-only loadout — no merge-hook actions, so nothing writes to the
+	// provider settings file except (potentially) session-end injection.
+	actions := []PlannedAction{{Type: catalog.Rules, Name: "r", Action: "create-symlink"}}
+	opts := ApplyOptions{Mode: "try", HomeDir: home, ProjectRoot: t.TempDir()}
+
+	for _, f := range collectBackupFiles(actions, crush, opts) {
+		if strings.HasSuffix(f, "crush.json") {
+			t.Errorf("crush has no session_end event; try-mode rules-only apply must not back up crush.json (remove would clobber user edits), got %v", f)
+		}
+	}
+
+	found := false
+	for _, f := range collectBackupFiles(actions, cc, opts) {
+		if strings.HasSuffix(f, "settings.json") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("claude-code supports session_end; try-mode must back up settings.json so auto-revert injection can be reverted")
+	}
+}

--- a/cli/internal/loadout/apply_test.go
+++ b/cli/internal/loadout/apply_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/installer"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
 	"github.com/tidwall/gjson"
 )
@@ -273,9 +274,12 @@ func TestApply_TryMode_InjectsSessionEndHook(t *testing.T) {
 		RepoRoot:    projectRoot,
 	}
 
-	_, err := Apply(manifest, cat, prov, opts)
+	result, err := Apply(manifest, cat, prov, opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.AutoRevertArmed {
+		t.Error("claude-code supports session_end, so AutoRevertArmed should be true")
 	}
 
 	// Verify settings.json has the SessionEnd hook
@@ -422,4 +426,310 @@ func TestReadJSONFileOrEmpty(t *testing.T) {
 			t.Errorf("error should mention invalid JSON, got: %v", err)
 		}
 	})
+}
+
+// setupUnsupportedHookEnv builds a windsurf-targeted env with one rule that
+// works and one hook whose event (before_tool_execute) windsurf has no
+// settings key for.
+func setupUnsupportedHookEnv(t *testing.T) (homeDir string, projectRoot string, manifest *Manifest, cat *catalog.Catalog, prov provider.Provider) {
+	t.Helper()
+	homeDir = t.TempDir()
+	projectRoot = t.TempDir()
+	os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755)
+	os.MkdirAll(filepath.Join(homeDir, ".codeium", "rules"), 0755)
+
+	ruleDir := filepath.Join(projectRoot, "content", "rules", "windsurf", "my-rule")
+	os.MkdirAll(ruleDir, 0755)
+	os.WriteFile(filepath.Join(ruleDir, "rule.md"), []byte("# My Rule"), 0644)
+
+	hookDir := filepath.Join(projectRoot, "content", "hooks", "windsurf", "dead-hook")
+	os.MkdirAll(hookDir, 0755)
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"before_tool_execute","handler":{"type":"command","command":"echo hi"}}]}`
+	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
+
+	manifest = &Manifest{
+		Kind:     "loadout",
+		Version:  1,
+		Provider: "windsurf",
+		Name:     "test-loadout",
+		Rules:    []ItemRef{{Name: "my-rule"}},
+		Hooks:    []ItemRef{{Name: "dead-hook"}},
+	}
+
+	cat = &catalog.Catalog{
+		RepoRoot: projectRoot,
+		Items: []catalog.ContentItem{
+			{Name: "my-rule", Type: catalog.Rules, Provider: "windsurf", Path: ruleDir},
+			{Name: "dead-hook", Type: catalog.Hooks, Provider: "windsurf", Path: hookDir},
+		},
+	}
+
+	prov = provider.Provider{
+		Name:      "Windsurf",
+		Slug:      "windsurf",
+		ConfigDir: ".codeium",
+		InstallDir: func(home string, ct catalog.ContentType) string {
+			switch ct {
+			case catalog.Rules:
+				return filepath.Join(home, ".codeium", "rules")
+			case catalog.Hooks:
+				return "__json_merge__"
+			}
+			return ""
+		},
+		SupportsType: func(ct catalog.ContentType) bool {
+			return ct == catalog.Rules || ct == catalog.Hooks
+		},
+	}
+
+	return
+}
+
+// TestApply_UnsupportedHook_FailsWithoutSkipFlag: applying a loadout that
+// contains a hook the target provider cannot read fails outright (nothing
+// applied) unless SkipUnsupported is set — no silent partial coverage, no
+// dead config (syllago-xqlc1).
+func TestApply_UnsupportedHook_FailsWithoutSkipFlag(t *testing.T) {
+	t.Parallel()
+	homeDir, projectRoot, manifest, cat, prov := setupUnsupportedHookEnv(t)
+
+	opts := ApplyOptions{
+		Mode:        "keep",
+		ProjectRoot: projectRoot,
+		HomeDir:     homeDir,
+		RepoRoot:    projectRoot,
+	}
+
+	_, err := Apply(manifest, cat, prov, opts)
+	if err == nil {
+		t.Fatal("expected error applying loadout with unsupported hook event")
+	}
+	if !strings.Contains(err.Error(), "dead-hook") || !strings.Contains(err.Error(), "before_tool_execute") {
+		t.Errorf("error should name the hook and event, got: %v", err)
+	}
+
+	// Nothing should have been applied.
+	if _, statErr := os.Stat(filepath.Join(homeDir, ".codeium", "rules", "my-rule")); statErr == nil {
+		t.Error("rule symlink should not exist after rejected apply")
+	}
+	if _, statErr := os.Stat(filepath.Join(homeDir, ".codeium", "settings.json")); statErr == nil {
+		t.Error("settings.json should not exist after rejected apply")
+	}
+}
+
+// TestApply_UnsupportedHook_SkippedWithFlag: with SkipUnsupported set, the
+// incompatible hook is skipped (and reported) while the rest of the loadout
+// applies normally.
+func TestApply_UnsupportedHook_SkippedWithFlag(t *testing.T) {
+	t.Parallel()
+	homeDir, projectRoot, manifest, cat, prov := setupUnsupportedHookEnv(t)
+
+	opts := ApplyOptions{
+		Mode:            "keep",
+		ProjectRoot:     projectRoot,
+		HomeDir:         homeDir,
+		RepoRoot:        projectRoot,
+		SkipUnsupported: true,
+	}
+
+	result, err := Apply(manifest, cat, prov, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The rule applied; the hook did not.
+	if _, statErr := os.Lstat(filepath.Join(homeDir, ".codeium", "rules", "my-rule")); statErr != nil {
+		t.Errorf("rule symlink should exist: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(homeDir, ".codeium", "settings.json")); statErr == nil {
+		data, _ := os.ReadFile(filepath.Join(homeDir, ".codeium", "settings.json"))
+		if gjson.GetBytes(data, "hooks").Exists() {
+			t.Errorf("no hooks should have been merged, got: %s", data)
+		}
+	}
+
+	var skipped *PlannedAction
+	for i := range result.Actions {
+		if result.Actions[i].Action == "skip-unsupported" {
+			skipped = &result.Actions[i]
+		}
+	}
+	if skipped == nil {
+		t.Fatal("expected a skip-unsupported action in the result")
+	}
+	if skipped.Name != "dead-hook" {
+		t.Errorf("skip-unsupported action should be dead-hook, got %s", skipped.Name)
+	}
+}
+
+// TestApplyHook_CrushFlattensAndRoutes: a loadout hook applied to crush must
+// land as a FLAT entry ({name, matcher, command}) in crush.json — not as a
+// CC-shape matcher group in a settings.json crush never reads (syllago-xqlc1,
+// mirrors installer hookSettingsPathImpl + FlattenForCrush).
+func TestApplyHook_CrushFlattensAndRoutes(t *testing.T) {
+	t.Parallel()
+	homeDir := t.TempDir()
+	projectRoot := t.TempDir()
+	os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755)
+
+	hookDir := filepath.Join(projectRoot, "content", "hooks", "crush", "guard-hook")
+	os.MkdirAll(hookDir, 0755)
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"name":"guard","event":"before_tool_execute","matcher":"shell","handler":{"type":"command","command":"echo guard"}}]}`
+	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
+
+	manifest := &Manifest{
+		Kind:     "loadout",
+		Version:  1,
+		Provider: "crush",
+		Name:     "crush-loadout",
+		Hooks:    []ItemRef{{Name: "guard-hook"}},
+	}
+
+	cat := &catalog.Catalog{
+		RepoRoot: projectRoot,
+		Items: []catalog.ContentItem{
+			{Name: "guard-hook", Type: catalog.Hooks, Provider: "crush", Path: hookDir},
+		},
+	}
+
+	prov := provider.Provider{
+		Name:      "Crush",
+		Slug:      "crush",
+		ConfigDir: ".config/crush",
+		InstallDir: func(home string, ct catalog.ContentType) string {
+			if ct == catalog.Hooks {
+				return "__json_merge__"
+			}
+			return ""
+		},
+		SupportsType: func(ct catalog.ContentType) bool {
+			return ct == catalog.Hooks
+		},
+	}
+
+	opts := ApplyOptions{
+		Mode:        "keep",
+		ProjectRoot: projectRoot,
+		HomeDir:     homeDir,
+		RepoRoot:    projectRoot,
+	}
+
+	if _, err := Apply(manifest, cat, prov, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The hook must land in crush.json, not settings.json.
+	crushPath := filepath.Join(homeDir, ".config", "crush", "crush.json")
+	data, readErr := os.ReadFile(crushPath)
+	if readErr != nil {
+		t.Fatalf("crush.json should exist: %v", readErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(homeDir, ".config", "crush", "settings.json")); statErr == nil {
+		t.Error("settings.json should not be written for crush")
+	}
+
+	entry := gjson.GetBytes(data, "hooks.PreToolUse.0")
+	if !entry.Exists() {
+		t.Fatalf("expected hooks.PreToolUse.0 in crush.json, got: %s", data)
+	}
+	if got := entry.Get("command").String(); got != "echo guard" {
+		t.Errorf("command: got %q, want 'echo guard'", got)
+	}
+	if got := entry.Get("matcher").String(); got != "bash" {
+		t.Errorf("matcher: got %q, want 'bash' (canonical shell -> crush native)", got)
+	}
+	if got := entry.Get("name").String(); got != "guard" {
+		t.Errorf("name: got %q, want 'guard'", got)
+	}
+	// Flat entry — no nested CC-shape hooks array.
+	if entry.Get("hooks").Exists() {
+		t.Errorf("crush entry must be flat, got nested hooks array: %s", entry.Raw)
+	}
+
+	// Tracking must record the command from the flat entry shape.
+	inst, err := installer.LoadInstalled(projectRoot)
+	if err != nil {
+		t.Fatalf("loading installed.json: %v", err)
+	}
+	if len(inst.Hooks) != 1 {
+		t.Fatalf("expected 1 tracked hook, got %d", len(inst.Hooks))
+	}
+	if inst.Hooks[0].Command != "echo guard" {
+		t.Errorf("tracked command: got %q, want 'echo guard'", inst.Hooks[0].Command)
+	}
+}
+
+// TestApply_TryMode_CrushNoSessionEndCorruption: crush has no session_end
+// event, so try-mode auto-revert injection must be skipped rather than writing
+// a dead CC-shape hooks.SessionEnd group into the real crush.json. A warning
+// tells the user to revert manually (syllago-xqlc1, codex review finding).
+func TestApply_TryMode_CrushNoSessionEndCorruption(t *testing.T) {
+	t.Parallel()
+	homeDir := t.TempDir()
+	projectRoot := t.TempDir()
+	os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755)
+
+	ruleDir := filepath.Join(projectRoot, "content", "rules", "crush", "my-rule")
+	os.MkdirAll(ruleDir, 0755)
+	os.WriteFile(filepath.Join(ruleDir, "AGENTS.md"), []byte("# Rule"), 0644)
+
+	manifest := &Manifest{
+		Kind:     "loadout",
+		Version:  1,
+		Provider: "crush",
+		Name:     "crush-try",
+		Rules:    []ItemRef{{Name: "my-rule"}},
+	}
+	cat := &catalog.Catalog{
+		RepoRoot: projectRoot,
+		Items: []catalog.ContentItem{
+			{Name: "my-rule", Type: catalog.Rules, Provider: "crush", Path: ruleDir},
+		},
+	}
+	prov := provider.Provider{
+		Name:      "Crush",
+		Slug:      "crush",
+		ConfigDir: ".config/crush",
+		InstallDir: func(home string, ct catalog.ContentType) string {
+			if ct == catalog.Rules {
+				return filepath.Join(home, ".config", "crush", "rules")
+			}
+			return ""
+		},
+		SupportsType: func(ct catalog.ContentType) bool { return ct == catalog.Rules },
+	}
+
+	opts := ApplyOptions{
+		Mode:        "try",
+		ProjectRoot: projectRoot,
+		HomeDir:     homeDir,
+		RepoRoot:    projectRoot,
+	}
+
+	result, err := Apply(manifest, cat, prov, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.AutoRevertArmed {
+		t.Error("crush has no session_end event, so AutoRevertArmed should be false")
+	}
+
+	// crush.json must not have been created/corrupted by SessionEnd injection.
+	crushPath := filepath.Join(homeDir, ".config", "crush", "crush.json")
+	if data, statErr := os.ReadFile(crushPath); statErr == nil {
+		if gjson.GetBytes(data, "hooks").Exists() {
+			t.Errorf("crush.json should have no injected hooks, got: %s", data)
+		}
+	}
+
+	// The user must be warned that auto-revert is unavailable.
+	var warned bool
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "auto-revert") || strings.Contains(w, "session-end") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("expected a no-auto-revert warning, got warnings: %v", result.Warnings)
+	}
 }

--- a/cli/internal/loadout/preview.go
+++ b/cli/internal/loadout/preview.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/converter"
 	"github.com/OpenScribbler/syllago/cli/internal/installer"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
 )
@@ -15,9 +16,9 @@ import (
 type PlannedAction struct {
 	Type    catalog.ContentType
 	Name    string
-	Action  string // "create-symlink", "merge-hook", "merge-mcp", "skip-exists", "error-conflict"
+	Action  string // "create-symlink", "merge-hook", "merge-mcp", "skip-exists", "skip-unsupported", "error-conflict"
 	Detail  string // human-readable path or description
-	Problem string // non-empty if Action == "error-conflict"
+	Problem string // non-empty if Action == "error-conflict" or "skip-unsupported"
 }
 
 // Preview computes all actions without modifying any files.
@@ -51,7 +52,7 @@ func Preview(refs []ResolvedRef, prov provider.Provider, repoRoot string, homeDi
 func previewOne(ref ResolvedRef, prov provider.Provider, homeDir string, inst *installer.Installed, resolver *config.PathResolver) (PlannedAction, error) {
 	switch ref.Type {
 	case catalog.Hooks:
-		return previewHook(ref, inst), nil
+		return previewHook(ref, prov, inst), nil
 	case catalog.MCP:
 		return previewMCP(ref, inst), nil
 	default:
@@ -129,8 +130,9 @@ func previewSymlink(ref ResolvedRef, prov provider.Provider, homeDir string, res
 	}, nil
 }
 
-// previewHook checks installed.json for an existing hook entry.
-func previewHook(ref ResolvedRef, inst *installer.Installed) PlannedAction {
+// previewHook checks installed.json for an existing hook entry and whether
+// the target provider can read the hook's event at all.
+func previewHook(ref ResolvedRef, prov provider.Provider, inst *installer.Installed) PlannedAction {
 	// Check if any hook with this name is already installed (any event)
 	for _, h := range inst.Hooks {
 		if h.Name == ref.Name {
@@ -142,12 +144,51 @@ func previewHook(ref ResolvedRef, inst *installer.Installed) PlannedAction {
 			}
 		}
 	}
+
+	// A hook whose event is a real event the provider simply has no settings
+	// key for would merge as dead config the provider never reads
+	// (syllago-xqlc1). Plan it as skip-unsupported so Apply can gate on it and
+	// --skip-unsupported can pass it over. The IsValidHookEvent guard is
+	// deliberate: an unknown/malformed event is NOT skippable — it stays a
+	// merge-hook action so applyHook raises the hard injection-guard error,
+	// which fires even under --skip-unsupported. A missing or unparseable hook
+	// file likewise stays merge-hook so applyHook reports the real error.
+	if event, ok := hookEvent(ref.Item.Path); ok &&
+		converter.IsValidHookEvent(event) &&
+		!converter.ProviderSupportsHookEvent(event, prov.Slug) {
+		return PlannedAction{
+			Type:    ref.Type,
+			Name:    ref.Name,
+			Action:  "skip-unsupported",
+			Detail:  fmt.Sprintf("hook %s not applied", ref.Name),
+			Problem: fmt.Sprintf("%s does not support hook event %q", prov.Name, event),
+		}
+	}
+
 	return PlannedAction{
 		Type:   ref.Type,
 		Name:   ref.Name,
 		Action: "merge-hook",
 		Detail: fmt.Sprintf("merge hook %s into settings.json", ref.Name),
 	}
+}
+
+// hookEvent reads the event name from a hook item's hook.json. Returns
+// ok=false when the file is missing or malformed.
+func hookEvent(itemDir string) (string, bool) {
+	hookFile := findHookFile(itemDir)
+	if hookFile == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(hookFile)
+	if err != nil {
+		return "", false
+	}
+	manifest, err := converter.ParseManifest(data)
+	if err != nil || len(manifest.Hooks) != 1 {
+		return "", false
+	}
+	return manifest.Hooks[0].Event, true
 }
 
 // previewMCP checks installed.json for an existing MCP entry.

--- a/cli/internal/loadout/preview_test.go
+++ b/cli/internal/loadout/preview_test.go
@@ -3,6 +3,7 @@ package loadout
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
@@ -323,5 +324,87 @@ func TestPreview_RegularFileConflict(t *testing.T) {
 	}
 	if actions[0].Action != "error-conflict" {
 		t.Errorf("expected error-conflict for regular file, got %s", actions[0].Action)
+	}
+}
+
+// TestPreview_HookUnsupportedEvent: a hook whose event the target provider
+// has no settings key for is planned as "skip-unsupported" instead of
+// "merge-hook", so Apply can gate on it (syllago-xqlc1). before_tool_execute
+// has no windsurf mapping — merging it would write dead config windsurf
+// never reads.
+func TestPreview_HookUnsupportedEvent(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	os.MkdirAll(filepath.Join(repoRoot, ".syllago"), 0755)
+
+	hookDir := filepath.Join(repoRoot, "hooks", "dead-hook")
+	os.MkdirAll(hookDir, 0755)
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"before_tool_execute","handler":{"type":"command","command":"echo hi"}}]}`
+	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
+
+	prov := provider.Provider{
+		Name: "Windsurf",
+		Slug: "windsurf",
+		InstallDir: func(home string, ct catalog.ContentType) string {
+			return "__json_merge__"
+		},
+	}
+
+	refs := []ResolvedRef{
+		{Type: catalog.Hooks, Name: "dead-hook", Item: catalog.ContentItem{
+			Name: "dead-hook", Type: catalog.Hooks, Path: hookDir,
+		}},
+	}
+
+	actions, err := Preview(refs, prov, repoRoot, t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if actions[0].Action != "skip-unsupported" {
+		t.Errorf("expected skip-unsupported, got %s", actions[0].Action)
+	}
+	if !strings.Contains(actions[0].Problem, "before_tool_execute") {
+		t.Errorf("problem should name the event, got %q", actions[0].Problem)
+	}
+}
+
+// TestPreview_HookInvalidEvent: a hook with an unknown/malformed event name is
+// NOT plannable as skip-unsupported — it must stay a merge-hook action so
+// applyHook raises the hard injection-guard error, which fires even under
+// --skip-unsupported. Only real-but-unmapped events are skippable
+// (syllago-xqlc1, codex review finding).
+func TestPreview_HookInvalidEvent(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	os.MkdirAll(filepath.Join(repoRoot, ".syllago"), 0755)
+
+	hookDir := filepath.Join(repoRoot, "hooks", "bad-hook")
+	os.MkdirAll(hookDir, 0755)
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"not_a_real_event","handler":{"type":"command","command":"echo hi"}}]}`
+	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
+
+	prov := provider.Provider{
+		Name: "Windsurf",
+		Slug: "windsurf",
+		InstallDir: func(home string, ct catalog.ContentType) string {
+			return "__json_merge__"
+		},
+	}
+
+	refs := []ResolvedRef{
+		{Type: catalog.Hooks, Name: "bad-hook", Item: catalog.ContentItem{
+			Name: "bad-hook", Type: catalog.Hooks, Path: hookDir,
+		}},
+	}
+
+	actions, err := Preview(refs, prov, repoRoot, t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if actions[0].Action != "merge-hook" {
+		t.Errorf("invalid event should stay merge-hook (so applyHook errors), got %s", actions[0].Action)
 	}
 }

--- a/cli/internal/telemetry/catalog.go
+++ b/cli/internal/telemetry/catalog.go
@@ -124,6 +124,13 @@ func EventCatalog() []EventDef {
 					Commands:    []string{"loadout_apply", "add"},
 				},
 				{
+					Name:        "skip_unsupported",
+					Type:        "bool",
+					Description: "Whether --skip-unsupported was used to apply past provider-unsupported hooks",
+					Example:     false,
+					Commands:    []string{"loadout_apply"},
+				},
+				{
 					Name:        "discovery_candidate_count",
 					Type:        "int",
 					Description: "Number of monolithic rule files considered by add (D18)",

--- a/cli/telemetry.json
+++ b/cli/telemetry.json
@@ -146,6 +146,15 @@
           ]
         },
         {
+          "name": "skip_unsupported",
+          "type": "bool",
+          "description": "Whether --skip-unsupported was used to apply past provider-unsupported hooks",
+          "example": false,
+          "commands": [
+            "loadout_apply"
+          ]
+        },
+        {
           "name": "discovery_candidate_count",
           "type": "int",
           "description": "Number of monolithic rule files considered by add (D18)",


### PR DESCRIPTION
## Summary

Fixes syllago-xqlc1: two related gaps in the hook JSON-merge paths that wrote dead config the target provider never reads, while reporting success.

**Dead-config events.** `installHook` and loadout `applyHook` treated `TranslateHookEvent` ok=false as "already native", but it also means "known canonical event with no mapping for this provider." `before_tool_execute` to windsurf, or `session_end` to crush, merged under a settings key the provider never reads. New `converter.ProviderSupportsHookEvent` (canonical-with-mapping OR the provider's own native name) gates both merge paths, and also rejects another provider's native name reaching the wrong provider.

**Loadout crush handling.** Loadout apply had no crush support: it merged a CC-shape matcher group into a `settings.json` crush never reads. It now routes crush hooks to `crush.json` as flat entries via the shared `installer.FlattenForCrush`.

**Partial apply.** A loadout containing a hook the provider can't read now fails the whole apply rather than silently landing at partial coverage. `--skip-unsupported` applies the compatible items and reports what was skipped.

**Try-mode auto-revert.** `injectSessionEndHook` now translates `session_end` to the native key and skips injection when the provider lacks the event (crush), so `crush.json` is never corrupted; the CLI reports when auto-revert is unavailable.

## Testing

- New unit + integration tests: event-support predicate, install rejection (both doors), loadout preview skip-unsupported classification, apply gate + `--skip-unsupported`, crush flatten+route, crush try-mode no-corruption, invalid-event-stays-hard-error.
- Full `make test` suite green; `make fmt` clean; binary rebuilt and installed.
- Independent codex review (2 rounds): both initial findings and one follow-up UX finding fixed.

Reviewed for ADR-0001 (hook degradation enforcement) compliance: this strengthens the no-silent-degradation posture and does not modify degradation logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)