### PR TITLE
acif: split platform_unmappable into totality-net vs mechanism-malformed (Decision #40)

### DIFF
--- a/cli/internal/acif/diagnostics.go
+++ b/cli/internal/acif/diagnostics.go
@@ -39,6 +39,7 @@ const (
 	ErrHookScriptFileMissing          = "acif.hook.script_file_missing"
 	ErrHookScriptPathInvalid          = "acif.hook.script_path_invalid"
 	ErrHookPlatformUnmappable         = "acif.hook.platform_unmappable"
+	ErrHookPlatformMechanismMalformed = "acif.hook.platform_mechanism_malformed"
 	ErrHookNoDefaultForDegradedRender = "acif.hook.no_default_for_degraded_render"
 
 	DiagHookPlatformOverrideDropped     = "acif.hook.platform_override_dropped"

--- a/cli/internal/acif/hook_test.go
+++ b/cli/internal/acif/hook_test.go
@@ -516,7 +516,32 @@ func TestHookMechanisms(t *testing.T) {
 			"path":"unused.json",
 			"content":{"shell":"bash"}
 		}`), HookOpts{})
+		expectHookReject(t, err, ErrHookPlatformMechanismMalformed)
+	})
+
+	t.Run("unknown mechanism token rejects the totality net", func(t *testing.T) {
+		_, err := CanonicalizeProviderConfig(hookBlock(t, `{
+			"provider":"unknown-per-os-table",
+			"path":"unused.json",
+			"content":{"platforms":{"win32":"hooks/w.cmd"}}
+		}`), HookOpts{})
 		expectHookReject(t, err, ErrHookPlatformUnmappable)
+	})
+
+	t.Run("malformed instances of recognized mechanisms reject malformed, never unmappable", func(t *testing.T) {
+		cases := []string{
+			`{"provider":"per-os-key-map","path":"u.json","content":{"windows":123,"command":"hooks/base.sh"}}`,
+			`{"provider":"dual-shell-fields","path":"u.json","content":{"bash":"hooks/run.sh","fish":"hooks/run.fish"}}`,
+			`{"provider":"dual-shell-fields","path":"u.json","content":{}}`,
+			`{"provider":"filename-extension-convention","path":"u.json","content":{"path":"hooks/x.sh"}}`,
+			`{"provider":"per-os-key-map","path":"u.json","content":"{not json"}`,
+		}
+		for _, cfg := range cases {
+			_, err := CanonicalizeProviderConfig(hookBlock(t, cfg), HookOpts{})
+			expectHookReject(t, err, ErrHookPlatformMechanismMalformed)
+		}
+		_, err := CanonicalizeProviderConfig(map[string]any{"provider": "per-os-key-map", "path": "u.json"}, HookOpts{})
+		expectHookReject(t, err, ErrHookPlatformMechanismMalformed)
 	})
 
 	t.Run("identity merge", func(t *testing.T) {

--- a/cli/internal/acif/hookmech.go
+++ b/cli/internal/acif/hookmech.go
@@ -10,7 +10,7 @@ func CanonicalizeProviderConfig(config map[string]any, opts HookOpts) (*HookResu
 	provider, _ := config["provider"].(string)
 	content, ok := config["content"]
 	if !ok {
-		return nil, hookReject(ErrHookPlatformUnmappable, "")
+		return nil, hookReject(ErrHookPlatformMechanismMalformed, "provider_config carries no content field; supply the mechanism content")
 	}
 
 	decoded, err := decodeProviderContent(content)
@@ -41,7 +41,7 @@ func decodeProviderContent(content any) (any, error) {
 	if s, ok := content.(string); ok {
 		var decoded any
 		if err := decodeJSONUseNumberBytes([]byte(s), &decoded); err != nil {
-			return nil, hookReject(ErrHookPlatformUnmappable, err.Error())
+			return nil, hookReject(ErrHookPlatformMechanismMalformed, "content string does not decode as JSON; supply structured mechanism content: "+err.Error())
 		}
 		return decoded, nil
 	}
@@ -51,7 +51,7 @@ func decodeProviderContent(content any) (any, error) {
 func canonicalizePerOSKeyMap(content any, opts HookOpts) (*HookResult, error) {
 	obj, ok := content.(map[string]any)
 	if !ok {
-		return nil, hookReject(ErrHookPlatformUnmappable, "")
+		return nil, hookReject(ErrHookPlatformMechanismMalformed, "per-os-key-map content must be an object")
 	}
 
 	var scripts []map[string]any
@@ -62,13 +62,13 @@ func canonicalizePerOSKeyMap(content any, opts HookOpts) (*HookResult, error) {
 		case "command":
 			path, ok := raw.(string)
 			if !ok {
-				return nil, hookReject(ErrHookPlatformUnmappable, key)
+				return nil, hookReject(ErrHookPlatformMechanismMalformed, "value under \""+key+"\" must be a string entrypoint path")
 			}
 			defaultEntry = map[string]any{"type": "file", "path": path}
 		case "windows", "linux", "osx":
 			path, ok := raw.(string)
 			if !ok {
-				return nil, hookReject(ErrHookPlatformUnmappable, key)
+				return nil, hookReject(ErrHookPlatformMechanismMalformed, "value under \""+key+"\" must be a string entrypoint path")
 			}
 			osTag := key
 			if osTag == "osx" {
@@ -85,7 +85,7 @@ func canonicalizePerOSKeyMap(content any, opts HookOpts) (*HookResult, error) {
 	}
 
 	if len(passthrough) > 0 && defaultEntry == nil {
-		return nil, hookReject(ErrHookPlatformUnmappable, "")
+		return nil, hookReject(ErrHookPlatformMechanismMalformed, "passthrough keys require a base command entry to carry them; add a command key")
 	}
 	if defaultEntry != nil {
 		for k, v := range passthrough {
@@ -141,13 +141,13 @@ func mergeConstrainedScriptIdentities(scripts []map[string]any) []map[string]any
 func canonicalizeDualShellFields(content any, opts HookOpts) (*HookResult, error) {
 	obj, ok := content.(map[string]any)
 	if !ok {
-		return nil, hookReject(ErrHookPlatformUnmappable, "")
+		return nil, hookReject(ErrHookPlatformMechanismMalformed, "dual-shell-fields content must be an object")
 	}
 	var scripts []map[string]any
 	for key, raw := range obj {
 		path, ok := raw.(string)
 		if !ok {
-			return nil, hookReject(ErrHookPlatformUnmappable, key)
+			return nil, hookReject(ErrHookPlatformMechanismMalformed, "value under \""+key+"\" must be a string entrypoint path")
 		}
 		switch key {
 		case "bash":
@@ -163,11 +163,11 @@ func canonicalizeDualShellFields(content any, opts HookOpts) (*HookResult, error
 				"os":   []any{"windows"},
 			})
 		default:
-			return nil, hookReject(ErrHookPlatformUnmappable, key)
+			return nil, hookReject(ErrHookPlatformMechanismMalformed, "key \""+key+"\" is not in the closed dual-shell key set {bash, powershell}")
 		}
 	}
 	if len(scripts) == 0 {
-		return nil, hookReject(ErrHookPlatformUnmappable, "")
+		return nil, hookReject(ErrHookPlatformMechanismMalformed, "dual-shell-fields requires at least one of bash, powershell")
 	}
 	return canonicalizeSynthesizedScripts(scripts, "inferred-from-convention", []Diagnostic{{ID: DiagHookPlatformShellOSProxy}}, opts)
 }
@@ -175,11 +175,11 @@ func canonicalizeDualShellFields(content any, opts HookOpts) (*HookResult, error
 func canonicalizeFilenameExtensionConvention(content any, opts HookOpts) (*HookResult, error) {
 	obj, ok := content.(map[string]any)
 	if !ok {
-		return nil, hookReject(ErrHookPlatformUnmappable, "")
+		return nil, hookReject(ErrHookPlatformMechanismMalformed, "filename-extension-convention content must be an object")
 	}
 	path, ok := obj["file"].(string)
 	if !ok {
-		return nil, hookReject(ErrHookPlatformUnmappable, "")
+		return nil, hookReject(ErrHookPlatformMechanismMalformed, "filename-extension-convention requires a string file field")
 	}
 
 	script := map[string]any{"type": "file", "path": path}

--- a/cli/internal/acif/rule.go
+++ b/cli/internal/acif/rule.go
@@ -70,8 +70,17 @@ func CanonicalizeRuleProviderConfig(config map[string]any) (*ItemResult, error) 
 	if provider, _ := config["provider"].(string); provider != "rule-activation-source" {
 		return nil, &RejectError{ID: ErrRuleActivationModeUnmappable}
 	}
-	content, _ := config["content"].(map[string]any)
-	mode, _ := content["source_sub_mode"].(string)
+	// [ACIF-RULE] §10 envelope rule: a modeless provider configuration is a
+	// present activation declaration without a mode claim — never the
+	// totality net.
+	content, ok := config["content"].(map[string]any)
+	if !ok {
+		return nil, &RejectError{ID: ErrRuleActivationModeMissing, Detail: "provider_config content must be an object carrying source_sub_mode"}
+	}
+	mode, ok := content["source_sub_mode"].(string)
+	if !ok || mode == "" {
+		return nil, &RejectError{ID: ErrRuleActivationModeMissing, Detail: "content carries no source_sub_mode string; declare the source-mechanism token"}
+	}
 	activation := map[string]any{}
 	switch mode {
 	case "always_on":

--- a/cli/internal/acif/rule_test.go
+++ b/cli/internal/acif/rule_test.go
@@ -133,6 +133,19 @@ func TestRuleMechanismDecode(t *testing.T) {
 		"content":  map[string]any{"source_sub_mode": "sometimes"},
 	})
 	assertReject(t, err, ErrRuleActivationModeUnmappable)
+
+	// [ACIF-RULE] §10 envelope faults: modeless configurations reject
+	// activation_mode_missing, never the totality net.
+	envelopeFaults := []map[string]any{
+		{"provider": "rule-activation-source"},
+		{"provider": "rule-activation-source", "content": "not an object"},
+		{"provider": "rule-activation-source", "content": map[string]any{"globs": []any{"*.md"}}},
+		{"provider": "rule-activation-source", "content": map[string]any{"source_sub_mode": 7}},
+	}
+	for _, cfg := range envelopeFaults {
+		_, err := CanonicalizeRuleProviderConfig(cfg)
+		assertReject(t, err, ErrRuleActivationModeMissing)
+	}
 }
 
 func TestRuleDerivedProjectionAndDegradedRender(t *testing.T) {


### PR DESCRIPTION
## What

Implements the impl half of ACIF Decision #40 (acif-7eg, Gate B spec-purist ratified):

- `acif.hook.platform_unmappable` is now emitted ONLY when the mechanism token has no [ACIF-HOOK] §7.4 row (the Class B totality-net signal downstream tooling keys on).
- New reject id `acif.hook.platform_mechanism_malformed` covers malformed instances of recognized mechanisms (non-string entrypoints, passthrough keys without a base `command`, unrecognized dual-shell keys, missing `file`) and envelope faults (absent/undecodable content), with fix-forward `Detail` text naming the remedy.
- Rule provider-config envelope faults now reject `acif.rule.activation_mode_missing` per the [ACIF-RULE] §10 envelope rule instead of leaking into the totality net.

## Why

The overload made capmon's class-B confirmation readback unable to distinguish "genuinely unmapped mechanism" (spec-gap candidate) from "authoring error in a mapped mechanism" — every hook authoring error would have counted as Class B spec-gap evidence.

## Verification

- `go vet` + `go test` green on `internal/acif` and `cmd/acif-adapter`; `go build ./...` green.
- Full ACIF conformance suite (suite 6, 170 vectors incl. the new TV-PLATFORM-u/v and TV-RULE-n/o negative vectors) passes against the adapter.
- Regression tests added for every reclassified reject path.

Spec side: OpenScribbler/agent-content-interchange-format@b35f0fc0 (specs, vectors, Decision #40) and @57c2d7f2 (source-mechanisms.yaml export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)