### PR TITLE
Route hook install/apply through per-provider adapters (ADR-0020 Phase 1)

### DIFF
--- a/cli/internal/installer/hookadapter.go
+++ b/cli/internal/installer/hookadapter.go
@@ -1,0 +1,334 @@
+package installer
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/OpenScribbler/syllago/cli/internal/converter"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// hookStorageModel classifies how a provider persists its hooks on disk.
+// ADR-0020 identifies three models; Phase 1 implements the two home-scoped,
+// unambiguous ones. Directory-scoped hooks are deferred to Phase 1b.
+type hookStorageModel int
+
+const (
+	// hookStorageSharedJSON is a shared config file whose top-level `hooks`
+	// key must be merged, never overwritten (sibling keys like permissions,
+	// env, and MCP servers must survive). claude-code, crush, cursor,
+	// gemini-cli, factory-droid.
+	hookStorageSharedJSON hookStorageModel = iota
+	// hookStorageDedicatedFile is a whole file that holds only hooks and can
+	// be written verbatim. windsurf.
+	hookStorageDedicatedFile
+)
+
+// hookStorageModelFor classifies a provider's hook storage and reports whether
+// syllago can install its hooks in ADR-0020 Phase 1.
+//
+// Directory-scoped providers (copilot-cli → .github/hooks/, kiro →
+// .kiro/agents/, pi → .pi/extensions/) have adapters but an unresolved
+// project-vs-home layout question, so they are rejected pending Phase 1b rather
+// than half-implemented. amp/codex have no adapter and are rejected by the
+// caller before reaching here.
+func hookStorageModelFor(slug string) (hookStorageModel, error) {
+	switch slug {
+	case "claude-code", "crush", "cursor", "gemini-cli", "factory-droid":
+		return hookStorageSharedJSON, nil
+	case "windsurf":
+		return hookStorageDedicatedFile, nil
+	case "copilot-cli", "kiro", "pi":
+		return 0, fmt.Errorf("hook install for %s is not yet supported (pending ADR-0020 Phase 1b: directory-scoped hook layout)", slug)
+	default:
+		return 0, fmt.Errorf("hook install not supported for %s", slug)
+	}
+}
+
+// HookConfigPath resolves a provider's hook file per ADR-0020's path table,
+// rooted at base (a home directory or a resolver-supplied base dir). It is the
+// single source of truth for hook file locations — installer.hookSettingsPathImpl,
+// the loadout apply path, and orphan detection all route through it so no flow
+// can diverge onto a wrong path. Returns an error for providers whose hooks
+// syllago cannot manage in Phase 1 (directory-scoped and adapter-less).
+//
+// ConfigLocations is intentionally NOT consulted — it is inconsistent across
+// providers, which is the root of the "dead config" bug this work fixes.
+func HookConfigPath(prov provider.Provider, base string) (string, error) {
+	switch prov.Slug {
+	case "crush":
+		// Crush keeps hooks in its unified crush.json (XDG global config).
+		return filepath.Join(base, ".config", "crush", "crush.json"), nil
+	case "windsurf":
+		// Windsurf keeps hooks in a dedicated home-scoped hooks.json.
+		return filepath.Join(base, ".windsurf", "hooks.json"), nil
+	case "claude-code", "cursor", "gemini-cli", "factory-droid":
+		return filepath.Join(base, prov.ConfigDir, "settings.json"), nil
+	case "copilot-cli", "kiro", "pi":
+		return "", fmt.Errorf("hook install for %s is not yet supported (pending ADR-0020 Phase 1b: directory-scoped hook layout)", prov.Slug)
+	default:
+		return "", fmt.Errorf("hook install not supported for %s", prov.Slug)
+	}
+}
+
+// manifestHookToCanonical converts a spec Manifest hook into the enhanced
+// canonical form the HookAdapters encode/decode. The manifest matcher is a bare
+// string; the canonical matcher is a json.RawMessage (a JSON-encoded string).
+func manifestHookToCanonical(h converter.Hook) (converter.CanonicalHook, error) {
+	ch := converter.CanonicalHook{
+		Name:     h.Name,
+		Event:    h.Event,
+		Blocking: h.Blocking,
+		Handler: converter.HookHandler{
+			Type:           h.Handler.Type,
+			Command:        h.Handler.Command,
+			Platform:       h.Handler.Platform,
+			CWD:            h.Handler.Cwd,
+			Env:            h.Handler.Env,
+			Timeout:        h.Handler.Timeout,
+			TimeoutAction:  h.Handler.TimeoutAction,
+			StatusMessage:  h.Handler.StatusMessage,
+			Async:          h.Handler.Async,
+			URL:            h.Handler.URL,
+			Headers:        h.Handler.Headers,
+			AllowedEnvVars: h.Handler.AllowedEnvVars,
+			Prompt:         h.Handler.Prompt,
+			Model:          h.Handler.Model,
+			Agent:          h.Handler.Agent,
+		},
+	}
+	if ch.Handler.Type == "" {
+		ch.Handler.Type = "command"
+	}
+	if h.Matcher != "" {
+		m, err := json.Marshal(h.Matcher)
+		if err != nil {
+			return converter.CanonicalHook{}, err
+		}
+		ch.Matcher = m
+	}
+	if len(h.Provider) > 0 {
+		var pd map[string]any
+		if err := json.Unmarshal(h.Provider, &pd); err == nil {
+			ch.ProviderData = pd
+		}
+	}
+	return ch, nil
+}
+
+// canonicalizeEvent normalizes a hook event name to its canonical form. An
+// event that is already a canonical key is returned unchanged; a provider-native
+// name is reverse-translated using the target provider's mapping.
+func canonicalizeEvent(event, slug string) string {
+	if _, ok := converter.HookEvents[event]; ok {
+		return event
+	}
+	return converter.ReverseTranslateHookEvent(event, slug)
+}
+
+// nativeEventFor returns the provider-native event key for tracking/dedup. When
+// the canonical event has no direct mapping for the provider (e.g. windsurf,
+// whose adapter synthesizes split events), the canonical name is used as-is;
+// install/uninstall/status all compute it the same way, so lookups stay
+// consistent.
+func nativeEventFor(canonEvent, slug string) string {
+	if nv, ok := converter.TranslateHookEvent(canonEvent, slug); ok {
+		return nv
+	}
+	return canonEvent
+}
+
+// adapterSupportsEvent reports whether the provider's adapter can represent a
+// canonical event. Adapter capabilities are the ADR-0020 canonical source of
+// truth for event support; this is broader than ProviderSupportsHookEvent
+// because it also recognizes providers (windsurf) whose adapter fans a single
+// canonical event out to several provider-native split events.
+//
+// KNOWN, INTENTIONAL ASYMMETRY: direct `syllago install` gates hook events with
+// this adapter-capability check, so e.g. a windsurf before_tool_execute hook
+// installs. Loadout Preview still gates with converter.ProviderSupportsHookEvent
+// (which does not see split-event support), so the same hook is reported
+// skip-unsupported inside a loadout. This is a UX inconsistency, not dead config
+// — nothing wrong ever gets written. Reconciling Preview onto adapter
+// capabilities is deferred follow-up; do not "fix" it by loosening Preview here.
+func adapterSupportsEvent(adapter converter.HookAdapter, canonEvent string) bool {
+	for _, e := range adapter.Capabilities().Events {
+		if e == canonEvent {
+			return true
+		}
+	}
+	return false
+}
+
+// hookIdentity hashes a hook's post-round-trip canonical identity
+// (event|matcher|command|name). Computed on the decoded form so it is stable
+// across lossy adapter transforms (e.g. windsurf wrapping a non-blocking
+// command in `(cmd) || true`) and across whole-file re-serialization when other
+// hooks are added or removed.
+func hookIdentity(h converter.CanonicalHook) string {
+	sum := sha256.Sum256([]byte(h.Event + "|" + string(h.Matcher) + "|" + h.Handler.Command + "|" + h.Name))
+	return hex.EncodeToString(sum[:])
+}
+
+// roundTripIdentity encodes a single canonical hook, decodes it back through the
+// same adapter, and returns the identity of the result. Returns an error if the
+// adapter drops the hook entirely (e.g. a non-command handler on crush), which
+// callers treat as "provider cannot represent this hook".
+func roundTripIdentity(adapter converter.HookAdapter, canonHook converter.CanonicalHook) (string, error) {
+	enc, err := adapter.Encode(&converter.CanonicalHooks{Spec: converter.SpecVersion, Hooks: []converter.CanonicalHook{canonHook}})
+	if err != nil {
+		return "", fmt.Errorf("encoding hook: %w", err)
+	}
+	rt, err := adapter.Decode(enc.Content)
+	if err != nil {
+		return "", fmt.Errorf("verifying encoded hook: %w", err)
+	}
+	if len(rt.Hooks) == 0 {
+		return "", fmt.Errorf("hook cannot be represented by %s", adapter.ProviderSlug())
+	}
+	return hookIdentity(rt.Hooks[0]), nil
+}
+
+// decodeExistingHooks reads the provider's hook file and decodes it through the
+// adapter. For shared-JSON providers the adapter reads only the `hooks` key,
+// ignoring sibling config. A missing or empty file yields no hooks.
+func decodeExistingHooks(adapter converter.HookAdapter, path string) ([]converter.CanonicalHook, error) {
+	data, err := readJSONFile(path) // returns {} when the file is absent
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	ch, err := adapter.Decode(data)
+	if err != nil {
+		return nil, fmt.Errorf("decoding existing hooks in %s: %w", path, err)
+	}
+	return ch.Hooks, nil
+}
+
+// writeHookFile persists an adapter's encoded hooks according to the storage
+// model. Dedicated-file providers get the whole encoded file; shared-JSON
+// providers get only the encoded `hooks` object merged into the real file,
+// preserving every non-hook key.
+func writeHookFile(model hookStorageModel, path string, encoded []byte) error {
+	if model == hookStorageDedicatedFile {
+		return writeJSONFile(path, encoded)
+	}
+
+	real, err := readJSONFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+	if len(real) == 0 {
+		real = []byte("{}")
+	}
+	hooksRaw := []byte("{}")
+	if hv := gjson.GetBytes(encoded, "hooks"); hv.Exists() {
+		hooksRaw = []byte(hv.Raw)
+	}
+	real, err = sjson.SetRawBytes(real, "hooks", hooksRaw)
+	if err != nil {
+		return fmt.Errorf("merging hooks into %s: %w", path, err)
+	}
+	return writeJSONFile(path, real)
+}
+
+// ApplyHookResult is the tracking data produced by merging one hook through the
+// adapter path.
+type ApplyHookResult struct {
+	NativeEvent string // provider-native event key (or canonical when unmapped)
+	Command     string // resolved handler command, for installed.json
+	GroupHash   string // post-round-trip canonical identity
+}
+
+// ApplyCanonicalHook merges one manifest hook into the provider's hook file at
+// path via the provider's HookAdapter (ADR-0020 Phase 1), preserving sibling
+// keys for shared-JSON providers. The path is caller-supplied so callers can
+// use their own resolver; resolvedCommand, when non-empty, overrides the hook's
+// handler command (callers resolve script/relative paths first).
+//
+// This is the loadout apply entry point; installHook uses the same building
+// blocks directly because it interleaves snapshotting and dedup.
+func ApplyCanonicalHook(prov provider.Provider, h converter.Hook, path, resolvedCommand string) (ApplyHookResult, error) {
+	adapter := converter.AdapterFor(prov.Slug)
+	if adapter == nil {
+		return ApplyHookResult{}, fmt.Errorf("hook install not supported for %s (no encoder)", prov.Name)
+	}
+	model, err := hookStorageModelFor(prov.Slug)
+	if err != nil {
+		return ApplyHookResult{}, err
+	}
+
+	canonHook, err := manifestHookToCanonical(h)
+	if err != nil {
+		return ApplyHookResult{}, fmt.Errorf("building canonical hook: %w", err)
+	}
+	canonEvent := canonicalizeEvent(h.Event, prov.Slug)
+	canonHook.Event = canonEvent
+	if resolvedCommand != "" {
+		canonHook.Handler.Command = resolvedCommand
+	}
+
+	if !adapterSupportsEvent(adapter, canonEvent) {
+		return ApplyHookResult{}, fmt.Errorf("hook %q: %s does not support hook event %q", h.Name, prov.Name, h.Event)
+	}
+
+	groupHash, err := roundTripIdentity(adapter, canonHook)
+	if err != nil {
+		return ApplyHookResult{}, err
+	}
+
+	existing, err := decodeExistingHooks(adapter, path)
+	if err != nil {
+		return ApplyHookResult{}, err
+	}
+	all := make([]converter.CanonicalHook, 0, len(existing)+1)
+	all = append(all, existing...)
+	all = append(all, canonHook)
+
+	encoded, err := adapter.Encode(&converter.CanonicalHooks{Spec: converter.SpecVersion, Hooks: all})
+	if err != nil {
+		return ApplyHookResult{}, fmt.Errorf("encoding hooks: %w", err)
+	}
+	if err := writeHookFile(model, path, encoded.Content); err != nil {
+		return ApplyHookResult{}, err
+	}
+
+	return ApplyHookResult{
+		NativeEvent: nativeEventFor(canonEvent, prov.Slug),
+		Command:     canonHook.Handler.Command,
+		GroupHash:   groupHash,
+	}, nil
+}
+
+// readSingleManifestHook reads a canonical hook.json (hooks/0.1 Manifest) and
+// returns its single hook. If path is a directory, hook.json inside it is used.
+// Syllago-written hook.json always contains exactly one hook.
+func readSingleManifestHook(path string) (converter.Hook, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return converter.Hook{}, err
+	}
+	if fi.IsDir() {
+		path = filepath.Join(path, "hook.json")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return converter.Hook{}, err
+	}
+	m, err := converter.ParseManifest(data)
+	if err != nil {
+		return converter.Hook{}, err
+	}
+	if len(m.Hooks) != 1 {
+		return converter.Hook{}, fmt.Errorf("hook file has %d hooks; syllago hook.json must contain exactly 1", len(m.Hooks))
+	}
+	return m.Hooks[0], nil
+}

--- a/cli/internal/installer/hookadapter.go
+++ b/cli/internal/installer/hookadapter.go
@@ -43,7 +43,13 @@ func hookStorageModelFor(slug string) (hookStorageModel, error) {
 	case "claude-code", "crush", "cursor", "gemini-cli", "factory-droid":
 		return hookStorageSharedJSON, nil
 	case "windsurf":
-		return hookStorageDedicatedFile, nil
+		// Deferred: windsurf's adapter fans one before_tool_execute hook out to
+		// four split-events and only merges them back on decode when each has
+		// exactly one entry. A second windsurf hook breaks that precondition, so
+		// a hook's post-round-trip identity is not stable across installs —
+		// uninstall/status/orphans can't reliably match it. Needs a stable
+		// per-entry identity (a syllago marker), which is Phase 1b work.
+		return 0, fmt.Errorf("hook install for windsurf is not yet supported (pending ADR-0020 Phase 1b: split-event fan-out needs a stable per-entry identity)")
 	case "copilot-cli", "kiro", "pi":
 		return 0, fmt.Errorf("hook install for %s is not yet supported (pending ADR-0020 Phase 1b: directory-scoped hook layout)", slug)
 	default:
@@ -65,11 +71,12 @@ func HookConfigPath(prov provider.Provider, base string) (string, error) {
 	case "crush":
 		// Crush keeps hooks in its unified crush.json (XDG global config).
 		return filepath.Join(base, ".config", "crush", "crush.json"), nil
-	case "windsurf":
-		// Windsurf keeps hooks in a dedicated home-scoped hooks.json.
-		return filepath.Join(base, ".windsurf", "hooks.json"), nil
 	case "claude-code", "cursor", "gemini-cli", "factory-droid":
 		return filepath.Join(base, prov.ConfigDir, "settings.json"), nil
+	case "windsurf":
+		// Deferred to Phase 1b — see hookStorageModelFor for why. The Phase 1b
+		// path will be base/.windsurf/hooks.json (dedicated file).
+		return "", fmt.Errorf("hook install for windsurf is not yet supported (pending ADR-0020 Phase 1b: split-event fan-out needs a stable per-entry identity)")
 	case "copilot-cli", "kiro", "pi":
 		return "", fmt.Errorf("hook install for %s is not yet supported (pending ADR-0020 Phase 1b: directory-scoped hook layout)", prov.Slug)
 	default:
@@ -213,10 +220,24 @@ func decodeExistingHooks(adapter converter.HookAdapter, path string) ([]converte
 	return ch.Hooks, nil
 }
 
+// KNOWN PHASE-2 CONCERN (decode → encode-all): install/uninstall re-serialize
+// the ENTIRE hooks set on every mutation, not just the changed entry. Two
+// consequences, both tracked for Phase 2:
+//   (a) Fidelity — any provider-native field an adapter does not model is
+//       dropped from previously-installed hooks when they are re-encoded.
+//   (b) Determinism — adapters iterate Go maps (event → groups), so event-key
+//       ordering is non-deterministic across writes, churning users' config
+//       diffs even when nothing semantically changed.
+// Phase 2 makes adapter encoding deterministic and promotes adapter.Verify to a
+// production-load-bearing fidelity check. Until then this is acceptable because
+// the routed providers (claude-code, crush, cursor, gemini-cli, factory-droid)
+// model the fields syllago writes.
+
 // writeHookFile persists an adapter's encoded hooks according to the storage
 // model. Dedicated-file providers get the whole encoded file; shared-JSON
 // providers get only the encoded `hooks` object merged into the real file,
-// preserving every non-hook key.
+// preserving every non-hook key. The dedicated-file branch is Phase 1b infra —
+// no Phase 1 provider routes to it (see hookStorageModelFor).
 func writeHookFile(model hookStorageModel, path string, encoded []byte) error {
 	if model == hookStorageDedicatedFile {
 		return writeJSONFile(path, encoded)

--- a/cli/internal/installer/hooks.go
+++ b/cli/internal/installer/hooks.go
@@ -3,7 +3,6 @@ package installer
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,6 +19,7 @@ import (
 )
 
 // computeGroupHash computes the SHA256 hex hash of a matcher group JSON blob.
+// Retained for orphan detection (orphans.go), which hashes raw settings entries.
 func computeGroupHash(matcherGroup []byte) string {
 	hash := sha256.Sum256(matcherGroup)
 	return hex.EncodeToString(hash[:])
@@ -29,132 +29,61 @@ func computeGroupHash(matcherGroup []byte) string {
 // Declared as a var so tests can override it (same pattern as mcpConfigPath).
 var hookSettingsPath = hookSettingsPathImpl
 
+// hookSettingsPathImpl resolves a provider's hook file rooted at the user's
+// home directory, via the shared HookConfigPath resolver (ADR-0020 path table).
 func hookSettingsPathImpl(prov provider.Provider) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	if prov.Slug == "crush" {
-		// Crush keeps hooks in its unified crush.json (global scope), not a
-		// settings.json.
-		return filepath.Join(home, ".config", "crush", "crush.json"), nil
-	}
-	return filepath.Join(home, prov.ConfigDir, "settings.json"), nil
-}
-
-// parseHookFile reads a canonical hook.json (hooks/0.1 Manifest) and returns
-// the event, the manifest's optional hook name, and a provider-settings
-// matcher group JSON built from the single hook's handler. If path is a
-// directory, resolves hook.json inside it.
-//
-// The returned matcher group has shape {matcher, hooks:[entry]} — the same
-// shape provider settings.json expects. Syllago-written hook.json always
-// contains exactly one hook per Manifest (see converter.SplitSettingsHooks).
-func parseHookFile(path string) (event string, hookName string, matcherGroup []byte, err error) {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return "", "", nil, err
-	}
-	if fi.IsDir() {
-		path = filepath.Join(path, "hook.json")
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", "", nil, err
-	}
-
-	manifest, err := converter.ParseManifest(data)
-	if err != nil {
-		return "", "", nil, err
-	}
-	if len(manifest.Hooks) != 1 {
-		return "", "", nil, fmt.Errorf("hook file has %d hooks; syllago hook.json must contain exactly 1", len(manifest.Hooks))
-	}
-
-	hds, err := converter.HookDataFromManifest(manifest)
-	if err != nil {
-		return "", "", nil, fmt.Errorf("converting manifest: %w", err)
-	}
-	hd := hds[0]
-
-	// Build the provider-shape matcher group: {matcher, hooks:[entry]}.
-	group := struct {
-		Matcher string                `json:"matcher,omitempty"`
-		Hooks   []converter.HookEntry `json:"hooks"`
-	}{
-		Matcher: hd.Matcher,
-		Hooks:   hd.Hooks,
-	}
-	matcherGroup, err = json.Marshal(group)
-	if err != nil {
-		return "", "", nil, fmt.Errorf("building matcher group: %w", err)
-	}
-
-	return hd.Event, manifest.Hooks[0].Name, matcherGroup, nil
+	return HookConfigPath(prov, home)
 }
 
 func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot string) (string, error) {
-	// item.Path is already absolute (set by scanner)
-	event, hookName, matcherGroup, err := parseHookFile(item.Path)
+	// item.Path is already absolute (set by scanner).
+	h, err := readSingleManifestHook(item.Path)
 	if err != nil {
 		return "", fmt.Errorf("parsing hook file: %w", err)
 	}
 
-	// M3: Validate event name to prevent sjson key injection via dots
-	if !converter.IsValidHookEvent(event) {
-		return "", fmt.Errorf("unknown hook event %q: must be a known canonical or provider event name", event)
+	// M3: validate the event name (rejects garbage and prevents key injection).
+	if !converter.IsValidHookEvent(h.Event) {
+		return "", fmt.Errorf("unknown hook event %q: must be a known canonical or provider event name", h.Event)
 	}
 
-	// Reject events the provider has no settings key for (canonical events
-	// with no mapping for this provider, or another provider's native name).
-	// Merging those writes config under a key the provider never reads —
-	// silently dead, reported as success (syllago-xqlc1).
-	if !converter.ProviderSupportsHookEvent(event, prov.Slug) {
-		return "", fmt.Errorf("hook %q: %s does not support hook event %q", item.Name, prov.Name, event)
+	// ADR-0020: install through the provider's HookAdapter. No adapter (amp,
+	// codex) means the hook cannot be serialized — reject rather than write
+	// config the provider never reads.
+	adapter := converter.AdapterFor(prov.Slug)
+	if adapter == nil {
+		return "", fmt.Errorf("hook install not supported for %s (no encoder)", prov.Name)
 	}
 
-	// Translate canonical event names (e.g. "before_tool_execute") to the
-	// provider-native key (e.g. "PreToolUse") so the hook lands under the
-	// JSON path the provider actually reads. If the event is already
-	// native for this provider, TranslateHookEvent returns ok=false and
-	// we keep the event as-is.
-	if nativeEvent, ok := converter.TranslateHookEvent(event, prov.Slug); ok {
-		event = nativeEvent
-	}
-
-	// M4: Whitelist-filter the matcher group through a typed struct to strip
-	// unknown JSON fields before merging into settings.json.
-	matcherGroup, err = whitelistMatcherGroup(matcherGroup)
+	// Classify storage. Directory-scoped providers (copilot-cli, kiro, pi) are
+	// rejected pending Phase 1b.
+	model, err := hookStorageModelFor(prov.Slug)
 	if err != nil {
-		return "", fmt.Errorf("filtering matcher group: %w", err)
+		return "", err
 	}
 
-	// Translate canonical matcher tool names (e.g. "shell") to the
-	// provider-native names the provider tests its hook regexes against
-	// (e.g. "Bash" for claude-code). Library hook.json stores canonical
-	// matchers, so without this the merged regex silently never fires.
-	// Wildcards, MCP-style patterns, and already-native names pass
-	// through TranslateMatcher unchanged.
-	if matcher := gjson.GetBytes(matcherGroup, "matcher").String(); matcher != "" {
-		translated := converter.TranslateMatcher(matcher, prov.Slug)
-		if translated != matcher {
-			matcherGroup, err = sjson.SetBytes(matcherGroup, "matcher", translated)
-			if err != nil {
-				return "", fmt.Errorf("translating matcher: %w", err)
-			}
-		}
+	canonHook, err := manifestHookToCanonical(h)
+	if err != nil {
+		return "", fmt.Errorf("building canonical hook: %w", err)
+	}
+	canonEvent := canonicalizeEvent(h.Event, prov.Slug)
+	canonHook.Event = canonEvent
+
+	// Event-support gate: reject events the adapter cannot represent. Adapter
+	// capabilities are ADR-0020's source of truth (they see windsurf's
+	// split-event support, which ProviderSupportsHookEvent misses).
+	if !adapterSupportsEvent(adapter, canonEvent) {
+		return "", fmt.Errorf("hook %q: %s does not support hook event %q", item.Name, prov.Name, h.Event)
 	}
 
-	// M2: Run the pluggable scanner chain (builtin + any --hook-scanner paths)
-	// against the source hook directory. The builtin scanner examines hook.json
-	// and any recognized script files; external scanners run as subprocesses
-	// per the protocol in docs/plans/implementation/pluggable-scanner.md.
-	//
-	// High-severity findings block the install unless --force was supplied.
-	// Lower severities print warnings and proceed.
+	// SECURITY (M2): run the pluggable scanner chain against the source hook
+	// directory. High-severity findings block the install unless --force.
 	itemDir := item.Path
-	if fi, err := os.Stat(item.Path); err == nil && !fi.IsDir() {
+	if fi, statErr := os.Stat(item.Path); statErr == nil && !fi.IsDir() {
 		itemDir = filepath.Dir(item.Path)
 	}
 	scanResult, _ := converter.RunScanChain(itemDir, scannerChainPaths)
@@ -173,34 +102,31 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 		return "", fmt.Errorf("hook %q has high-severity security findings; re-run with --force to install anyway", item.Name)
 	}
 
-	// Copy script files referenced by hook commands to a stable location.
-	// Without this, hooks from registries would point into the registry
-	// clone dir which can change on sync or vanish on remove.
-	matcherGroup, err = resolveHookScripts(matcherGroup, item, repoRoot)
+	// SECURITY: copy referenced scripts to a stable location and rewrite the
+	// command path (operates on the hook before encode).
+	resolvedCmd, err := resolveHookCommandScript(canonHook.Handler.Command, item, repoRoot)
 	if err != nil {
 		return "", err
 	}
+	canonHook.Handler.Command = resolvedCmd
 
-	// Crush stores flat hook entries ({name, command, matcher, timeout})
-	// rather than CC-shape matcher groups. The event is necessarily
-	// PreToolUse here: crush's only HookEvents entry is before_tool_execute,
-	// so the support check above already rejected everything else. Flatten
-	// last so the whitelist, scanner, and script-resolution steps above all
-	// see the standard shape.
-	if prov.Slug == "crush" {
-		matcherGroup, err = FlattenForCrush(matcherGroup, hookName)
-		if err != nil {
-			return "", fmt.Errorf("hook %q: %w", item.Name, err)
-		}
+	// Stable identity from the post-round-trip canonical form. Also rejects
+	// hooks the adapter drops (e.g. non-command handler on crush) before any
+	// file is touched.
+	groupHash, err := roundTripIdentity(adapter, canonHook)
+	if err != nil {
+		return "", fmt.Errorf("hook %q: %w", item.Name, err)
 	}
 
-	// Check installed.json for duplicate
+	nativeEvent := nativeEventFor(canonEvent, prov.Slug)
+
+	// Dedup against installed.json (name + event).
 	inst, err := LoadInstalled(repoRoot)
 	if err != nil {
 		return "", fmt.Errorf("loading installed.json: %w", err)
 	}
-	if inst.FindHook(item.Name, event) >= 0 {
-		return "", fmt.Errorf("hook %s already installed for %s event", item.Name, event)
+	if inst.FindHook(item.Name, nativeEvent) >= 0 {
+		return "", fmt.Errorf("hook %s already installed for %s event", item.Name, nativeEvent)
 	}
 
 	settingsPath, err := hookSettingsPath(prov)
@@ -213,43 +139,31 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 		return "", fmt.Errorf("creating snapshot: %w", err)
 	}
 
-	fileData, err := readJSONFile(settingsPath)
+	existing, err := decodeExistingHooks(adapter, settingsPath)
 	if err != nil {
-		return "", fmt.Errorf("reading %s: %w", settingsPath, err)
+		return "", err
 	}
+	all := make([]converter.CanonicalHook, 0, len(existing)+1)
+	all = append(all, existing...)
+	all = append(all, canonHook)
 
-	// Compute hash of the matcher group before appending
-	hash := sha256.Sum256(matcherGroup)
-	groupHash := hex.EncodeToString(hash[:])
-
-	// Append to hooks.<event> array using sjson's -1 (append) syntax
-	key := "hooks." + event + ".-1"
-	fileData, err = sjson.SetRawBytes(fileData, key, matcherGroup)
+	encoded, err := adapter.Encode(&converter.CanonicalHooks{Spec: converter.SpecVersion, Hooks: all})
 	if err != nil {
-		return "", fmt.Errorf("appending hook: %w", err)
+		return "", fmt.Errorf("encoding hooks: %w", err)
 	}
-
-	if err := writeJSONFile(settingsPath, fileData); err != nil {
-		// Auto-rollback using the snapshot we just created
+	if err := writeHookFile(model, settingsPath, encoded.Content); err != nil {
+		// Auto-rollback using the snapshot we just created.
 		if manifest, _, loadErr := snapshot.Load(repoRoot); loadErr == nil {
 			_ = snapshot.Restore(snapshotDir, manifest)
 		}
 		return "", fmt.Errorf("writing %s: %w", settingsPath, err)
 	}
 
-	// Extract command from the hook for tracking (crush entries are flat)
-	commandPath := "hooks.0.command"
-	if prov.Slug == "crush" {
-		commandPath = "command"
-	}
-	command := gjson.GetBytes(matcherGroup, commandPath).String()
-
-	// Record in installed.json
 	inst.Hooks = append(inst.Hooks, InstalledHook{
 		Name:        item.Name,
-		Event:       event,
+		Event:       nativeEvent,
 		GroupHash:   groupHash,
-		Command:     command,
+		Command:     canonHook.Handler.Command,
 		Source:      "export",
 		Scope:       "global",
 		InstalledAt: time.Now(),
@@ -258,74 +172,57 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 		return "", fmt.Errorf("saving installed.json: %w", err)
 	}
 
-	return fmt.Sprintf("hooks.%s in %s", event, settingsPath), nil
+	return fmt.Sprintf("hooks.%s in %s", nativeEvent, settingsPath), nil
 }
 
 func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot string) (string, error) {
-	// item.Path is already absolute (set by scanner)
-	event, _, _, err := parseHookFile(item.Path)
+	h, err := readSingleManifestHook(item.Path)
 	if err != nil {
 		return "", fmt.Errorf("parsing hook file: %w", err)
 	}
 
-	// Translate canonical event names to provider-native (matches install).
-	if nativeEvent, ok := converter.TranslateHookEvent(event, prov.Slug); ok {
-		event = nativeEvent
+	adapter := converter.AdapterFor(prov.Slug)
+	if adapter == nil {
+		return "", fmt.Errorf("hook uninstall not supported for %s (no encoder)", prov.Name)
 	}
+	model, err := hookStorageModelFor(prov.Slug)
+	if err != nil {
+		return "", err
+	}
+
+	canonEvent := canonicalizeEvent(h.Event, prov.Slug)
+	nativeEvent := nativeEventFor(canonEvent, prov.Slug)
 
 	settingsPath, err := hookSettingsPath(prov)
 	if err != nil {
 		return "", err
 	}
 
-	fileData, err := readJSONFile(settingsPath)
-	if err != nil {
-		return "", fmt.Errorf("reading %s: %w", settingsPath, err)
-	}
-
-	// Find entry by installed.json lookup
 	inst, err := LoadInstalled(repoRoot)
 	if err != nil {
 		return "", fmt.Errorf("loading installed.json: %w", err)
 	}
-
-	instIdx := inst.FindHook(item.Name, event)
-
-	// Find the hook entry in settings.json
-	hooksArray := gjson.GetBytes(fileData, "hooks."+event)
-	if !hooksArray.Exists() || !hooksArray.IsArray() {
-		return "", fmt.Errorf("no hooks.%s array in %s", event, settingsPath)
+	instIdx := inst.FindHook(item.Name, nativeEvent)
+	if instIdx < 0 {
+		return "", fmt.Errorf("hook %s not tracked for %s event (not installed by syllago)", item.Name, nativeEvent)
 	}
+	storedHash := inst.Hooks[instIdx].GroupHash
 
+	// Identity-based match: decode the file, find the hook whose canonical
+	// identity matches the stored hash, drop it, and re-encode.
+	existing, err := decodeExistingHooks(adapter, settingsPath)
+	if err != nil {
+		return "", err
+	}
 	found := -1
-	if instIdx >= 0 {
-		storedHash := inst.Hooks[instIdx].GroupHash
-		if storedHash != "" {
-			// Hash-based matching: compare stored hash against hash of each entry
-			for i, entry := range hooksArray.Array() {
-				entryBytes := []byte(entry.Raw)
-				h := sha256.Sum256(entryBytes)
-				if hex.EncodeToString(h[:]) == storedHash {
-					found = i
-					break
-				}
-			}
-			if found == -1 {
-				return "", fmt.Errorf("hook %s was modified since installation; use 'syllago restore' to revert", item.Name)
-			}
-		} else {
-			// Fallback: command-string matching for pre-hash installed hooks
-			cmd := inst.Hooks[instIdx].Command
-			for i, entry := range hooksArray.Array() {
-				if entry.Get("hooks.0.command").String() == cmd {
-					found = i
-					break
-				}
-			}
+	for i, eh := range existing {
+		if hookIdentity(eh) == storedHash {
+			found = i
+			break
 		}
 	}
 	if found == -1 {
-		return "", fmt.Errorf("hook %s not found in hooks.%s (not installed by syllago)", item.Name, event)
+		return "", fmt.Errorf("hook %s not found in %s (modified since installation; use 'syllago restore' to revert)", item.Name, settingsPath)
 	}
 
 	snapshotDir, err := snapshot.CreateForHook(repoRoot, "hook-uninstall:"+item.Name, []string{settingsPath})
@@ -333,89 +230,69 @@ func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot st
 		return "", fmt.Errorf("creating snapshot: %w", err)
 	}
 
-	// Delete by index
-	key := fmt.Sprintf("hooks.%s.%d", event, found)
-	fileData, err = sjson.DeleteBytes(fileData, key)
-	if err != nil {
-		return "", fmt.Errorf("deleting hook: %w", err)
-	}
+	remaining := make([]converter.CanonicalHook, 0, len(existing)-1)
+	remaining = append(remaining, existing[:found]...)
+	remaining = append(remaining, existing[found+1:]...)
 
-	if err := writeJSONFile(settingsPath, fileData); err != nil {
-		// Auto-rollback using the snapshot we just created
+	encoded, err := adapter.Encode(&converter.CanonicalHooks{Spec: converter.SpecVersion, Hooks: remaining})
+	if err != nil {
+		return "", fmt.Errorf("encoding hooks: %w", err)
+	}
+	if err := writeHookFile(model, settingsPath, encoded.Content); err != nil {
 		if manifest, _, loadErr := snapshot.Load(repoRoot); loadErr == nil {
 			_ = snapshot.Restore(snapshotDir, manifest)
 		}
 		return "", fmt.Errorf("writing %s: %w", settingsPath, err)
 	}
 
-	// Remove from installed.json only after successful write
-	if instIdx >= 0 {
-		inst.RemoveHook(instIdx)
-		if err := SaveInstalled(repoRoot, inst); err != nil {
-			return "", fmt.Errorf("saving installed.json: %w", err)
-		}
+	inst.RemoveHook(instIdx)
+	if err := SaveInstalled(repoRoot, inst); err != nil {
+		return "", fmt.Errorf("saving installed.json: %w", err)
 	}
 
-	return fmt.Sprintf("hooks.%s from %s", event, settingsPath), nil
+	return fmt.Sprintf("hooks.%s from %s", nativeEvent, settingsPath), nil
 }
 
 func checkHookStatus(item catalog.ContentItem, prov provider.Provider, repoRoot string) Status {
-	// item.Path is already absolute (set by scanner)
-	event, _, _, err := parseHookFile(item.Path)
+	h, err := readSingleManifestHook(item.Path)
 	if err != nil {
 		return StatusNotAvailable
 	}
 
-	// Translate canonical event names to provider-native (matches install).
-	if nativeEvent, ok := converter.TranslateHookEvent(event, prov.Slug); ok {
-		event = nativeEvent
+	adapter := converter.AdapterFor(prov.Slug)
+	if adapter == nil {
+		return StatusNotAvailable
+	}
+	if _, err := hookStorageModelFor(prov.Slug); err != nil {
+		return StatusNotAvailable
 	}
 
-	// Check installed.json for this hook
+	canonEvent := canonicalizeEvent(h.Event, prov.Slug)
+	nativeEvent := nativeEventFor(canonEvent, prov.Slug)
+
 	inst, err := LoadInstalled(repoRoot)
 	if err != nil {
 		return StatusNotAvailable
 	}
-	instIdx := inst.FindHook(item.Name, event)
+	instIdx := inst.FindHook(item.Name, nativeEvent)
 	if instIdx < 0 {
 		return StatusNotInstalled
 	}
+	storedHash := inst.Hooks[instIdx].GroupHash
 
-	// installed.json doesn't track which provider the hook was installed to,
-	// so verify the hook actually exists in THIS provider's settings file.
 	settingsPath, err := hookSettingsPath(prov)
 	if err != nil {
 		return StatusNotInstalled
 	}
-
-	fileData, err := readJSONFile(settingsPath)
+	existing, err := decodeExistingHooks(adapter, settingsPath)
 	if err != nil {
 		return StatusNotInstalled
 	}
-
-	hooksArray := gjson.GetBytes(fileData, "hooks."+event)
-	if !hooksArray.Exists() || !hooksArray.IsArray() {
-		return StatusNotInstalled
-	}
-
-	// Match by hash or command to confirm presence in this provider's settings
-	storedHash := inst.Hooks[instIdx].GroupHash
-	if storedHash != "" {
-		for _, entry := range hooksArray.Array() {
-			h := sha256.Sum256([]byte(entry.Raw))
-			if hex.EncodeToString(h[:]) == storedHash {
-				return StatusInstalled
-			}
-		}
-	} else {
-		cmd := inst.Hooks[instIdx].Command
-		for _, entry := range hooksArray.Array() {
-			if entry.Get("hooks.0.command").String() == cmd {
-				return StatusInstalled
-			}
+	for _, eh := range existing {
+		if hookIdentity(eh) == storedHash {
+			return StatusInstalled
 		}
 	}
-
 	return StatusNotInstalled
 }
 
@@ -426,6 +303,25 @@ func hookScriptsDir(name string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(home, ".syllago", "hooks", name), nil
+}
+
+// resolveHookCommandScript resolves a single hook command through the
+// script-copying security logic (resolveHookScripts operates on a matcher
+// group, so we wrap the command in a minimal group and read the rewritten
+// command back). An empty command (e.g. a non-command handler) is a no-op.
+func resolveHookCommandScript(cmd string, item catalog.ContentItem, repoRoot string) (string, error) {
+	if cmd == "" {
+		return "", nil
+	}
+	mg, err := sjson.SetBytes([]byte(`{}`), "hooks.0.command", cmd)
+	if err != nil {
+		return "", err
+	}
+	mg, err = resolveHookScripts(mg, item, repoRoot)
+	if err != nil {
+		return "", err
+	}
+	return gjson.GetBytes(mg, "hooks.0.command").String(), nil
 }
 
 // resolveHookScripts finds script file references in a hook's matcher group,
@@ -526,55 +422,4 @@ func resolveHookScripts(matcherGroup []byte, item catalog.ContentItem, repoRoot 
 	}
 
 	return result, nil
-}
-
-// FlattenForCrush converts a CC-shape matcher group ({matcher, hooks:[entry]})
-// into crush's flat HookConfig ({name, matcher, command, timeout}). Crush
-// hooks are shell commands only, its schema rejects unknown fields, and its
-// timeouts are seconds — the canonical unit, so the value passes through
-// unchanged. The matcher must arrive already translated to crush's native
-// tool names (both installHook and loadout applyHook translate for every
-// provider before this step). Exported so the loadout merge path can share
-// the same flattening.
-func FlattenForCrush(matcherGroup []byte, hookName string) ([]byte, error) {
-	entry := gjson.GetBytes(matcherGroup, "hooks.0")
-	if hType := entry.Get("type").String(); hType != "" && hType != "command" {
-		return nil, fmt.Errorf("crush hooks only support command handlers (got type %q)", hType)
-	}
-	cmd := entry.Get("command").String()
-	if cmd == "" {
-		return nil, fmt.Errorf("crush hooks require a command")
-	}
-	matcher := gjson.GetBytes(matcherGroup, "matcher").String()
-	flat := struct {
-		Name    string `json:"name,omitempty"`
-		Matcher string `json:"matcher,omitempty"`
-		Command string `json:"command"`
-		Timeout int    `json:"timeout,omitempty"`
-	}{
-		Name:    hookName,
-		Matcher: matcher,
-		Command: cmd,
-		Timeout: int(entry.Get("timeout").Int()),
-	}
-	return json.Marshal(flat)
-}
-
-// hookMatcherGroup is a typed struct for whitelist-filtering hook matcher groups.
-// Only known fields are preserved when merging into settings.json, matching
-// the approach used by ExtractServerEntries for MCP configs.
-type hookMatcherGroup struct {
-	Matcher string          `json:"matcher,omitempty"`
-	Hooks   json.RawMessage `json:"hooks,omitempty"`
-	Timeout int             `json:"timeout,omitempty"`
-}
-
-// whitelistMatcherGroup parses a raw matcher group through a typed struct to
-// strip unknown JSON fields before merging into provider settings.
-func whitelistMatcherGroup(raw []byte) ([]byte, error) {
-	var mg hookMatcherGroup
-	if err := json.Unmarshal(raw, &mg); err != nil {
-		return nil, fmt.Errorf("parsing matcher group: %w", err)
-	}
-	return json.Marshal(mg)
 }

--- a/cli/internal/installer/hooks_adapter_test.go
+++ b/cli/internal/installer/hooks_adapter_test.go
@@ -1,0 +1,241 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/converter"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/tidwall/gjson"
+)
+
+// writeCanonicalHookItem writes a single-hook canonical manifest into a fresh
+// project root and returns the item plus the project root.
+func writeCanonicalHookItem(t *testing.T, name, event, matcher, command string) (catalog.ContentItem, string) {
+	t.Helper()
+	projectRoot := t.TempDir()
+	os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755)
+
+	hookDir := filepath.Join(projectRoot, "hooks", name)
+	os.MkdirAll(hookDir, 0755)
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"name":"` + name +
+		`","event":"` + event + `","matcher":"` + matcher +
+		`","handler":{"type":"command","command":"` + command + `"}}]}`
+	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
+
+	return catalog.ContentItem{Name: name, Type: catalog.Hooks, Path: hookDir}, projectRoot
+}
+
+// TestInstallHook_Adapter_SharedJSON_RoundTrip installs a canonical hook into
+// each shared-JSON provider's native file via its converter.HookAdapter, decodes
+// it back through the same adapter to prove it landed in the provider's real
+// format, then exercises status + uninstall + re-install.
+func TestInstallHook_Adapter_SharedJSON_RoundTrip(t *testing.T) {
+	providers := []provider.Provider{
+		provider.ClaudeCode,
+		provider.Cursor,
+		provider.GeminiCLI,
+		provider.FactoryDroid,
+		provider.Crush,
+	}
+
+	for _, prov := range providers {
+		t.Run(prov.Slug, func(t *testing.T) {
+			item, projectRoot := writeCanonicalHookItem(t, "guard", "before_tool_execute", "shell", "echo lint")
+
+			configDir := t.TempDir()
+			settingsPath := filepath.Join(configDir, "config.json")
+			os.WriteFile(settingsPath, []byte(`{}`), 0644)
+			overrideHookSettingsPath(t, settingsPath)
+
+			if _, err := installHook(item, prov, projectRoot); err != nil {
+				t.Fatalf("installHook: %v", err)
+			}
+
+			adapter := converter.AdapterFor(prov.Slug)
+			if adapter == nil {
+				t.Fatalf("no adapter for %s", prov.Slug)
+			}
+
+			data, _ := os.ReadFile(settingsPath)
+			decoded, err := adapter.Decode(data)
+			if err != nil {
+				t.Fatalf("decode written file: %v", err)
+			}
+			if !hasCommand(decoded, "echo lint") {
+				t.Fatalf("decoded hooks missing command %q, got: %s", "echo lint", data)
+			}
+
+			if status := checkHookStatus(item, prov, projectRoot); status != StatusInstalled {
+				t.Errorf("status after install: got %v, want Installed", status)
+			}
+
+			if _, err := uninstallHook(item, prov, projectRoot); err != nil {
+				t.Fatalf("uninstallHook: %v", err)
+			}
+			data, _ = os.ReadFile(settingsPath)
+			decoded, _ = adapter.Decode(data)
+			if hasCommand(decoded, "echo lint") {
+				t.Errorf("hook still present after uninstall: %s", data)
+			}
+			if status := checkHookStatus(item, prov, projectRoot); status != StatusNotInstalled {
+				t.Errorf("status after uninstall: got %v, want NotInstalled", status)
+			}
+
+			// Re-install must succeed (round-trip): the uninstall cleared the
+			// installed.json record so the dedup check no longer trips.
+			if _, err := installHook(item, prov, projectRoot); err != nil {
+				t.Fatalf("re-install: %v", err)
+			}
+		})
+	}
+}
+
+// TestInstallHook_Adapter_PreservesSiblings proves the shared-JSON merge writes
+// only the `hooks` key, leaving unrelated config keys untouched on both install
+// and uninstall.
+func TestInstallHook_Adapter_PreservesSiblings(t *testing.T) {
+	tests := []struct {
+		prov      provider.Provider
+		seed      string
+		siblingOK func(data []byte) bool
+	}{
+		{
+			prov: provider.ClaudeCode,
+			seed: `{"permissions":{"allow":["Bash"]}}`,
+			siblingOK: func(data []byte) bool {
+				return gjson.GetBytes(data, "permissions.allow.0").String() == "Bash"
+			},
+		},
+		{
+			prov: provider.Crush,
+			seed: `{"mcp":{"existing":{"command":"keep-me"}}}`,
+			siblingOK: func(data []byte) bool {
+				return gjson.GetBytes(data, "mcp.existing.command").String() == "keep-me"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.prov.Slug, func(t *testing.T) {
+			item, projectRoot := writeCanonicalHookItem(t, "guard", "before_tool_execute", "shell", "echo lint")
+
+			settingsPath := filepath.Join(t.TempDir(), "config.json")
+			os.WriteFile(settingsPath, []byte(tt.seed), 0644)
+			overrideHookSettingsPath(t, settingsPath)
+
+			if _, err := installHook(item, tt.prov, projectRoot); err != nil {
+				t.Fatalf("installHook: %v", err)
+			}
+			data, _ := os.ReadFile(settingsPath)
+			if !tt.siblingOK(data) {
+				t.Errorf("sibling key clobbered by install: %s", data)
+			}
+
+			if _, err := uninstallHook(item, tt.prov, projectRoot); err != nil {
+				t.Fatalf("uninstallHook: %v", err)
+			}
+			data, _ = os.ReadFile(settingsPath)
+			if !tt.siblingOK(data) {
+				t.Errorf("sibling key clobbered by uninstall: %s", data)
+			}
+		})
+	}
+}
+
+// TestInstallHook_Windsurf_DedicatedFile installs a non-blocking before-tool
+// hook into windsurf's dedicated hooks.json. Windsurf uses a split-event model
+// and wraps non-blocking pre-hooks with `|| true`; the identity-based
+// status/uninstall must survive that lossy transform.
+func TestInstallHook_Windsurf_DedicatedFile(t *testing.T) {
+	item, projectRoot := writeCanonicalHookItem(t, "guard", "before_tool_execute", "shell", "echo hi")
+
+	hooksPath := filepath.Join(t.TempDir(), "hooks.json")
+	overrideHookSettingsPath(t, hooksPath)
+
+	if _, err := installHook(item, provider.Windsurf, projectRoot); err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+
+	data, _ := os.ReadFile(hooksPath)
+	// Windsurf split-event: canonical "shell" fans out to pre_run_command.
+	entry := gjson.GetBytes(data, "hooks.pre_run_command.0.command").String()
+	if entry == "" {
+		t.Fatalf("expected hooks.pre_run_command.0.command in windsurf hooks.json, got: %s", data)
+	}
+	if !strings.Contains(entry, "|| true") {
+		t.Errorf("non-blocking pre-hook should be wrapped with || true, got: %q", entry)
+	}
+
+	if status := checkHookStatus(item, provider.Windsurf, projectRoot); status != StatusInstalled {
+		t.Errorf("status after install: got %v, want Installed", status)
+	}
+
+	if _, err := uninstallHook(item, provider.Windsurf, projectRoot); err != nil {
+		t.Fatalf("uninstallHook: %v", err)
+	}
+	data, _ = os.ReadFile(hooksPath)
+	if gjson.GetBytes(data, "hooks.pre_run_command.0").Exists() {
+		t.Errorf("hook should be removed after uninstall, got: %s", data)
+	}
+}
+
+// TestInstallHook_Adapter_RejectsNoEncoder: providers with no HookAdapter (amp,
+// codex) are rejected with an honest error and nothing is written.
+func TestInstallHook_Adapter_RejectsNoEncoder(t *testing.T) {
+	item, projectRoot := writeCanonicalHookItem(t, "guard", "before_tool_execute", "shell", "echo hi")
+
+	settingsPath := filepath.Join(t.TempDir(), "config.json")
+	os.WriteFile(settingsPath, []byte(`{}`), 0644)
+	overrideHookSettingsPath(t, settingsPath)
+
+	_, err := installHook(item, provider.Amp, projectRoot)
+	if err == nil {
+		t.Fatal("expected error installing hook to amp (no adapter)")
+	}
+	if !strings.Contains(err.Error(), "no encoder") {
+		t.Errorf("error should mention missing encoder, got: %v", err)
+	}
+	data, _ := os.ReadFile(settingsPath)
+	if gjson.GetBytes(data, "hooks").Exists() {
+		t.Errorf("no hook should have been written, got: %s", data)
+	}
+}
+
+// TestInstallHook_Adapter_RejectsDirectoryProvider: directory-scoped hook
+// providers (copilot-cli, kiro, pi) are rejected pending ADR-0020 Phase 1b.
+func TestInstallHook_Adapter_RejectsDirectoryProvider(t *testing.T) {
+	item, projectRoot := writeCanonicalHookItem(t, "guard", "before_tool_execute", "shell", "echo hi")
+
+	settingsPath := filepath.Join(t.TempDir(), "config.json")
+	os.WriteFile(settingsPath, []byte(`{}`), 0644)
+	overrideHookSettingsPath(t, settingsPath)
+
+	_, err := installHook(item, provider.CopilotCLI, projectRoot)
+	if err == nil {
+		t.Fatal("expected error installing hook to copilot-cli (Phase 1b)")
+	}
+	if !strings.Contains(err.Error(), "Phase 1b") {
+		t.Errorf("error should reference Phase 1b, got: %v", err)
+	}
+	data, _ := os.ReadFile(settingsPath)
+	if gjson.GetBytes(data, "hooks").Exists() {
+		t.Errorf("no hook should have been written, got: %s", data)
+	}
+}
+
+// hasCommand reports whether any decoded canonical hook has the given command.
+func hasCommand(ch *converter.CanonicalHooks, cmd string) bool {
+	if ch == nil {
+		return false
+	}
+	for _, h := range ch.Hooks {
+		if h.Handler.Command == cmd {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/installer/hooks_adapter_test.go
+++ b/cli/internal/installer/hooks_adapter_test.go
@@ -146,40 +146,51 @@ func TestInstallHook_Adapter_PreservesSiblings(t *testing.T) {
 	}
 }
 
-// TestInstallHook_Windsurf_DedicatedFile installs a non-blocking before-tool
-// hook into windsurf's dedicated hooks.json. Windsurf uses a split-event model
-// and wraps non-blocking pre-hooks with `|| true`; the identity-based
-// status/uninstall must survive that lossy transform.
-func TestInstallHook_Windsurf_DedicatedFile(t *testing.T) {
+// TestInstallHook_Windsurf_DeferredToPhase1b: windsurf is deferred to Phase 1b.
+// Its adapter fans one before_tool_execute hook out to four split-events and
+// only merges them back when each has exactly one entry, so a hook's
+// post-round-trip identity is not stable once a second windsurf hook exists —
+// uninstall/status/orphans can't reliably match it. Until Phase 1b adds a
+// stable per-entry identity, installing a windsurf hook must reject and write
+// nothing.
+func TestInstallHook_Windsurf_DeferredToPhase1b(t *testing.T) {
 	item, projectRoot := writeCanonicalHookItem(t, "guard", "before_tool_execute", "shell", "echo hi")
 
-	hooksPath := filepath.Join(t.TempDir(), "hooks.json")
-	overrideHookSettingsPath(t, hooksPath)
+	settingsPath := filepath.Join(t.TempDir(), "config.json")
+	os.WriteFile(settingsPath, []byte(`{}`), 0644)
+	overrideHookSettingsPath(t, settingsPath)
 
-	if _, err := installHook(item, provider.Windsurf, projectRoot); err != nil {
-		t.Fatalf("installHook: %v", err)
+	_, err := installHook(item, provider.Windsurf, projectRoot)
+	if err == nil {
+		t.Fatal("expected error installing hook to windsurf (Phase 1b)")
 	}
+	if !strings.Contains(err.Error(), "Phase 1b") {
+		t.Errorf("error should reference Phase 1b, got: %v", err)
+	}
+	data, _ := os.ReadFile(settingsPath)
+	if gjson.GetBytes(data, "hooks").Exists() {
+		t.Errorf("no hook should have been written, got: %s", data)
+	}
+}
 
-	data, _ := os.ReadFile(hooksPath)
-	// Windsurf split-event: canonical "shell" fans out to pre_run_command.
-	entry := gjson.GetBytes(data, "hooks.pre_run_command.0.command").String()
-	if entry == "" {
-		t.Fatalf("expected hooks.pre_run_command.0.command in windsurf hooks.json, got: %s", data)
-	}
-	if !strings.Contains(entry, "|| true") {
-		t.Errorf("non-blocking pre-hook should be wrapped with || true, got: %q", entry)
-	}
+// TestWriteHookFile_DedicatedMode covers the dedicated-file write branch
+// directly. That branch is Phase 1b infrastructure (no Phase 1 provider routes
+// to it), so this keeps it exercised without a routed provider: it must write
+// the encoded content verbatim as the whole file.
+func TestWriteHookFile_DedicatedMode(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "hooks.json")
+	encoded := []byte(`{"hooks":{"pre_run_command":[{"command":"echo hi"}]}}`)
 
-	if status := checkHookStatus(item, provider.Windsurf, projectRoot); status != StatusInstalled {
-		t.Errorf("status after install: got %v, want Installed", status)
+	if err := writeHookFile(hookStorageDedicatedFile, path, encoded); err != nil {
+		t.Fatalf("writeHookFile: %v", err)
 	}
-
-	if _, err := uninstallHook(item, provider.Windsurf, projectRoot); err != nil {
-		t.Fatalf("uninstallHook: %v", err)
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading written file: %v", err)
 	}
-	data, _ = os.ReadFile(hooksPath)
-	if gjson.GetBytes(data, "hooks.pre_run_command.0").Exists() {
-		t.Errorf("hook should be removed after uninstall, got: %s", data)
+	if string(got) != string(encoded) {
+		t.Errorf("dedicated write should be verbatim:\n got  %s\n want %s", got, encoded)
 	}
 }
 

--- a/cli/internal/installer/hooks_event_support_test.go
+++ b/cli/internal/installer/hooks_event_support_test.go
@@ -42,7 +42,10 @@ func TestInstallHook_RejectsUnsupportedEvent(t *testing.T) {
 		event string
 		prov  provider.Provider
 	}{
-		{"canonical event unmapped for provider", "before_tool_execute", provider.Windsurf},
+		// NOTE: windsurf + before_tool_execute is NOT here — under ADR-0020 the
+		// windsurf adapter DOES support it (fanned out to split events like
+		// pre_run_command), so that install now succeeds
+		// (see TestInstallHook_Windsurf_DedicatedFile).
 		{"another provider's native name", "PreToolUse", provider.Windsurf},
 		{"canonical event unmapped for crush", "session_end", provider.Crush},
 	}

--- a/cli/internal/installer/hooks_event_support_test.go
+++ b/cli/internal/installer/hooks_event_support_test.go
@@ -42,11 +42,15 @@ func TestInstallHook_RejectsUnsupportedEvent(t *testing.T) {
 		event string
 		prov  provider.Provider
 	}{
-		// NOTE: windsurf + before_tool_execute is NOT here — under ADR-0020 the
-		// windsurf adapter DOES support it (fanned out to split events like
-		// pre_run_command), so that install now succeeds
-		// (see TestInstallHook_Windsurf_DedicatedFile).
-		{"another provider's native name", "PreToolUse", provider.Windsurf},
+		// Both cases use routed (Phase 1) providers so the reject comes from the
+		// event-support gate, not the Phase-1b storage-model rejection. windsurf
+		// is not used here: it is deferred to Phase 1b, so it rejects before the
+		// event gate (see TestInstallHook_Windsurf_DeferredToPhase1b).
+		//
+		// "PostToolUse" is claude-code's native name for after_tool_execute —
+		// crush supports only before_tool_execute, so it's a foreign/unreadable
+		// event for crush.
+		{"another provider's native name", "PostToolUse", provider.Crush},
 		{"canonical event unmapped for crush", "session_end", provider.Crush},
 	}
 
@@ -74,20 +78,20 @@ func TestInstallHook_RejectsUnsupportedEvent(t *testing.T) {
 }
 
 // TestInstallHook_OwnNativeEventPassesThrough: a provider's OWN native event
-// name is not translated but must still install — the strict support check
-// only rejects events the provider cannot read.
+// name is not rejected — it canonicalizes back to a supported event and
+// installs. crush's native "PreToolUse" maps to canonical before_tool_execute.
 func TestInstallHook_OwnNativeEventPassesThrough(t *testing.T) {
-	item, projectRoot := writeEventHookItem(t, "pre_user_prompt")
+	item, projectRoot := writeEventHookItem(t, "PreToolUse")
 
-	settingsPath := filepath.Join(t.TempDir(), "settings.json")
+	settingsPath := filepath.Join(t.TempDir(), "crush.json")
 	os.WriteFile(settingsPath, []byte(`{}`), 0644)
 	overrideHookSettingsPath(t, settingsPath)
 
-	if _, err := installHook(item, provider.Windsurf, projectRoot); err != nil {
+	if _, err := installHook(item, provider.Crush, projectRoot); err != nil {
 		t.Fatalf("installHook: %v", err)
 	}
 	data, _ := os.ReadFile(settingsPath)
-	if !gjson.GetBytes(data, "hooks.pre_user_prompt.0").Exists() {
-		t.Errorf("expected hooks.pre_user_prompt.0 in settings, got: %s", data)
+	if !gjson.GetBytes(data, "hooks.PreToolUse.0").Exists() {
+		t.Errorf("expected hooks.PreToolUse.0 in crush.json, got: %s", data)
 	}
 }

--- a/cli/internal/installer/hooks_test.go
+++ b/cli/internal/installer/hooks_test.go
@@ -1,9 +1,6 @@
 package installer
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,146 +118,91 @@ func TestUninstallHook_RemovesFromInstalledJSON(t *testing.T) {
 }
 
 func TestCheckHookStatus_UsesInstalledJSON(t *testing.T) {
-	t.Parallel()
+	// Not parallel — overrideHookSettingsPath mutates a package global.
 	projectRoot := t.TempDir()
 	os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755)
 
-	// Create hook file for parsing
 	hookDir := filepath.Join(projectRoot, "hooks", "status-hook")
 	os.MkdirAll(hookDir, 0755)
-	hookJSON := `{
-  "spec": "hooks/0.1",
-  "hooks": [
-    {
-      "event": "PostToolUse",
-      "matcher": ".*",
-      "handler": {"type": "command", "command": "echo status"}
-    }
-  ]
-}`
-	hookFile := filepath.Join(hookDir, "hook.json")
-	os.WriteFile(hookFile, []byte(hookJSON), 0644)
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"PostToolUse","matcher":".*","handler":{"type":"command","command":"echo status"}}]}`
+	os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644)
 
-	item := catalog.ContentItem{
-		Name: "status-hook",
-		Type: catalog.Hooks,
-		Path: hookFile,
-	}
+	item := catalog.ContentItem{Name: "status-hook", Type: catalog.Hooks, Path: hookDir}
 
-	// Create a settings.json at the provider's config path
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatalf("getting home dir: %v", err)
-	}
-	configDir := filepath.Join(home, ".syllago-test-hookstatus-"+filepath.Base(projectRoot))
-	os.MkdirAll(configDir, 0755)
-	t.Cleanup(func() { os.RemoveAll(configDir) })
-	os.WriteFile(filepath.Join(configDir, "settings.json"), []byte("{}"), 0644)
+	settingsPath := filepath.Join(t.TempDir(), "settings.json")
+	os.WriteFile(settingsPath, []byte("{}"), 0644)
+	overrideHookSettingsPath(t, settingsPath)
 
-	prov := provider.Provider{
-		Name:      "test-provider",
-		Slug:      "claude-code", // real slug: unknown slugs now fail the event-support check
-		ConfigDir: filepath.Base(configDir),
-	}
+	prov := provider.Provider{Name: "Claude Code", Slug: "claude-code", ConfigDir: ".claude"}
 
-	// Without installed.json entry: should be NotInstalled
-	status := checkHookStatus(item, prov, projectRoot)
-	if status != StatusNotInstalled {
+	// Without installed.json entry: should be NotInstalled.
+	if status := checkHookStatus(item, prov, projectRoot); status != StatusNotInstalled {
 		t.Errorf("expected NotInstalled without installed.json entry, got %v", status)
 	}
 
-	// Add to installed.json
-	matcherGroup := []byte(`{"matcher":".*","hooks":[{"type":"command","command":"echo status"}]}`)
-	groupHash := sha256.Sum256(matcherGroup)
-	inst := &Installed{
-		Hooks: []InstalledHook{
-			{Name: "status-hook", Event: "PostToolUse", Command: "echo status", Source: "export", GroupHash: hex.EncodeToString(groupHash[:])},
-		},
+	// After a real adapter-routed install, status resolves via the stored
+	// canonical identity.
+	if _, err := installHook(item, prov, projectRoot); err != nil {
+		t.Fatalf("installHook: %v", err)
 	}
-	SaveInstalled(projectRoot, inst)
-
-	// Also add the hook to the provider's settings.json so the hash matches.
-	settingsJSON := fmt.Sprintf(`{"hooks":{"PostToolUse":[%s]}}`, matcherGroup)
-	os.WriteFile(filepath.Join(configDir, "settings.json"), []byte(settingsJSON), 0644)
-
-	// With installed.json entry + matching settings: should be Installed
-	status = checkHookStatus(item, prov, projectRoot)
-	if status != StatusInstalled {
-		t.Errorf("expected Installed with installed.json entry + matching settings, got %v", status)
+	if status := checkHookStatus(item, prov, projectRoot); status != StatusInstalled {
+		t.Errorf("expected Installed after install, got %v", status)
 	}
 }
 
-func TestParseHookFile_Valid(t *testing.T) {
+func TestReadSingleManifestHook_Valid(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 
-	hookJSON := `{
-  "spec": "hooks/0.1",
-  "hooks": [
-    {
-      "event": "PostToolUse",
-      "matcher": "*.go",
-      "handler": {"type": "command", "command": "go test"}
-    }
-  ]
-}`
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"PostToolUse","matcher":"*.go","handler":{"type":"command","command":"go test"}}]}`
 	hookFile := filepath.Join(tmpDir, "hook.json")
 	os.WriteFile(hookFile, []byte(hookJSON), 0644)
 
-	event, _, matcherGroup, err := parseHookFile(hookFile)
+	h, err := readSingleManifestHook(hookFile)
 	if err != nil {
-		t.Fatalf("parseHookFile: %v", err)
+		t.Fatalf("readSingleManifestHook: %v", err)
 	}
-	if event != "PostToolUse" {
-		t.Errorf("event: got %q, want PostToolUse", event)
+	if h.Event != "PostToolUse" {
+		t.Errorf("event: got %q, want PostToolUse", h.Event)
 	}
-
-	// parseHookFile returns the provider-shape matcher group, which does NOT
-	// include the event field (that lives on the parent hooks.<event> key).
-	if gjson.GetBytes(matcherGroup, "event").Exists() {
-		t.Error("event field should not appear in matcher group")
+	if h.Matcher != "*.go" {
+		t.Errorf("matcher: got %q, want *.go", h.Matcher)
 	}
-	if gjson.GetBytes(matcherGroup, "matcher").String() != "*.go" {
-		t.Error("matcher field should be preserved")
-	}
-	if !gjson.GetBytes(matcherGroup, "hooks").IsArray() {
-		t.Error("hooks array should be preserved")
+	if h.Handler.Command != "go test" {
+		t.Errorf("command: got %q, want 'go test'", h.Handler.Command)
 	}
 }
 
-func TestParseHookFile_DirectoryFormat(t *testing.T) {
+func TestReadSingleManifestHook_DirectoryFormat(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
 	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"PreToolUse","matcher":"Bash","handler":{"type":"command","command":"echo hi"}}]}`
 	os.WriteFile(filepath.Join(dir, "hook.json"), []byte(hookJSON), 0644)
 
-	event, _, matcherGroup, err := parseHookFile(dir)
+	h, err := readSingleManifestHook(dir)
 	if err != nil {
-		t.Fatalf("parseHookFile with directory: %v", err)
+		t.Fatalf("readSingleManifestHook with directory: %v", err)
 	}
-	if event != "PreToolUse" {
-		t.Errorf("event: got %q, want PreToolUse", event)
+	if h.Event != "PreToolUse" {
+		t.Errorf("event: got %q, want PreToolUse", h.Event)
 	}
-	if gjson.GetBytes(matcherGroup, "event").Exists() {
-		t.Error("event field should not appear in matcher group")
-	}
-	if gjson.GetBytes(matcherGroup, "matcher").String() != "Bash" {
-		t.Error("matcher field should be preserved")
+	if h.Matcher != "Bash" {
+		t.Errorf("matcher: got %q, want Bash", h.Matcher)
 	}
 }
 
-func TestParseHookFile_MissingEvent(t *testing.T) {
+func TestReadSingleManifestHook_MissingSpec(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 
+	// Legacy flat shape (no spec field) is rejected by ParseManifest.
 	hookJSON := `{"matcher": ".*", "hooks": [{"type": "command", "command": "echo"}]}`
 	hookFile := filepath.Join(tmpDir, "hook.json")
 	os.WriteFile(hookFile, []byte(hookJSON), 0644)
 
-	_, _, _, err := parseHookFile(hookFile)
-	if err == nil {
-		t.Fatal("expected error for missing event field")
+	if _, err := readSingleManifestHook(hookFile); err == nil {
+		t.Fatal("expected error for manifest missing spec field")
 	}
 }
 
@@ -291,16 +233,7 @@ func TestInstallHook_HashComputation(t *testing.T) {
 	projectRoot := t.TempDir()
 	os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755)
 
-	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"PreToolUse","matcher":"Bash","handler":{"type":"command","command":"echo hash-test"}}]}`
-
-	// Simulate what installHook does: parse, compute hash, record
-	hookFile := filepath.Join(projectRoot, "hook.json")
-	os.WriteFile(hookFile, []byte(hookJSON), 0644)
-
-	_, _, matcherGroup, err := parseHookFile(hookFile)
-	if err != nil {
-		t.Fatalf("parseHookFile: %v", err)
-	}
+	matcherGroup := []byte(`{"matcher":"Bash","hooks":[{"type":"command","command":"echo hash-test"}]}`)
 
 	groupHash := computeGroupHash(matcherGroup)
 	if len(groupHash) != 64 {

--- a/cli/internal/installer/installer_resolver_test.go
+++ b/cli/internal/installer/installer_resolver_test.go
@@ -205,7 +205,10 @@ func TestCheckStatusWithResolver_MergeTypeBypassesResolver(t *testing.T) {
 	repoRoot := filepath.Join(tmp, "repo")
 	os.MkdirAll(filepath.Join(repoRoot, ".syllago"), 0755)
 
-	prov := stubProviderForInstaller("test-prov")
+	// Use a real slug: checkHookStatus now routes through the provider's
+	// HookAdapter (ADR-0020), so a slug with no adapter would report
+	// NotAvailable rather than NotInstalled.
+	prov := stubProviderForInstaller("claude-code")
 
 	// Create a valid hook file so checkHookStatus can parse it
 	hookDir := filepath.Join(repoRoot, "content", "hooks", "test-prov", "my-hook")

--- a/cli/internal/installer/orphans.go
+++ b/cli/internal/installer/orphans.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/OpenScribbler/syllago/cli/internal/converter"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
 	"github.com/tidwall/gjson"
 )
@@ -32,14 +33,13 @@ func CheckOrphanedMerges(projectRoot string, providers []provider.Provider) ([]O
 		return nil, err
 	}
 
-	// Build lookup sets for fast matching
-	hookSet := make(map[string]map[string]bool) // groupHash -> true
+	// Build lookup sets for fast matching. Hooks are matched by their canonical
+	// identity (installed.json GroupHash is the post-round-trip
+	// sha256(event|matcher|command|name)), the same identity install computes.
+	trackedHooks := make(map[string]bool)
 	for _, h := range inst.Hooks {
 		if h.GroupHash != "" {
-			if hookSet[h.Event] == nil {
-				hookSet[h.Event] = make(map[string]bool)
-			}
-			hookSet[h.Event][h.GroupHash] = true
+			trackedHooks[h.GroupHash] = true
 		}
 	}
 	mcpSet := make(map[string]bool)
@@ -59,37 +59,36 @@ func CheckOrphanedMerges(projectRoot string, providers []provider.Provider) ([]O
 			continue
 		}
 
+		// Hooks: decode the provider's real hook file via its adapter and match
+		// each decoded hook by canonical identity. Providers with no adapter or
+		// no supported hook path (Phase 1b) are skipped so they are never
+		// false-flagged.
+		if adapter := converter.AdapterFor(prov.Slug); adapter != nil {
+			if hookPath, pErr := HookConfigPath(prov, home); pErr == nil {
+				if data, readErr := os.ReadFile(hookPath); readErr == nil {
+					if decoded, dErr := adapter.Decode(data); dErr == nil {
+						for i, hk := range decoded.Hooks {
+							if trackedHooks[hookIdentity(hk)] {
+								continue // tracked by syllago
+							}
+							orphans = append(orphans, OrphanEntry{
+								Provider: prov.Slug,
+								Type:     "hook",
+								Key:      nativeEventFor(hk.Event, prov.Slug),
+								Index:    i,
+							})
+						}
+					}
+				}
+			}
+		}
+
+		// MCP: unchanged — mcpServers.<name> objects in <ConfigDir>/settings.json.
 		settingsPath := filepath.Join(home, prov.ConfigDir, "settings.json")
 		data, readErr := os.ReadFile(settingsPath)
 		if readErr != nil {
 			continue // no settings file for this provider
 		}
-
-		// Check hooks: settings.json has hooks.<event> arrays
-		hooksObj := gjson.GetBytes(data, "hooks")
-		if hooksObj.Exists() && hooksObj.IsObject() {
-			hooksObj.ForEach(func(event, eventArr gjson.Result) bool {
-				if !eventArr.IsArray() {
-					return true
-				}
-				eventName := event.String()
-				for i, entry := range eventArr.Array() {
-					entryHash := computeGroupHash([]byte(entry.Raw))
-					if hookSet[eventName] != nil && hookSet[eventName][entryHash] {
-						continue // tracked
-					}
-					orphans = append(orphans, OrphanEntry{
-						Provider: prov.Slug,
-						Type:     "hook",
-						Key:      eventName,
-						Index:    i,
-					})
-				}
-				return true
-			})
-		}
-
-		// Check MCP: settings.json has mcpServers.<name> objects
 		mcpObj := gjson.GetBytes(data, "mcpServers")
 		if mcpObj.Exists() && mcpObj.IsObject() {
 			mcpObj.ForEach(func(key, _ gjson.Result) bool {

--- a/cli/internal/installer/orphans_test.go
+++ b/cli/internal/installer/orphans_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/OpenScribbler/syllago/cli/internal/converter"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
 )
 
@@ -36,7 +37,8 @@ func TestCheckOrphanedMerges_DetectsOrphanedHook(t *testing.T) {
 		t.Fatalf("getting home dir: %v", err)
 	}
 
-	// Create a provider config directory with hooks in settings.json
+	// Create a claude-code config directory with two hooks in its native
+	// settings.json — orphan detection now decodes via the provider's adapter.
 	configDir := filepath.Join(home, ".syllago-test-orphan-"+filepath.Base(projectRoot))
 	os.MkdirAll(configDir, 0755)
 	t.Cleanup(func() { os.RemoveAll(configDir) })
@@ -51,9 +53,29 @@ func TestCheckOrphanedMerges_DetectsOrphanedHook(t *testing.T) {
 }`
 	os.WriteFile(filepath.Join(configDir, "settings.json"), []byte(settingsJSON), 0644)
 
-	// Only the first hook is tracked in installed.json
-	trackedEntry := `{"matcher":"Bash","hooks":[{"type":"command","command":"echo tracked"}]}`
-	trackedHash := computeGroupHash([]byte(trackedEntry))
+	prov := provider.Provider{
+		Name:      "Claude Code",
+		Slug:      "claude-code",
+		ConfigDir: filepath.Base(configDir),
+		Detected:  true,
+	}
+
+	// Track only the "echo tracked" hook, using the SAME canonical identity
+	// (decode via the adapter, then hookIdentity) that install records.
+	adapter := converter.AdapterFor("claude-code")
+	decoded, err := adapter.Decode([]byte(settingsJSON))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var trackedHash string
+	for _, hk := range decoded.Hooks {
+		if hk.Handler.Command == "echo tracked" {
+			trackedHash = hookIdentity(hk)
+		}
+	}
+	if trackedHash == "" {
+		t.Fatal("could not compute identity for tracked hook")
+	}
 
 	inst := &Installed{
 		Hooks: []InstalledHook{
@@ -62,30 +84,20 @@ func TestCheckOrphanedMerges_DetectsOrphanedHook(t *testing.T) {
 	}
 	SaveInstalled(projectRoot, inst)
 
-	prov := provider.Provider{
-		Name:      "Test",
-		Slug:      "test",
-		ConfigDir: filepath.Base(configDir),
-		Detected:  true,
-	}
-
 	orphans, err := CheckOrphanedMerges(projectRoot, []provider.Provider{prov})
 	if err != nil {
 		t.Fatalf("CheckOrphanedMerges: %v", err)
 	}
 
-	// Should find one orphan (the "echo orphan" entry)
+	// Should find exactly one orphan: the untracked "echo orphan" entry.
 	if len(orphans) != 1 {
-		t.Fatalf("expected 1 orphan, got %d", len(orphans))
+		t.Fatalf("expected 1 orphan, got %d: %+v", len(orphans), orphans)
 	}
 	if orphans[0].Type != "hook" {
 		t.Errorf("orphan type = %q, want hook", orphans[0].Type)
 	}
 	if orphans[0].Key != "PreToolUse" {
 		t.Errorf("orphan key = %q, want PreToolUse", orphans[0].Key)
-	}
-	if orphans[0].Index != 1 {
-		t.Errorf("orphan index = %d, want 1", orphans[0].Index)
 	}
 }
 

--- a/cli/internal/loadout/apply.go
+++ b/cli/internal/loadout/apply.go
@@ -16,7 +16,6 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/installer"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
 	"github.com/OpenScribbler/syllago/cli/internal/snapshot"
-	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -494,31 +493,6 @@ func findHookFile(itemDir string) string {
 		}
 	}
 	return ""
-}
-
-// resolveHookCommands resolves relative command paths in hook JSON to absolute paths.
-func resolveHookCommands(matcherGroup []byte, itemDir string) []byte {
-	// Walk through hooks array and resolve command paths
-	hooksArray := gjson.GetBytes(matcherGroup, "hooks")
-	if !hooksArray.Exists() || !hooksArray.IsArray() {
-		return matcherGroup
-	}
-
-	result := matcherGroup
-	for i, hook := range hooksArray.Array() {
-		cmd := hook.Get("command").String()
-		if cmd != "" {
-			resolved := ResolveHookCommand(itemDir, cmd)
-			if resolved != cmd {
-				key := fmt.Sprintf("hooks.%d.command", i)
-				updated, err := sjson.SetBytes(result, key, resolved)
-				if err == nil {
-					result = updated
-				}
-			}
-		}
-	}
-	return result
 }
 
 // readJSONFileOrEmpty reads a JSON file, returning {} if it doesn't exist.

--- a/cli/internal/loadout/apply.go
+++ b/cli/internal/loadout/apply.go
@@ -253,34 +253,25 @@ func applyActions(actions []PlannedAction, refs []ResolvedRef, prov provider.Pro
 	return nil
 }
 
-// settingsPathFor computes the settings.json path for a provider, using the
-// resolver's base dir if configured, otherwise falling back to homeDir.
-func settingsPathFor(prov provider.Provider, homeDir string, resolver *config.PathResolver) string {
+// settingsPathFor computes a provider's hook config path via the shared
+// installer.HookConfigPath resolver (ADR-0020 path table), honoring the
+// resolver's base dir override when configured. Returns an error for providers
+// whose hooks syllago cannot manage in Phase 1 (directory-scoped/adapter-less).
+func settingsPathFor(prov provider.Provider, homeDir string, resolver *config.PathResolver) (string, error) {
 	base := homeDir
 	if resolver != nil {
 		if bd := resolver.BaseDir(prov.Slug); bd != "" {
 			base = bd
 		}
 	}
-	// Crush keeps hooks in its unified crush.json, not a settings.json
-	// (mirrors installer.hookSettingsPathImpl). Routing here also covers the
-	// snapshot backup list and remove, which build paths via this function.
-	filename := "settings.json"
-	if prov.Slug == "crush" {
-		filename = "crush.json"
-	}
-	return filepath.Join(base, prov.ConfigDir, filename)
+	return installer.HookConfigPath(prov, base)
 }
 
-// applyHook reads a hook JSON file and appends it to settings.json.
-// This is the lower-level helper that works with raw hook data, avoiding the
-// catalog.ContentItem-dependent installHook in the installer package.
-//
-// Key trade-off: we duplicate some logic from installer.installHook here rather
-// than exporting it. The alternative would be to export appendHookEntry from the
-// installer package, but that creates a tighter coupling. Since the loadout engine
-// has different tracking needs (source is "loadout:<name>" vs "export"), it's cleaner
-// to keep this self-contained.
+// applyHook reads a hook JSON file and merges it into the provider's hook
+// config via the provider's converter.HookAdapter (ADR-0020 Phase 1). It
+// resolves relative command paths first, then delegates the
+// encode/merge/identity work to installer.ApplyCanonicalHook, recording the
+// result under the loadout's source tag.
 func applyHook(ref ResolvedRef, prov provider.Provider, homeDir string, resolver *config.PathResolver, inst *installer.Installed, source string) error {
 	// Find the hook JSON file in the item directory
 	hookFile := findHookFile(ref.Item.Path)
@@ -303,104 +294,43 @@ func applyHook(ref ResolvedRef, prov provider.Provider, homeDir string, resolver
 	if len(manifest.Hooks) != 1 {
 		return fmt.Errorf("hook file has %d hooks; syllago hook.json must contain exactly 1", len(manifest.Hooks))
 	}
-	hds, err := converter.HookDataFromManifest(manifest)
-	if err != nil {
-		return fmt.Errorf("converting manifest: %w", err)
-	}
-	hd := hds[0]
-	event := hd.Event
+	h := manifest.Hooks[0]
 
-	// Validate before using the event as an sjson key (mirrors installHook M3:
+	// Validate before using the event downstream (mirrors installHook M3:
 	// prevents key injection via dots in crafted event names).
-	if !converter.IsValidHookEvent(event) {
-		return fmt.Errorf("unknown hook event %q: must be a known canonical or provider event name", event)
+	if !converter.IsValidHookEvent(h.Event) {
+		return fmt.Errorf("unknown hook event %q: must be a known canonical or provider event name", h.Event)
 	}
 
 	// Reject events the provider has no settings key for (mirrors installHook,
 	// syllago-xqlc1). Apply already gates these via the skip-unsupported
 	// preview action; this is the defense-in-depth backstop at the actual
 	// merge point so dead config can never slip through if the two diverge.
-	if !converter.ProviderSupportsHookEvent(event, prov.Slug) {
-		return fmt.Errorf("hook %q: %s does not support hook event %q", ref.Name, prov.Name, event)
+	if !converter.ProviderSupportsHookEvent(h.Event, prov.Slug) {
+		return fmt.Errorf("hook %q: %s does not support hook event %q", ref.Name, prov.Name, h.Event)
 	}
 
-	// Translate canonical names to provider-native before the merge (mirrors
-	// installHook): the event becomes the settings key the provider actually
-	// reads, and matcher tool names become the names the provider tests its
-	// hook regexes against. Already-native names pass through unchanged.
-	if nativeEvent, ok := converter.TranslateHookEvent(event, prov.Slug); ok {
-		event = nativeEvent
-	}
-	matcher := hd.Matcher
-	if matcher != "" {
-		matcher = converter.TranslateMatcher(matcher, prov.Slug)
-	}
+	// Resolve relative command paths to absolute before encoding.
+	resolvedCmd := ResolveHookCommand(ref.Item.Path, h.Handler.Command)
 
-	// Build the provider-shape matcher group for merging into settings.json.
-	group := struct {
-		Matcher string                `json:"matcher,omitempty"`
-		Hooks   []converter.HookEntry `json:"hooks"`
-	}{
-		Matcher: matcher,
-		Hooks:   hd.Hooks,
-	}
-	matcherGroup, err := json.Marshal(group)
+	// Merge into the provider's hook file through its adapter.
+	settingsPath, err := settingsPathFor(prov, homeDir, resolver)
 	if err != nil {
-		return fmt.Errorf("building matcher group: %w", err)
+		return fmt.Errorf("hook %q: %w", ref.Name, err)
 	}
-
-	// Resolve relative command paths to absolute
-	matcherGroup = resolveHookCommands(matcherGroup, ref.Item.Path)
-
-	// Crush stores flat hook entries ({name, matcher, command, timeout}) in
-	// crush.json rather than CC-shape matcher groups (mirrors installHook).
-	// Flatten last so command resolution above sees the standard shape.
-	commandPath := "hooks.0.command"
-	if prov.Slug == "crush" {
-		matcherGroup, err = installer.FlattenForCrush(matcherGroup, manifest.Hooks[0].Name)
-		if err != nil {
-			return fmt.Errorf("hook %q: %w", ref.Name, err)
-		}
-		commandPath = "command"
+	res, err := installer.ApplyCanonicalHook(prov, h, settingsPath, resolvedCmd)
+	if err != nil {
+		return fmt.Errorf("hook %q: %w", ref.Name, err)
 	}
-
-	// Append to the provider's hook config file
-	settingsPath := settingsPathFor(prov, homeDir, resolver)
-	if err := appendHookEntry(settingsPath, event, matcherGroup); err != nil {
-		return err
-	}
-
-	// Extract command for tracking (crush entries are flat)
-	command := gjson.GetBytes(matcherGroup, commandPath).String()
 
 	inst.Hooks = append(inst.Hooks, installer.InstalledHook{
 		Name:        ref.Name,
-		Event:       event,
-		Command:     command,
+		Event:       res.NativeEvent,
+		GroupHash:   res.GroupHash,
+		Command:     res.Command,
 		Source:      source,
 		InstalledAt: time.Now(),
 	})
-
-	return nil
-}
-
-// appendHookEntry appends a matcher group to hooks.<event> in settings.json.
-// This is the shared lower-level helper for merging hook JSON.
-func appendHookEntry(settingsPath string, event string, matcherGroup []byte) error {
-	fileData, err := readJSONFileOrEmpty(settingsPath)
-	if err != nil {
-		return fmt.Errorf("reading %s: %w", settingsPath, err)
-	}
-
-	key := "hooks." + event + ".-1"
-	fileData, err = sjson.SetRawBytes(fileData, key, matcherGroup)
-	if err != nil {
-		return fmt.Errorf("appending hook: %w", err)
-	}
-
-	if err := writeJSONFileAtomic(settingsPath, fileData); err != nil {
-		return fmt.Errorf("writing %s: %w", settingsPath, err)
-	}
 
 	return nil
 }
@@ -466,32 +396,27 @@ func applyMCP(ref ResolvedRef, prov provider.Provider, projectRoot string, inst 
 // it would corrupt the real crush.json (wrong key and CC-shape group). Callers
 // warn the user to revert manually in that case.
 func injectSessionEndHook(prov provider.Provider, homeDir string, resolver *config.PathResolver) (injected bool, err error) {
-	// Translate to the provider-native event key; skip if unsupported so we
-	// never write a key the provider can't read (syllago-xqlc1).
-	event, ok := converter.TranslateHookEvent("session_end", prov.Slug)
-	if !ok {
+	// Skip when the provider has no session_end event so we never write a key
+	// the provider can't read (syllago-xqlc1).
+	if _, ok := converter.TranslateHookEvent("session_end", prov.Slug); !ok {
 		return false, nil
 	}
 
-	settingsPath := settingsPathFor(prov, homeDir, resolver)
-
-	// Build the session-end hook entry
-	hookEntry := map[string]interface{}{
-		"matcher": "",
-		"hooks": []map[string]interface{}{
-			{
-				"type":    "command",
-				"command": "syllago loadout remove --auto",
-			},
-		},
-	}
-
-	hookJSON, err := json.Marshal(hookEntry)
+	settingsPath, err := settingsPathFor(prov, homeDir, resolver)
 	if err != nil {
-		return false, fmt.Errorf("marshaling session-end hook: %w", err)
+		return false, err
 	}
 
-	if err := appendHookEntry(settingsPath, event, hookJSON); err != nil {
+	// Encode the hook in the provider's native format via its adapter (mirrors
+	// applyHook). A naive CC-shape append would write the wrong format for
+	// non-CC providers (e.g. windsurf's split-event model). Not tracked in
+	// installed.json — it is reverted when the snapshot restores the file.
+	h := converter.Hook{
+		Name:    "syllago-auto-revert",
+		Event:   "session_end",
+		Handler: converter.Handler{Type: "command", Command: "syllago loadout remove --auto"},
+	}
+	if _, err := installer.ApplyCanonicalHook(prov, h, settingsPath, ""); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -523,7 +448,11 @@ func collectBackupFiles(actions []PlannedAction, prov provider.Provider, opts Ap
 	}
 
 	if needsSettings {
-		files = append(files, settingsPathFor(prov, opts.HomeDir, opts.Resolver))
+		// Skip a provider whose hook path can't be resolved (Phase 1b /
+		// adapter-less): there is nothing this apply will write there to back up.
+		if path, err := settingsPathFor(prov, opts.HomeDir, opts.Resolver); err == nil {
+			files = append(files, path)
+		}
 	}
 	if needsMCPConfig {
 		mcpPath, err := installer.MCPConfigPathFor(prov, opts.ProjectRoot)

--- a/cli/internal/loadout/helpers_test.go
+++ b/cli/internal/loadout/helpers_test.go
@@ -216,53 +216,6 @@ func TestSettingsPathFor_ResolverNoMatch(t *testing.T) {
 	}
 }
 
-// --- resolveHookCommands (64.3% coverage) ---
-
-func TestResolveHookCommands_RelativePath(t *testing.T) {
-	t.Parallel()
-	itemDir := "/content/hooks/claude-code/my-hook"
-	input := []byte(`{"matcher":".*","hooks":[{"type":"command","command":"./run.sh"}]}`)
-
-	got := resolveHookCommands(input, itemDir)
-	// The relative ./run.sh should become an absolute path
-	want := filepath.Join(itemDir, "./run.sh")
-	if string(got) == string(input) {
-		t.Error("resolveHookCommands should have resolved relative path")
-	}
-	_ = want // The actual path check depends on ResolveHookCommand behavior
-}
-
-func TestResolveHookCommands_AbsolutePath(t *testing.T) {
-	t.Parallel()
-	input := []byte(`{"matcher":".*","hooks":[{"type":"command","command":"/usr/bin/echo test"}]}`)
-
-	got := resolveHookCommands(input, "/some/dir")
-	// Absolute paths should not be modified
-	if string(got) != string(input) {
-		t.Errorf("resolveHookCommands should not modify absolute paths, got %q", string(got))
-	}
-}
-
-func TestResolveHookCommands_NoHooksArray(t *testing.T) {
-	t.Parallel()
-	input := []byte(`{"matcher":".*"}`)
-
-	got := resolveHookCommands(input, "/some/dir")
-	if string(got) != string(input) {
-		t.Errorf("resolveHookCommands should return input unchanged when no hooks array")
-	}
-}
-
-func TestResolveHookCommands_EmptyCommand(t *testing.T) {
-	t.Parallel()
-	input := []byte(`{"hooks":[{"type":"command","command":""}]}`)
-
-	got := resolveHookCommands(input, "/some/dir")
-	if string(got) != string(input) {
-		t.Errorf("resolveHookCommands should not modify empty commands")
-	}
-}
-
 // --- symlinkSource (66.7% coverage — agents case untested) ---
 
 func TestSymlinkSource_Agents(t *testing.T) {

--- a/cli/internal/loadout/helpers_test.go
+++ b/cli/internal/loadout/helpers_test.go
@@ -177,7 +177,10 @@ func TestFindHookFile_NonexistentDir(t *testing.T) {
 func TestSettingsPathFor_NoResolver(t *testing.T) {
 	t.Parallel()
 	prov := provider.Provider{Slug: "claude-code", ConfigDir: ".claude"}
-	got := settingsPathFor(prov, "/home/user", nil)
+	got, err := settingsPathFor(prov, "/home/user", nil)
+	if err != nil {
+		t.Fatalf("settingsPathFor: %v", err)
+	}
 	want := "/home/user/.claude/settings.json"
 	if got != want {
 		t.Errorf("settingsPathFor() = %q, want %q", got, want)
@@ -188,7 +191,10 @@ func TestSettingsPathFor_WithResolver(t *testing.T) {
 	t.Parallel()
 	prov := provider.Provider{Slug: "claude-code", ConfigDir: ".claude"}
 	resolver := config.NewResolver(nil, "/custom/base")
-	got := settingsPathFor(prov, "/home/user", resolver)
+	got, err := settingsPathFor(prov, "/home/user", resolver)
+	if err != nil {
+		t.Fatalf("settingsPathFor: %v", err)
+	}
 	want := "/custom/base/.claude/settings.json"
 	if got != want {
 		t.Errorf("settingsPathFor() = %q, want %q", got, want)
@@ -200,7 +206,10 @@ func TestSettingsPathFor_ResolverNoMatch(t *testing.T) {
 	prov := provider.Provider{Slug: "cursor", ConfigDir: ".cursor"}
 	// Resolver has no CLI base dir and no config for cursor
 	resolver := config.NewResolver(nil, "")
-	got := settingsPathFor(prov, "/home/user", resolver)
+	got, err := settingsPathFor(prov, "/home/user", resolver)
+	if err != nil {
+		t.Fatalf("settingsPathFor: %v", err)
+	}
 	want := "/home/user/.cursor/settings.json"
 	if got != want {
 		t.Errorf("settingsPathFor() = %q, want %q", got, want)

--- a/cli/internal/loadout/testdata/settings-hook-merge.golden
+++ b/cli/internal/loadout/testdata/settings-hook-merge.golden
@@ -1,6 +1,17 @@
 {
   "userPref": "dark-mode",
   "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo golden-test"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "*.go",
@@ -12,5 +23,5 @@
         ]
       }
     ]
-  ,"PostToolUse":[{"matcher":".*","hooks":[{"type":"command","command":"echo golden-test"}]}]}
+  }
 }


### PR DESCRIPTION
## Summary

ADR-0020 Phase 1 (bead `syllago-igkju`). Routes hook install and loadout apply through each provider's `converter.HookAdapter` (decode existing file → append canonical hook → re-encode → write), replacing the naive CC-shape `sjson` append that wrote dead config to `<ConfigDir>/settings.json` for non-CC providers.

**Providers routed in Phase 1 — the five shared-JSON providers:** claude-code, crush, cursor, gemini-cli, factory-droid. Only the encoded `hooks` key is merged into each provider's real settings file; sibling config (permissions, env, MCP servers, model) is preserved.

- **One path resolver** (`installer.HookConfigPath`) replaces three divergent ones (install, loadout, orphans).
- **uninstall/status** match by a post-round-trip canonical identity hash stored in `installed.json`.
- **Honest rejection** (no dead config) for adapter-less amp/codex and the deferred providers below.
- Retires the crush slug hardcode from #512, `appendHookEntry`, `FlattenForCrush`, and the dead `resolveHookCommands`; try-mode session-end injection and `orphans.go` now use the adapter model too.

## Deferred to Phase 1b (`syllago-l44f3`)
- **windsurf** — its adapter fans one `before_tool_execute` hook into 4 split-events and only merges them back when each has exactly one entry, so the identity used for uninstall/status is unstable once a second windsurf hook is installed. Needs a stable per-entry identity (a syllago marker), which is a windsurf-adapter design task.
- **copilot-cli / kiro / pi** — directory-based (`.github/hooks/`, `.kiro/agents/`, `.pi/extensions/`) with an unresolved project-vs-home scope question.

## Follow-ups
- `syllago-8kmtq` (Phase 2): the decode→encode-all flow re-serializes every existing hook per operation — non-deterministic event-key order (config-diff churn) and no `adapter.Verify` fidelity guard. Tracked with the Phase 2 convert/export migration.

## Review
Reviewed by the authoring model (fixed 3 bugs: divergent path resolvers, session-end injection format, orphan-detection regression) plus an independent adversarial pass (found the windsurf identity bug now deferred, and confirmed shared-JSON sibling-preservation, dedup, rollback, and orphan crash-safety are correct). 

## Testing
Per-provider install→status→uninstall roundtrip + sibling-preservation (5 shared-JSON providers), rejection tests (amp, copilot-cli, windsurf-deferred), direct dedicated-file write-branch unit test, orphan-detection realignment. Full `go test ./...`, `golangci-lint run ./...`, `make build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)