### PR TITLE
Refresh sigstore trusted-root freshness date (re-verified against v1.2.0)

### DIFF
--- a/cli/internal/moat/sigstore_verify_test.go
+++ b/cli/internal/moat/sigstore_verify_test.go
@@ -13,8 +13,11 @@ import (
 // beyond trustedRootMaxAge, which is how we avoid silently passing sigstore
 // tests against stale Fulcio / Rekor root material.
 //
-// Source: sigstore-go v1.1.4 examples/trusted-root.json.
-var trustedRootCapturedAt = time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC)
+// Source: sigstore-go v1.2.0 examples/trusted-root-public-good.json
+// (byte-identical to the prior v1.1.4 capture — the public-good Fulcio/Rekor
+// material did not rotate; re-verified against the pinned sigstore-go version
+// on the date below, so no fixture bytes or downstream bundle fixtures changed).
+var trustedRootCapturedAt = time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC)
 
 // trustedRootMaxAge is the upper bound beyond which the fixture is
 // considered stale enough to fail tests. 90 days is long enough to avoid


### PR DESCRIPTION
## Summary

`internal/moat`'s `TestTrustedRootFixture_FreshnessWindow` is a deliberate 90-day time-bomb guarding `testdata/trusted-root-public-good.json` against silently drifting past a Fulcio/Rekor key rotation. The fixture (captured 2026-04-17) hit the cap, turning main's CI red and blocking all merges.

Fetched sigstore-go **v1.2.0**'s `examples/trusted-root-public-good.json` (our pinned verifier version) and confirmed it is **byte-identical** to the bundled fixture — the public-good trust material has not rotated. Bumped `trustedRootCapturedAt` to 2026-07-15. No fixture bytes changed and no downstream signed-bundle fixtures (`syllago-guide.*`) needed regeneration; `go test ./internal/moat/...` is green.

Test-only, one file. Unblocks all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)