### PR TITLE
acif: implement PROTOCOL op 4.14 resolve_install_targets (syllago-f9qdk)

### DIFF
--- a/cli/cmd/acif-adapter/handlers.go
+++ b/cli/cmd/acif-adapter/handlers.go
@@ -48,7 +48,7 @@ func dispatch(req request) any {
 			"implementation":   "syllago",
 			"version":          adapterVersion,
 			"adapter_protocol": 2,
-			"scopes":           []string{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher", "registry", "render"},
+			"scopes":           []string{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher", "registry", "render", "install"},
 		})
 	case "ingest":
 		return handleIngest(req.Input)
@@ -76,6 +76,8 @@ func dispatch(req request) any {
 		return handleResolvePack(req.Input)
 	case "resolve_reference":
 		return handleResolveReference(req.Input)
+	case "resolve_install_targets":
+		return handleResolveInstallTargets(req.Input)
 	default:
 		return unsupportedResponse()
 	}

--- a/cli/cmd/acif-adapter/install.go
+++ b/cli/cmd/acif-adapter/install.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/OpenScribbler/syllago/cli/internal/acif"
+)
+
+type resolveInstallTargetsInput struct {
+	Provider    string             `json:"provider"`
+	ContentType string             `json:"content_type"`
+	ContentName string             `json:"content_name"`
+	HomeDir     string             `json:"home_dir"`
+	ProjectRoot string             `json:"project_root"`
+	Scope       string             `json:"scope"`
+	Entry       *acif.InstallEntry `json:"entry"`
+}
+
+// handleResolveInstallTargets implements PROTOCOL op 4.14 over
+// [ACIF-INSTALL] §6–§11.
+func handleResolveInstallTargets(raw json.RawMessage) any {
+	var input resolveInstallTargetsInput
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return errorResponse("adapter: " + err.Error())
+	}
+
+	targets, diags, err := acif.ResolveInstallTargets(acif.InstallResolveInput{
+		Provider:    input.Provider,
+		ContentType: input.ContentType,
+		ContentName: input.ContentName,
+		HomeDir:     input.HomeDir,
+		ProjectRoot: input.ProjectRoot,
+		Scope:       input.Scope,
+		Entry:       input.Entry,
+	})
+	if err != nil {
+		var reject *acif.RejectError
+		if errors.As(err, &reject) {
+			return rejectResponse(reject)
+		}
+		return errorResponse("adapter: " + err.Error())
+	}
+
+	result := map[string]any{"targets": targets}
+	if len(diags) > 0 {
+		result["diagnostics"] = diags
+	}
+	return okResponse(result)
+}

--- a/cli/cmd/acif-adapter/main_test.go
+++ b/cli/cmd/acif-adapter/main_test.go
@@ -600,3 +600,50 @@ func TestIngestAgentProviderConfigOrphanRequires(t *testing.T) {
 		t.Fatalf("params = %#v, want key=tool_restrictions", result["params"])
 	}
 }
+
+func TestResolveInstallTargetsOp(t *testing.T) {
+	t.Parallel()
+	requests := `{"op":"resolve_install_targets","input":{"provider":"claude-code","content_type":"agent","content_name":"helper","home_dir":"/h","project_root":"/p","scope":"user"}}` + "\n" +
+		`{"op":"resolve_install_targets","input":{"provider":"kiro","content_type":"rule","content_name":"style","home_dir":"/h","project_root":"/p","scope":"user"}}` + "\n" +
+		`{"op":"resolve_install_targets","input":[1,2]}` + "\n"
+	responses := runLines(t, requests)
+	if len(responses) != 3 {
+		t.Fatalf("responses = %d, want 3", len(responses))
+	}
+
+	wantOK := map[string]any{
+		"ok": true,
+		"result": map[string]any{
+			"targets": []any{map[string]any{
+				"scope":        "user",
+				"path":         "/h/.claude/agents/helper.md",
+				"layout":       "single_file",
+				"status":       "current",
+				"write_target": true,
+			}},
+		},
+	}
+	if !reflect.DeepEqual(responses[0], wantOK) {
+		t.Errorf("ok response = %#v, want %#v", responses[0], wantOK)
+	}
+
+	wantReject := map[string]any{
+		"ok":    false,
+		"error": "acif.install.scope_unavailable",
+		"diagnostics": []any{map[string]any{
+			"id":     "acif.install.scope_unavailable",
+			"params": map[string]any{"available_scopes": []any{"project"}},
+		}},
+	}
+	if !reflect.DeepEqual(responses[1], wantReject) {
+		t.Errorf("reject response = %#v, want %#v", responses[1], wantReject)
+	}
+
+	if responses[2]["ok"] != false {
+		t.Errorf("malformed-input response ok = %v, want false", responses[2]["ok"])
+	}
+	errText, _ := responses[2]["error"].(string)
+	if !strings.HasPrefix(errText, "adapter: ") {
+		t.Errorf("malformed-input error = %q, want adapter: prefix", errText)
+	}
+}

--- a/cli/cmd/acif-adapter/main_test.go
+++ b/cli/cmd/acif-adapter/main_test.go
@@ -61,7 +61,7 @@ func TestHello(t *testing.T) {
 			"implementation":   "syllago",
 			"version":          "0.0.0-dev",
 			"adapter_protocol": float64(2),
-			"scopes":           []any{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher", "registry", "render"},
+			"scopes":           []any{"core", "hook", "skill", "rule", "command", "agent", "mcp", "publisher", "registry", "render", "install"},
 		},
 	}
 	if !reflect.DeepEqual(responses[0], want) {

--- a/cli/internal/acif/install-entry-points.yaml
+++ b/cli/internal/acif/install-entry-points.yaml
@@ -1,0 +1,230 @@
+# ACIF install-entry-points export (machine-readable).
+#
+# The published, machine-readable projection of the install-target matrix
+# ([ACIF-INSTALL] Appendix A.2): for each (provider, content type) a
+# provider supports on disk, the ordered entry-point rows an install tool
+# resolves. The normative source is the Appendix A.2 table; this file is a
+# derived artifact whose currency is selftest-enforced (the
+# install-entry-points sync check fails if it drifts from that table).
+# Downstream conforming consumers — install tools, capmon's path-drift
+# probe, any registry re-serving the matrix — diff against THIS file,
+# never against spec prose (CHANGE-PROCESS.md, source-of-truth rule).
+#
+# Row model ([ACIF-INSTALL] §6): scope ∈ {user, project, managed};
+# path_template in the closed §8 grammar (`<content-name>` is the only
+# placeholder; `~/` = user home; otherwise project-root-relative);
+# layout ∈ {single_file, directory_of_files, merged_into_shared_file};
+# status ∈ {current, superseded} — superseded rows are retained, never
+# deleted. List order within a (provider, content type) is normative
+# precedence: the first current row for a scope is the write target.
+# The informative as_of names the survey basis a row was verified against.
+#
+# This export is a deterministic projection of the Appendix A.2 table: it
+# carries NO crawl date and NO observational provenance — determinism is
+# what downstream drift checks diff against. Correcting a row because a
+# provider moved a location is a row-data amendment (CHANGE-PROCESS.md,
+# "Row-data amendments"): land on observation, supersede, never delete.
+# Grammar/enum changes are Class C. Providers are keyed by the slugs the
+# normative appendices already use ([ACIF-HOOK] Appendix A/B columns).
+
+install_entry_points:
+  amp:
+    hook:
+      - {scope: project, path_template: ".amp/settings.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    mcp_config:
+      - {scope: project, path_template: ".amp/settings.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: user, path_template: "~/.config/amp/AGENTS.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: "AGENTS.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.config/agents/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".agents/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+  claude-code:
+    agent:
+      - {scope: user, path_template: "~/.claude/agents/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".claude/agents/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    command:
+      - {scope: user, path_template: "~/.claude/commands/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".claude/commands/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    hook:
+      - {scope: user, path_template: "~/.claude/settings.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey; installer path table (ADR-0020)"}
+      - {scope: project, path_template: ".claude/settings.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    mcp_config:
+      - {scope: project, path_template: ".mcp.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: user, path_template: "~/.claude/rules/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".claude/rules/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: "CLAUDE.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.claude/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".claude/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+  cline:
+    command:
+      - {scope: user, path_template: "~/Documents/Cline/Workflows/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".clinerules/workflows/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: user, path_template: "~/Documents/Cline/Rules/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".clinerules/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".clinerules", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.cline/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".cline/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+  codex:
+    command:
+      - {scope: project, path_template: ".codex/commands/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    hook:
+      - {scope: project, path_template: ".codex/hooks.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    mcp_config:
+      - {scope: user, path_template: "~/.codex/config.toml", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: user, path_template: "~/.codex/AGENTS.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: "AGENTS.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.agents/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".agents/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+  copilot-cli:
+    agent:
+      - {scope: user, path_template: "~/.github/agents/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".copilot/agents/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".github/agents/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    command:
+      - {scope: user, path_template: "~/.copilot/commands/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".copilot/commands/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    hook:
+      - {scope: project, path_template: ".github/hooks/<content-name>.json", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    mcp_config:
+      - {scope: user, path_template: "~/.copilot/mcp-config.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".copilot/mcp-config.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: project, path_template: ".github/copilot-instructions.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: "AGENTS.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.github/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".github/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+  crush:
+    hook:
+      - {scope: user, path_template: "~/.config/crush/crush.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey; installer path table (ADR-0020)"}
+      - {scope: project, path_template: "crush.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    mcp_config:
+      - {scope: user, path_template: "~/.config/crush/crush.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: "crush.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: project, path_template: "AGENTS.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.config/crush/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".crush/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+  cursor:
+    agent:
+      - {scope: user, path_template: "~/.cursor/agents/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".cursor/agents/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    hook:
+      - {scope: user, path_template: "~/.cursor/settings.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey; installer path table (ADR-0020)"}
+      - {scope: project, path_template: ".cursor/settings.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    mcp_config:
+      - {scope: user, path_template: "~/.cursor/mcp.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".cursor/mcp.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: project, path_template: ".cursor/rules/<content-name>.mdc", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".cursorrules", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.cursor/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".cursor/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+  factory-droid:
+    agent:
+      - {scope: user, path_template: "~/.factory/droids/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".factory/droids/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    command:
+      - {scope: user, path_template: "~/.factory/commands/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".factory/commands/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    hook:
+      - {scope: user, path_template: "~/.factory/settings.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey; installer path table (ADR-0020)"}
+      - {scope: project, path_template: ".factory/settings.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    mcp_config:
+      - {scope: user, path_template: "~/.factory/mcp.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".factory/mcp.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: project, path_template: "AGENTS.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.factory/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".factory/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+  gemini-cli:
+    agent:
+      - {scope: user, path_template: "~/.gemini/agents/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".gemini/agents/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    hook:
+      - {scope: user, path_template: "~/.gemini/settings.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey; installer path table (ADR-0020)"}
+      - {scope: project, path_template: ".gemini/settings.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    mcp_config:
+      - {scope: user, path_template: "~/.gemini/settings.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".gemini/settings.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: user, path_template: "~/.gemini/GEMINI.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: "GEMINI.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.gemini/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: user, path_template: "~/.agents/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".gemini/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".agents/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+  kiro:
+    mcp_config:
+      - {scope: user, path_template: "~/.kiro/settings/mcp.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".kiro/settings/mcp.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: project, path_template: ".kiro/steering/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+  opencode:
+    agent:
+      - {scope: user, path_template: "~/.config/opencode/agents/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".opencode/agents/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    command:
+      - {scope: user, path_template: "~/.config/opencode/commands/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".opencode/commands/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    mcp_config:
+      - {scope: project, path_template: "opencode.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: "opencode.jsonc", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: user, path_template: "~/.config/opencode/AGENTS.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: "AGENTS.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.config/opencode/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: user, path_template: "~/.agents/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".opencode/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".agents/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+  pi:
+    command:
+      - {scope: user, path_template: "~/.pi/agent/prompts/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".pi/prompts/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    hook:
+      - {scope: user, path_template: "~/.pi/agent/extensions/<content-name>.ts", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".pi/extensions/<content-name>.ts", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: project, path_template: "AGENTS.md", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.pi/agent/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".pi/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+  roo-code:
+    command:
+      - {scope: user, path_template: "~/.roo/commands/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".roo/commands/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    mcp_config:
+      - {scope: project, path_template: ".roo/mcp.json", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: user, path_template: "~/.roo/rules/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".roo/rules/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".roorules", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.roo/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: user, path_template: "~/.agents/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".roo/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".agents/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+  windsurf:
+    command:
+      - {scope: user, path_template: "~/.codeium/windsurf/global_workflows/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".windsurf/workflows/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+    rule:
+      - {scope: project, path_template: ".windsurf/rules/<content-name>.md", layout: single_file, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".windsurfrules", layout: merged_into_shared_file, status: current, as_of: "syllago 2026-07 survey"}
+    skill:
+      - {scope: user, path_template: "~/.codeium/windsurf/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: user, path_template: "~/.agents/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".windsurf/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}
+      - {scope: project, path_template: ".agents/skills/<content-name>/", layout: directory_of_files, status: current, as_of: "syllago 2026-07 survey"}

--- a/cli/internal/acif/installtargets.go
+++ b/cli/internal/acif/installtargets.go
@@ -1,0 +1,226 @@
+package acif
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Entry-point resolution over the install-target matrix
+// ([ACIF-INSTALL] §6–§9, §11; PROTOCOL op 4.14).
+
+// InstallEntryPointsPathEnv points at a refreshed copy of the
+// conformance/install-entry-points.yaml export. The embedded copy is the
+// vendored fallback ([ACIF-INSTALL] §12, refresh-over-vendored).
+const InstallEntryPointsPathEnv = "ACIF_INSTALL_ENTRY_POINTS"
+
+//go:embed install-entry-points.yaml
+var vendoredInstallEntryPoints []byte
+
+// InstallEntry is one entry-point row ([ACIF-INSTALL] §6). JSON tags cover
+// the PROTOCOL §4.14 `entry` override; YAML tags cover the export rows.
+type InstallEntry struct {
+	Scope        string `yaml:"scope" json:"scope"`
+	PathTemplate string `yaml:"path_template" json:"path_template"`
+	Layout       string `yaml:"layout" json:"layout"`
+	Status       string `yaml:"status" json:"status"`
+}
+
+// InstallTarget is one resolved entry point (PROTOCOL §4.14 result row).
+type InstallTarget struct {
+	Scope       string `json:"scope"`
+	Path        string `json:"path"`
+	Layout      string `json:"layout"`
+	Status      string `json:"status"`
+	WriteTarget bool   `json:"write_target"`
+}
+
+// InstallResolveInput carries the PROTOCOL §4.14 inputs. Entry, when
+// non-nil, overrides the matrix with a single fully-formed row.
+type InstallResolveInput struct {
+	Provider    string
+	ContentType string
+	ContentName string
+	HomeDir     string
+	ProjectRoot string
+	Scope       string
+	Entry       *InstallEntry
+}
+
+type installMatrix map[string]map[string][]InstallEntry
+
+var (
+	installMatrixOnce sync.Once
+	installMatrixVal  installMatrix
+	installMatrixErr  error
+)
+
+func loadInstallMatrix() (installMatrix, error) {
+	installMatrixOnce.Do(func() {
+		data := vendoredInstallEntryPoints
+		if path := os.Getenv(InstallEntryPointsPathEnv); path != "" {
+			refreshed, err := os.ReadFile(path)
+			if err != nil {
+				installMatrixErr = fmt.Errorf("read %s: %w", path, err)
+				return
+			}
+			data = refreshed
+		}
+		var doc struct {
+			InstallEntryPoints installMatrix `yaml:"install_entry_points"`
+		}
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			installMatrixErr = fmt.Errorf("parse install-entry-points export: %w", err)
+			return
+		}
+		installMatrixVal = doc.InstallEntryPoints
+	})
+	return installMatrixVal, installMatrixErr
+}
+
+// installPlaceholderRe matches placeholder tokens in a path template. The
+// token set is closed (§8.1): `<content-name>` is the only member in 0.1.
+var installPlaceholderRe = regexp.MustCompile(`<[^<>/]+>`)
+
+func unrecognizedInstallToken(template string) string {
+	for _, token := range installPlaceholderRe.FindAllString(template, -1) {
+		if token != "<content-name>" {
+			return token
+		}
+	}
+	return ""
+}
+
+// resolveInstallPath anchors and substitutes one row (§8.3). Resolution is
+// byte-exact string assembly: no separator normalization, no Clean — a
+// trailing slash on a directory_of_files template survives.
+func resolveInstallPath(row InstallEntry, contentName, homeDir, projectRoot string) string {
+	path := row.PathTemplate
+	switch {
+	case strings.HasPrefix(path, "~/"):
+		path = homeDir + path[1:]
+	case row.Scope == "managed":
+		// Managed templates are absolute and resolve verbatim.
+	default:
+		path = projectRoot + "/" + path
+	}
+	return strings.ReplaceAll(path, "<content-name>", contentName)
+}
+
+// ResolveInstallTargets resolves the ordered entry-point rows for an
+// invocation per [ACIF-INSTALL] §6–§9 and the §11 disposition lanes. The
+// returned error is a *RejectError for every spec-minted refusal.
+func ResolveInstallTargets(in InstallResolveInput) ([]InstallTarget, []Diagnostic, error) {
+	// §8.2 validity predicate — rejected before any path is formed. A
+	// content name carries no separators, so the whole name is the only
+	// segment substitution can produce.
+	name := in.ContentName
+	if name == "" || name == "." || name == ".." ||
+		strings.ContainsAny(name, "/\\") || strings.ContainsRune(name, 0) {
+		return nil, nil, &RejectError{ID: "acif.install.content_name_invalid"}
+	}
+
+	var rows []InstallEntry
+	if in.Entry != nil {
+		rows = []InstallEntry{*in.Entry}
+	} else {
+		matrix, err := loadInstallMatrix()
+		if err != nil {
+			return nil, nil, err
+		}
+		rows = matrix[in.Provider][in.ContentType]
+	}
+
+	// §6: absence is meaningful — no rows means refuse, never guess.
+	if len(rows) == 0 {
+		return nil, nil, &RejectError{ID: "acif.install.no_entry_point"}
+	}
+
+	if in.Scope != "" {
+		var filtered []InstallEntry
+		var available []string
+		seen := map[string]bool{}
+		for _, row := range rows {
+			if row.Scope == in.Scope {
+				filtered = append(filtered, row)
+			} else if !seen[row.Scope] {
+				seen[row.Scope] = true
+				available = append(available, row.Scope)
+			}
+		}
+		if len(filtered) == 0 {
+			return nil, nil, &RejectError{
+				ID: "acif.install.scope_unavailable",
+				Diagnostics: []Diagnostic{{
+					ID:     "acif.install.scope_unavailable",
+					Params: map[string]any{"available_scopes": available},
+				}},
+			}
+		}
+		rows = filtered
+	}
+
+	// §6: the first status-current row per scope is the write target.
+	writeIndex := map[string]int{}
+	for i, row := range rows {
+		if row.Status == "current" {
+			if _, ok := writeIndex[row.Scope]; !ok {
+				writeIndex[row.Scope] = i
+			}
+		}
+	}
+
+	targets := make([]InstallTarget, 0, len(rows))
+	var diags []Diagnostic
+	for i, row := range rows {
+		isWrite := false
+		if j, ok := writeIndex[row.Scope]; ok && j == i {
+			isWrite = true
+		}
+		// §8.1 placeholder totality: a token outside the closed grammar
+		// refuses the write direction; a read/discovery row cannot yield a
+		// resolved path either, so it is disclosed and skipped (§11).
+		if token := unrecognizedInstallToken(row.PathTemplate); token != "" {
+			diag := Diagnostic{
+				ID:     "acif.install.placeholder_unrecognized",
+				Params: map[string]any{"token": token},
+			}
+			if isWrite {
+				return nil, nil, &RejectError{
+					ID:          "acif.install.placeholder_unrecognized",
+					Diagnostics: []Diagnostic{diag},
+				}
+			}
+			diags = append(diags, diag)
+			continue
+		}
+		targets = append(targets, InstallTarget{
+			Scope:       row.Scope,
+			Path:        resolveInstallPath(row, name, in.HomeDir, in.ProjectRoot),
+			Layout:      row.Layout,
+			Status:      row.Status,
+			WriteTarget: isWrite,
+		})
+	}
+
+	// §11 supersession lane: a scope whose rows exist but include no
+	// status-current row resolves through a superseded location — warn,
+	// with the targets still returned.
+	warned := map[string]bool{}
+	for _, row := range rows {
+		if _, ok := writeIndex[row.Scope]; !ok && !warned[row.Scope] {
+			warned[row.Scope] = true
+			diags = append(diags, Diagnostic{
+				ID:     "acif.install.entry_point_superseded",
+				Params: map[string]any{"scope": row.Scope},
+			})
+		}
+	}
+
+	return targets, diags, nil
+}

--- a/cli/internal/acif/installtargets.go
+++ b/cli/internal/acif/installtargets.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -154,6 +155,8 @@ func ResolveInstallTargets(in InstallResolveInput) ([]InstallTarget, []Diagnosti
 			}
 		}
 		if len(filtered) == 0 {
+			// PROTOCOL Appendix A pins available_scopes as sorted.
+			sort.Strings(available)
 			return nil, nil, &RejectError{
 				ID: "acif.install.scope_unavailable",
 				Diagnostics: []Diagnostic{{

--- a/cli/internal/acif/installtargets_test.go
+++ b/cli/internal/acif/installtargets_test.go
@@ -1,0 +1,216 @@
+package acif
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func resolveOK(t *testing.T, in InstallResolveInput) ([]InstallTarget, []Diagnostic) {
+	t.Helper()
+	targets, diags, err := ResolveInstallTargets(in)
+	if err != nil {
+		t.Fatalf("ResolveInstallTargets: %v", err)
+	}
+	return targets, diags
+}
+
+func resolveReject(t *testing.T, in InstallResolveInput) *RejectError {
+	t.Helper()
+	_, _, err := ResolveInstallTargets(in)
+	var reject *RejectError
+	if !errors.As(err, &reject) {
+		t.Fatalf("expected RejectError, got %v", err)
+	}
+	return reject
+}
+
+// TV-INSTALL-a: multiplicity and write-target selection — order preserved,
+// first current row per scope is the write target.
+func TestResolveInstallTargets_MultiplicityWriteTarget(t *testing.T) {
+	t.Parallel()
+	targets, diags := resolveOK(t, InstallResolveInput{
+		Provider: "copilot-cli", ContentType: "agent", ContentName: "reviewer",
+		HomeDir: "/home/u", ProjectRoot: "/proj",
+	})
+	want := []InstallTarget{
+		{Scope: "user", Path: "/home/u/.github/agents/reviewer.md", Layout: "single_file", Status: "current", WriteTarget: true},
+		{Scope: "project", Path: "/proj/.copilot/agents/reviewer.md", Layout: "single_file", Status: "current", WriteTarget: true},
+		{Scope: "project", Path: "/proj/.github/agents/reviewer.md", Layout: "single_file", Status: "current", WriteTarget: false},
+	}
+	if !reflect.DeepEqual(targets, want) {
+		t.Errorf("targets = %+v, want %+v", targets, want)
+	}
+	if len(diags) != 0 {
+		t.Errorf("unexpected diagnostics: %+v", diags)
+	}
+}
+
+// TV-INSTALL-b (subset): layout coverage — one case per layout member,
+// including trailing-slash preservation on directory_of_files.
+func TestResolveInstallTargets_Layouts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   InstallResolveInput
+		want []InstallTarget
+	}{
+		{
+			name: "single_file",
+			in: InstallResolveInput{Provider: "claude-code", ContentType: "agent",
+				ContentName: "helper", HomeDir: "/h", ProjectRoot: "/p", Scope: "user"},
+			want: []InstallTarget{{Scope: "user", Path: "/h/.claude/agents/helper.md",
+				Layout: "single_file", Status: "current", WriteTarget: true}},
+		},
+		{
+			name: "merged_into_shared_file",
+			in: InstallResolveInput{Provider: "claude-code", ContentType: "hook",
+				ContentName: "guard", HomeDir: "/h", ProjectRoot: "/p", Scope: "user"},
+			want: []InstallTarget{{Scope: "user", Path: "/h/.claude/settings.json",
+				Layout: "merged_into_shared_file", Status: "current", WriteTarget: true}},
+		},
+		{
+			name: "directory_of_files",
+			in: InstallResolveInput{Provider: "gemini-cli", ContentType: "skill",
+				ContentName: "review", HomeDir: "/h", ProjectRoot: "/p", Scope: "user"},
+			want: []InstallTarget{
+				{Scope: "user", Path: "/h/.gemini/skills/review/",
+					Layout: "directory_of_files", Status: "current", WriteTarget: true},
+				{Scope: "user", Path: "/h/.agents/skills/review/",
+					Layout: "directory_of_files", Status: "current", WriteTarget: false},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			targets, _ := resolveOK(t, tc.in)
+			if !reflect.DeepEqual(targets, tc.want) {
+				t.Errorf("targets = %+v, want %+v", targets, tc.want)
+			}
+		})
+	}
+}
+
+// TV-INSTALL-c: §8.2 validity predicate rejects before path formation.
+func TestResolveInstallTargets_ContentNameInvalid(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"a/b", `a\b`, "..", ".", "", "nul\x00byte"} {
+		reject := resolveReject(t, InstallResolveInput{
+			Provider: "claude-code", ContentType: "command", ContentName: name,
+			HomeDir: "/h", ProjectRoot: "/p",
+		})
+		if reject.ID != "acif.install.content_name_invalid" {
+			t.Errorf("name %q: got %s, want acif.install.content_name_invalid", name, reject.ID)
+		}
+	}
+}
+
+// TV-INSTALL-d: §8.1 placeholder totality — an unrecognized token in the
+// write row refuses.
+func TestResolveInstallTargets_PlaceholderUnrecognized(t *testing.T) {
+	t.Parallel()
+	reject := resolveReject(t, InstallResolveInput{
+		Provider: "claude-code", ContentType: "command", ContentName: "deploy",
+		HomeDir: "/h", ProjectRoot: "/p",
+		Entry: &InstallEntry{Scope: "user",
+			PathTemplate: "~/.claude/commands/<unknown-variant>/<content-name>.md",
+			Layout:       "single_file", Status: "current"},
+	})
+	if reject.ID != "acif.install.placeholder_unrecognized" {
+		t.Errorf("got %s, want acif.install.placeholder_unrecognized", reject.ID)
+	}
+}
+
+// TV-INSTALL-e: disposition lanes — no_entry_point, scope_unavailable with
+// pinned params, and the supersession warn with targets returned.
+func TestResolveInstallTargets_DispositionLanes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no_entry_point", func(t *testing.T) {
+		t.Parallel()
+		reject := resolveReject(t, InstallResolveInput{
+			Provider: "windsurf", ContentType: "hook", ContentName: "guard",
+			HomeDir: "/h", ProjectRoot: "/p",
+		})
+		if reject.ID != "acif.install.no_entry_point" {
+			t.Errorf("got %s, want acif.install.no_entry_point", reject.ID)
+		}
+	})
+
+	t.Run("scope_unavailable", func(t *testing.T) {
+		t.Parallel()
+		reject := resolveReject(t, InstallResolveInput{
+			Provider: "kiro", ContentType: "rule", ContentName: "style",
+			HomeDir: "/h", ProjectRoot: "/p", Scope: "user",
+		})
+		if reject.ID != "acif.install.scope_unavailable" {
+			t.Fatalf("got %s, want acif.install.scope_unavailable", reject.ID)
+		}
+		if len(reject.Diagnostics) != 1 {
+			t.Fatalf("diagnostics = %+v, want one entry", reject.Diagnostics)
+		}
+		want := map[string]any{"available_scopes": []string{"project"}}
+		if !reflect.DeepEqual(reject.Diagnostics[0].Params, want) {
+			t.Errorf("params = %+v, want %+v", reject.Diagnostics[0].Params, want)
+		}
+	})
+
+	t.Run("superseded_warns_and_proceeds", func(t *testing.T) {
+		t.Parallel()
+		targets, diags := resolveOK(t, InstallResolveInput{
+			Provider: "claude-code", ContentType: "command", ContentName: "deploy",
+			HomeDir: "/h", ProjectRoot: "/p",
+			Entry: &InstallEntry{Scope: "user",
+				PathTemplate: "~/.claude/commands/<content-name>.md",
+				Layout:       "single_file", Status: "superseded"},
+		})
+		want := []InstallTarget{{Scope: "user", Path: "/h/.claude/commands/deploy.md",
+			Layout: "single_file", Status: "superseded", WriteTarget: false}}
+		if !reflect.DeepEqual(targets, want) {
+			t.Errorf("targets = %+v, want %+v", targets, want)
+		}
+		if len(diags) != 1 || diags[0].ID != "acif.install.entry_point_superseded" {
+			t.Errorf("diagnostics = %+v, want acif.install.entry_point_superseded", diags)
+		}
+	})
+}
+
+// TV-INSTALL-f: anchor resolution — home-anchored, project-anchored, and
+// absolute managed templates resolve against invocation-supplied roots.
+func TestResolveInstallTargets_Anchors(t *testing.T) {
+	t.Parallel()
+
+	userTargets, _ := resolveOK(t, InstallResolveInput{
+		Provider: "pi", ContentType: "hook", ContentName: "tracer",
+		HomeDir: "/home/dev", ProjectRoot: "/work/repo", Scope: "user",
+	})
+	wantUser := []InstallTarget{{Scope: "user", Path: "/home/dev/.pi/agent/extensions/tracer.ts",
+		Layout: "single_file", Status: "current", WriteTarget: true}}
+	if !reflect.DeepEqual(userTargets, wantUser) {
+		t.Errorf("user targets = %+v, want %+v", userTargets, wantUser)
+	}
+
+	projTargets, _ := resolveOK(t, InstallResolveInput{
+		Provider: "pi", ContentType: "hook", ContentName: "tracer",
+		HomeDir: "/home/dev", ProjectRoot: "/work/repo", Scope: "project",
+	})
+	wantProj := []InstallTarget{{Scope: "project", Path: "/work/repo/.pi/extensions/tracer.ts",
+		Layout: "single_file", Status: "current", WriteTarget: true}}
+	if !reflect.DeepEqual(projTargets, wantProj) {
+		t.Errorf("project targets = %+v, want %+v", projTargets, wantProj)
+	}
+
+	managedTargets, _ := resolveOK(t, InstallResolveInput{
+		Provider: "claude-code", ContentType: "agent", ContentName: "auditor",
+		HomeDir: "/home/dev", ProjectRoot: "/work/repo",
+		Entry: &InstallEntry{Scope: "managed",
+			PathTemplate: "/etc/acme/agents/<content-name>.md",
+			Layout:       "single_file", Status: "current"},
+	})
+	wantManaged := []InstallTarget{{Scope: "managed", Path: "/etc/acme/agents/auditor.md",
+		Layout: "single_file", Status: "current", WriteTarget: true}}
+	if !reflect.DeepEqual(managedTargets, wantManaged) {
+		t.Errorf("managed targets = %+v, want %+v", managedTargets, wantManaged)
+	}
+}

--- a/cli/internal/acif/installtargets_test.go
+++ b/cli/internal/acif/installtargets_test.go
@@ -156,6 +156,23 @@ func TestResolveInstallTargets_DispositionLanes(t *testing.T) {
 		}
 	})
 
+	t.Run("scope_unavailable_sorts_available_scopes", func(t *testing.T) {
+		t.Parallel()
+		// copilot-cli agent rows are ordered user, project, project; the
+		// PROTOCOL Appendix A param contract pins available_scopes sorted.
+		reject := resolveReject(t, InstallResolveInput{
+			Provider: "copilot-cli", ContentType: "agent", ContentName: "reviewer",
+			HomeDir: "/h", ProjectRoot: "/p", Scope: "managed",
+		})
+		if reject.ID != "acif.install.scope_unavailable" {
+			t.Fatalf("got %s, want acif.install.scope_unavailable", reject.ID)
+		}
+		want := map[string]any{"available_scopes": []string{"project", "user"}}
+		if !reflect.DeepEqual(reject.Diagnostics[0].Params, want) {
+			t.Errorf("params = %+v, want %+v", reject.Diagnostics[0].Params, want)
+		}
+	})
+
 	t.Run("superseded_warns_and_proceeds", func(t *testing.T) {
 		t.Parallel()
 		targets, diags := resolveOK(t, InstallResolveInput{


### PR DESCRIPTION
Adds the `install` scope to the acif adapter — entry-point resolution over the [ACIF-INSTALL] install-target matrix.

- New `cli/internal/acif/installtargets.go`: §8.2 content-name validity predicate, §8.3 byte-exact anchor resolution (home/project/managed), §6 first-current-row-per-scope write-target selection, §8.1 closed placeholder grammar, §11 disposition lanes (`no_entry_point`, `scope_unavailable` with `available_scopes` params, supersession warn).
- Vendors `conformance/install-entry-points.yaml` (13 providers, 124 rows) via `go:embed`; `ACIF_INSTALL_ENTRY_POINTS` env var refreshes over the vendored copy per §12.
- Adapter claims the `install` scope in `hello`; new op wired in dispatch.
- Unit tests mirror TV-INSTALL-a..f.

Verification: ACIF conformance runner — install scope 6/6 pass; full static suite green across all claimed scopes. `go test ./...`, `go vet`, `gofmt` clean.

Closes syllago-f9qdk (bd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)