### PR TITLE
feat(installer): consume ACIF install-entry-points matrix

### DIFF
--- a/cli/cmd/syllago/install_cmd.go
+++ b/cli/cmd/syllago/install_cmd.go
@@ -167,6 +167,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	scannerPaths, _ := cmd.Flags().GetStringSlice("hook-scanner")
 	force, _ := cmd.Flags().GetBool("force")
 	installer.SetScannerChain(scannerPaths, force)
+	refreshInstallEntryPointsForInstall()
 
 	// --to-all and --to are mutually exclusive.
 	if toAll && toSlug != "" {

--- a/cli/cmd/syllago/install_refresh.go
+++ b/cli/cmd/syllago/install_refresh.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/OpenScribbler/syllago/cli/internal/acif"
+)
+
+// Falling back to the vendored matrix is normal operation per
+// [ACIF-INSTALL] §12 (refresh-over-vendored), so a failed refresh is
+// deliberately silent — offline installs must not warn on every run.
+var refreshInstallEntryPointsForInstall = func() {
+	_ = acif.RefreshInstallEntryPoints(nil)
+}

--- a/cli/cmd/syllago/install_refresh_test.go
+++ b/cli/cmd/syllago/install_refresh_test.go
@@ -1,0 +1,5 @@
+package main
+
+func init() {
+	refreshInstallEntryPointsForInstall = func() {}
+}

--- a/cli/cmd/syllago/loadout_apply.go
+++ b/cli/cmd/syllago/loadout_apply.go
@@ -57,6 +57,8 @@ func init() {
 }
 
 func runLoadoutApply(cmd *cobra.Command, args []string) error {
+	refreshInstallEntryPointsForInstall()
+
 	projectRoot, _ := findProjectRoot()
 	checkAndWarnStaleSnapshot(projectRoot)
 

--- a/cli/internal/acif/bodyhash.go
+++ b/cli/internal/acif/bodyhash.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"github.com/OpenScribbler/syllago/cli/internal/moathash"
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -132,7 +132,7 @@ func hashEntryFile(path string, override []byte) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("reading entry file: %w", err)
 	}
-	return sha256Hex(stripFrontmatter(moat.CanonicalText(data))), nil
+	return sha256Hex(stripFrontmatter(moathash.CanonicalText(data))), nil
 }
 
 func multiFileBodyHash(files []bodyFile, entryRel string, entryOverride []byte) (string, error) {
@@ -158,7 +158,7 @@ func multiFileBodyHash(files []bodyFile, entryRel string, entryOverride []byte) 
 		if f.rel == entryRel {
 			fileHash, err = hashEntryFile(f.abs, entryOverride)
 		} else {
-			fileHash, err = moat.FileHash(f.abs)
+			fileHash, err = moathash.FileHash(f.abs)
 		}
 		if err != nil {
 			return "", fmt.Errorf("hashing %s: %w", f.rel, err)

--- a/cli/internal/acif/hook.go
+++ b/cli/internal/acif/hook.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/OpenScribbler/syllago/cli/internal/converter"
-	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"github.com/OpenScribbler/syllago/cli/internal/moathash"
 )
 
 type HookOpts struct {
@@ -266,7 +266,7 @@ func canonicalizeHookScript(script map[string]any) (map[string]any, error) {
 		if !ok {
 			return nil, hookReject(ErrHookScriptPathInvalid, "")
 		}
-		out["content"] = string(moat.CanonicalText([]byte(content)))
+		out["content"] = string(moathash.CanonicalText([]byte(content)))
 	default:
 		return nil, hookReject(ErrHookScriptPathInvalid, scriptType)
 	}

--- a/cli/internal/acif/hookhash.go
+++ b/cli/internal/acif/hookhash.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"github.com/OpenScribbler/syllago/cli/internal/moathash"
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -99,7 +99,7 @@ func hookReferencedFileManifest(paths []string, bodyRoot string) ([]byte, error)
 			return nil, fmt.Errorf("hook path collision: %q and %q normalize to %q", prior, path, key)
 		}
 		seenKeys[key] = path
-		fileHash, err := moat.FileHash(abs)
+		fileHash, err := moathash.FileHash(abs)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/internal/acif/hookproject.go
+++ b/cli/internal/acif/hookproject.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"sort"
 
-	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"github.com/OpenScribbler/syllago/cli/internal/moathash"
 )
 
 func ScriptSelection(block map[string]any, targets []string) (map[string]string, []Diagnostic, error) {
@@ -166,7 +166,7 @@ func executableIdentity(script map[string]any) string {
 		return typ + "\x00" + path
 	case "inline":
 		content, _ := script["content"].(string)
-		sum := sha256.Sum256(moat.CanonicalText([]byte(content)))
+		sum := sha256.Sum256(moathash.CanonicalText([]byte(content)))
 		return typ + "\x00" + hex.EncodeToString(sum[:])
 	default:
 		return typ

--- a/cli/internal/acif/installrefresh.go
+++ b/cli/internal/acif/installrefresh.go
@@ -22,7 +22,7 @@ func RefreshInstallEntryPoints(client *http.Client) error {
 	if err != nil {
 		return fmt.Errorf("fetch install entry points: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("fetch install entry points: status %s", resp.Status)

--- a/cli/internal/acif/installrefresh.go
+++ b/cli/internal/acif/installrefresh.go
@@ -1,0 +1,42 @@
+package acif
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const installEntryPointsURL = "https://raw.githubusercontent.com/OpenScribbler/agent-content-interchange-format/main/conformance/install-entry-points.yaml"
+
+// RefreshInstallEntryPoints fetches the current ACIF install entry-point
+// matrix and swaps it in for the vendored fallback after successful parsing.
+// ACIF_INSTALL_ENTRY_POINTS remains higher precedence because loadInstallMatrix
+// reads that path before consulting this swappable fallback.
+func RefreshInstallEntryPoints(client *http.Client) error {
+	if client == nil {
+		client = &http.Client{Timeout: 3 * time.Second}
+	}
+
+	resp, err := client.Get(installEntryPointsURL)
+	if err != nil {
+		return fmt.Errorf("fetch install entry points: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("fetch install entry points: status %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read install entry points: %w", err)
+	}
+
+	matrix, err := parseInstallMatrix(body)
+	if err != nil {
+		return fmt.Errorf("parse refreshed install entry points: %w", err)
+	}
+	swapInstallMatrix(matrix)
+	return nil
+}

--- a/cli/internal/acif/installrefresh_test.go
+++ b/cli/internal/acif/installrefresh_test.go
@@ -1,0 +1,278 @@
+package acif
+
+import (
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+type rewriteTransport struct {
+	target *url.URL
+	base   http.RoundTripper
+}
+
+func (rt rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.URL.Scheme = rt.target.Scheme
+	clone.URL.Host = rt.target.Host
+	clone.Host = rt.target.Host
+	return rt.base.RoundTrip(clone)
+}
+
+func installRefreshClient(t *testing.T, target string) *http.Client {
+	t.Helper()
+	u, err := url.Parse(target)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	return &http.Client{
+		Timeout: 2 * time.Second,
+		Transport: rewriteTransport{
+			target: u,
+			base:   http.DefaultTransport,
+		},
+	}
+}
+
+func newInstallRefreshServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("local httptest listener unavailable: %v", err)
+	}
+	ts := httptest.NewUnstartedServer(handler)
+	ts.Listener = ln
+	ts.Start()
+	return ts
+}
+
+func resetInstallMatrixStateForTest(t *testing.T) {
+	t.Helper()
+	installMatrixMu.Lock()
+	installMatrixLoaded = false
+	installMatrixVal = nil
+	installMatrixErr = nil
+	installMatrixMu.Unlock()
+}
+
+func unsetInstallEntryPointsPathEnv(t *testing.T) {
+	t.Helper()
+	old, had := os.LookupEnv(InstallEntryPointsPathEnv)
+	if err := os.Unsetenv(InstallEntryPointsPathEnv); err != nil {
+		t.Fatalf("unset %s: %v", InstallEntryPointsPathEnv, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(InstallEntryPointsPathEnv, old)
+			return
+		}
+		_ = os.Unsetenv(InstallEntryPointsPathEnv)
+	})
+}
+
+func vendoredRows(t *testing.T) []InstallEntry {
+	t.Helper()
+	unsetInstallEntryPointsPathEnv(t)
+	resetInstallMatrixStateForTest(t)
+	rows, err := InstallEntryRows("claude-code", "skill")
+	if err != nil {
+		t.Fatalf("InstallEntryRows: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("expected vendored claude-code skill rows")
+	}
+	return rows
+}
+
+func TestRefreshInstallEntryPoints_Success(t *testing.T) {
+	unsetInstallEntryPointsPathEnv(t)
+	resetInstallMatrixStateForTest(t)
+
+	ts := newInstallRefreshServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`
+install_entry_points:
+  test-provider:
+    skill:
+      - {scope: user, path_template: "~/.test/skills/<content-name>/", layout: directory_of_files, status: current}
+`))
+	}))
+	defer ts.Close()
+
+	if err := RefreshInstallEntryPoints(installRefreshClient(t, ts.URL)); err != nil {
+		t.Fatalf("RefreshInstallEntryPoints: %v", err)
+	}
+
+	rows, err := InstallEntryRows("test-provider", "skill")
+	if err != nil {
+		t.Fatalf("InstallEntryRows: %v", err)
+	}
+	wantRows := []InstallEntry{{
+		Scope:        "user",
+		PathTemplate: "~/.test/skills/<content-name>/",
+		Layout:       "directory_of_files",
+		Status:       "current",
+	}}
+	if !reflect.DeepEqual(rows, wantRows) {
+		t.Errorf("rows = %+v, want %+v", rows, wantRows)
+	}
+
+	targets, _, err := ResolveInstallTargets(InstallResolveInput{
+		Provider: "test-provider", ContentType: "skill", ContentName: "alpha",
+		HomeDir: "/home/u", ProjectRoot: "/repo", Scope: "user",
+	})
+	if err != nil {
+		t.Fatalf("ResolveInstallTargets: %v", err)
+	}
+	wantTargets := []InstallTarget{{
+		Scope: "user", Path: "/home/u/.test/skills/alpha/",
+		Layout: "directory_of_files", Status: "current", WriteTarget: true,
+	}}
+	if !reflect.DeepEqual(targets, wantTargets) {
+		t.Errorf("targets = %+v, want %+v", targets, wantTargets)
+	}
+}
+
+func TestRefreshInstallEntryPoints_TransportCoverage(t *testing.T) {
+	validBody := `
+install_entry_points:
+  transport-provider:
+    skill:
+      - {scope: user, path_template: "~/.transport/skills/<content-name>/", layout: directory_of_files, status: current}
+`
+
+	tests := []struct {
+		name      string
+		status    int
+		body      string
+		fetchErr  error
+		wantError bool
+	}{
+		{name: "valid", status: http.StatusOK, body: validBody},
+		{name: "garbage", status: http.StatusOK, body: "install_entry_points: [", wantError: true},
+		{name: "non_200", status: http.StatusTeapot, body: "nope", wantError: true},
+		{name: "connection_refused", fetchErr: errors.New("connection refused"), wantError: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			unsetInstallEntryPointsPathEnv(t)
+			resetInstallMatrixStateForTest(t)
+
+			client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.URL.String() != installEntryPointsURL {
+					t.Fatalf("request URL = %q, want %q", req.URL.String(), installEntryPointsURL)
+				}
+				if tc.fetchErr != nil {
+					return nil, tc.fetchErr
+				}
+				return &http.Response{
+					StatusCode: tc.status,
+					Status:     http.StatusText(tc.status),
+					Body:       io.NopCloser(strings.NewReader(tc.body)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			})}
+
+			err := RefreshInstallEntryPoints(client)
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if rows, rowsErr := InstallEntryRows("transport-provider", "skill"); rowsErr != nil || len(rows) != 0 {
+					t.Fatalf("failed refresh should not expose transport rows: rows=%+v err=%v", rows, rowsErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("RefreshInstallEntryPoints: %v", err)
+			}
+			rows, rowsErr := InstallEntryRows("transport-provider", "skill")
+			if rowsErr != nil {
+				t.Fatalf("InstallEntryRows: %v", rowsErr)
+			}
+			if len(rows) != 1 || rows[0].PathTemplate != "~/.transport/skills/<content-name>/" {
+				t.Fatalf("rows = %+v, want refreshed transport row", rows)
+			}
+		})
+	}
+}
+
+func TestRefreshInstallEntryPoints_GarbageKeepsVendoredState(t *testing.T) {
+	before := vendoredRows(t)
+
+	ts := newInstallRefreshServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("install_entry_points: ["))
+	}))
+	defer ts.Close()
+
+	if err := RefreshInstallEntryPoints(installRefreshClient(t, ts.URL)); err == nil {
+		t.Fatal("expected parse error")
+	}
+	after, err := InstallEntryRows("claude-code", "skill")
+	if err != nil {
+		t.Fatalf("InstallEntryRows after failed refresh: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Errorf("vendored rows changed after failed refresh: got %+v, want %+v", after, before)
+	}
+}
+
+func TestRefreshInstallEntryPoints_Non200KeepsVendoredState(t *testing.T) {
+	before := vendoredRows(t)
+
+	ts := newInstallRefreshServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusTeapot)
+	}))
+	defer ts.Close()
+
+	if err := RefreshInstallEntryPoints(installRefreshClient(t, ts.URL)); err == nil {
+		t.Fatal("expected status error")
+	}
+	after, err := InstallEntryRows("claude-code", "skill")
+	if err != nil {
+		t.Fatalf("InstallEntryRows after failed refresh: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Errorf("vendored rows changed after non-200 refresh: got %+v, want %+v", after, before)
+	}
+}
+
+func TestRefreshInstallEntryPoints_ConnectionRefusedKeepsVendoredState(t *testing.T) {
+	before := vendoredRows(t)
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("local listener unavailable: %v", err)
+	}
+	target := "http://" + ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	if err := RefreshInstallEntryPoints(installRefreshClient(t, target)); err == nil {
+		t.Fatal("expected connection error")
+	}
+	after, err := InstallEntryRows("claude-code", "skill")
+	if err != nil {
+		t.Fatalf("InstallEntryRows after failed refresh: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Errorf("vendored rows changed after connection error: got %+v, want %+v", after, before)
+	}
+}

--- a/cli/internal/acif/installtargets.go
+++ b/cli/internal/acif/installtargets.go
@@ -56,32 +56,80 @@ type InstallResolveInput struct {
 type installMatrix map[string]map[string][]InstallEntry
 
 var (
-	installMatrixOnce sync.Once
-	installMatrixVal  installMatrix
-	installMatrixErr  error
+	installMatrixMu     sync.RWMutex
+	installMatrixLoaded bool
+	installMatrixVal    installMatrix
+	installMatrixErr    error
 )
 
+func parseInstallMatrix(data []byte) (installMatrix, error) {
+	var doc struct {
+		InstallEntryPoints installMatrix `yaml:"install_entry_points"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse install-entry-points export: %w", err)
+	}
+	if doc.InstallEntryPoints == nil {
+		return nil, fmt.Errorf("parse install-entry-points export: missing install_entry_points")
+	}
+	return doc.InstallEntryPoints, nil
+}
+
+func loadVendoredInstallMatrix() (installMatrix, error) {
+	installMatrixMu.RLock()
+	if installMatrixLoaded {
+		matrix, err := installMatrixVal, installMatrixErr
+		installMatrixMu.RUnlock()
+		return matrix, err
+	}
+	installMatrixMu.RUnlock()
+
+	matrix, err := parseInstallMatrix(vendoredInstallEntryPoints)
+
+	installMatrixMu.Lock()
+	if !installMatrixLoaded {
+		installMatrixVal = matrix
+		installMatrixErr = err
+		installMatrixLoaded = true
+	}
+	matrix, err = installMatrixVal, installMatrixErr
+	installMatrixMu.Unlock()
+
+	return matrix, err
+}
+
+func swapInstallMatrix(matrix installMatrix) {
+	installMatrixMu.Lock()
+	installMatrixVal = matrix
+	installMatrixErr = nil
+	installMatrixLoaded = true
+	installMatrixMu.Unlock()
+}
+
 func loadInstallMatrix() (installMatrix, error) {
-	installMatrixOnce.Do(func() {
-		data := vendoredInstallEntryPoints
-		if path := os.Getenv(InstallEntryPointsPathEnv); path != "" {
-			refreshed, err := os.ReadFile(path)
-			if err != nil {
-				installMatrixErr = fmt.Errorf("read %s: %w", path, err)
-				return
-			}
-			data = refreshed
+	if path := os.Getenv(InstallEntryPointsPathEnv); path != "" {
+		refreshed, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
 		}
-		var doc struct {
-			InstallEntryPoints installMatrix `yaml:"install_entry_points"`
-		}
-		if err := yaml.Unmarshal(data, &doc); err != nil {
-			installMatrixErr = fmt.Errorf("parse install-entry-points export: %w", err)
-			return
-		}
-		installMatrixVal = doc.InstallEntryPoints
-	})
-	return installMatrixVal, installMatrixErr
+		return parseInstallMatrix(refreshed)
+	}
+	return loadVendoredInstallMatrix()
+}
+
+// InstallEntryRows returns the matrix rows for a provider/content-type pair.
+// The ACIF_INSTALL_ENTRY_POINTS override has the same precedence here as it
+// does in ResolveInstallTargets.
+func InstallEntryRows(provider, contentType string) ([]InstallEntry, error) {
+	matrix, err := loadInstallMatrix()
+	if err != nil {
+		return nil, err
+	}
+	rows := matrix[provider][contentType]
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return append([]InstallEntry(nil), rows...), nil
 }
 
 // installPlaceholderRe matches placeholder tokens in a path template. The

--- a/cli/internal/acif/record.go
+++ b/cli/internal/acif/record.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"github.com/OpenScribbler/syllago/cli/internal/moathash"
 	"gopkg.in/yaml.v3"
 )
 
@@ -154,7 +154,7 @@ func IngestExtensionBlock(kind string, sidecar map[string]any) (*RecordResult, e
 }
 
 func parseFrontmatterDocument(data []byte) (frontmatterDocument, error) {
-	text := moat.CanonicalText(data)
+	text := moathash.CanonicalText(data)
 	yamlText, body, present := splitFrontmatter(text)
 	doc := frontmatterDocument{Body: string(body), Present: present}
 	if !present || len(bytes.TrimSpace(yamlText)) == 0 {

--- a/cli/internal/config/acifresolve.go
+++ b/cli/internal/config/acifresolve.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/OpenScribbler/syllago/cli/internal/acif"
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+)
+
+func acifContentType(ct catalog.ContentType) string {
+	switch ct {
+	case catalog.Skills:
+		return "skill"
+	case catalog.Agents:
+		return "agent"
+	case catalog.MCP:
+		return "mcp_config"
+	case catalog.Rules:
+		return "rule"
+	case catalog.Hooks:
+		return "hook"
+	case catalog.Commands:
+		return "command"
+	default:
+		return ""
+	}
+}
+
+func matrixInstallDir(providerSlug string, ct catalog.ContentType, homeDir string) (string, bool) {
+	contentType := acifContentType(ct)
+	if contentType == "" {
+		return "", false
+	}
+
+	rows, err := acif.InstallEntryRows(providerSlug, contentType)
+	if err != nil {
+		return "", false
+	}
+	for _, row := range rows {
+		if row.Status != "current" || row.Scope != "user" {
+			continue
+		}
+		if row.Layout == "merged_into_shared_file" {
+			if ct != catalog.Hooks && ct != catalog.MCP {
+				return "", false
+			}
+			return provider.JSONMergeSentinel, true
+		}
+		return matrixTemplateDir(row.PathTemplate, homeDir)
+	}
+	return "", false
+}
+
+func matrixTemplateDir(pathTemplate, homeDir string) (string, bool) {
+	resolved := pathTemplate
+	if strings.HasPrefix(resolved, "~/") {
+		resolved = homeDir + resolved[1:]
+	}
+
+	trimmed := strings.TrimRight(resolved, "/")
+	lastSlash := strings.LastIndex(trimmed, "/")
+	if lastSlash < 0 {
+		return "", false
+	}
+
+	parent := trimmed[:lastSlash]
+	finalSegment := trimmed[lastSlash+1:]
+	if parent == "" || !strings.Contains(finalSegment, "<content-name>") {
+		return "", false
+	}
+	if strings.Contains(parent, "<content-name>") {
+		return "", false
+	}
+	return filepath.Clean(parent), true
+}

--- a/cli/internal/config/acifresolve_test.go
+++ b/cli/internal/config/acifresolve_test.go
@@ -1,0 +1,238 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/acif"
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+)
+
+func unsetACIFInstallEntryPointsEnv(t *testing.T) {
+	t.Helper()
+	old, had := os.LookupEnv(acif.InstallEntryPointsPathEnv)
+	if err := os.Unsetenv(acif.InstallEntryPointsPathEnv); err != nil {
+		t.Fatalf("unset %s: %v", acif.InstallEntryPointsPathEnv, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(acif.InstallEntryPointsPathEnv, old)
+			return
+		}
+		_ = os.Unsetenv(acif.InstallEntryPointsPathEnv)
+	})
+}
+
+func TestACIFContentType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		ct   catalog.ContentType
+		want string
+	}{
+		{catalog.Skills, "skill"},
+		{catalog.Agents, "agent"},
+		{catalog.MCP, "mcp_config"},
+		{catalog.Rules, "rule"},
+		{catalog.Hooks, "hook"},
+		{catalog.Commands, "command"},
+		{catalog.Loadouts, ""},
+		{catalog.SearchResults, ""},
+		{catalog.Library, ""},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.ct), func(t *testing.T) {
+			t.Parallel()
+			if got := acifContentType(tc.ct); got != tc.want {
+				t.Errorf("acifContentType(%s) = %q, want %q", tc.ct, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatrixInstallDirVendoredRows(t *testing.T) {
+	unsetACIFInstallEntryPointsEnv(t)
+
+	tests := []struct {
+		name         string
+		providerSlug string
+		ct           catalog.ContentType
+		want         string
+		wantOK       bool
+	}{
+		{
+			name:         "directory_of_files trims content directory",
+			providerSlug: "claude-code",
+			ct:           catalog.Skills,
+			want:         "/home/u/.claude/skills",
+			wantOK:       true,
+		},
+		{
+			name:         "single_file trims content file",
+			providerSlug: "claude-code",
+			ct:           catalog.Agents,
+			want:         "/home/u/.claude/agents",
+			wantOK:       true,
+		},
+		{
+			name:         "merged layout returns JSON merge sentinel",
+			providerSlug: "claude-code",
+			ct:           catalog.Hooks,
+			want:         provider.JSONMergeSentinel,
+			wantOK:       true,
+		},
+		{
+			name:         "no user row falls back to legacy caller",
+			providerSlug: "claude-code",
+			ct:           catalog.MCP,
+			wantOK:       false,
+		},
+		{
+			name:         "virtual type has no matrix mapping",
+			providerSlug: "claude-code",
+			ct:           catalog.Loadouts,
+			wantOK:       false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := matrixInstallDir(tc.providerSlug, tc.ct, "/home/u")
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Errorf("matrixInstallDir = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatrixInstallDirTemplateValidation(t *testing.T) {
+	matrixPath := filepath.Join(t.TempDir(), "install-entry-points.yaml")
+	if err := os.WriteFile(matrixPath, []byte(`
+install_entry_points:
+  valid-dir:
+    skill:
+      - {scope: user, path_template: "~/.valid/skills/<content-name>/", layout: directory_of_files, status: current}
+  valid-file:
+    skill:
+      - {scope: user, path_template: "~/.valid/rules/<content-name>.md", layout: single_file, status: current}
+  invalid-nonfinal:
+    skill:
+      - {scope: user, path_template: "~/.bad/<content-name>/rule.md", layout: single_file, status: current}
+  invalid-missing:
+    skill:
+      - {scope: user, path_template: "~/.bad/static.md", layout: single_file, status: current}
+  valid-merged:
+    hook:
+      - {scope: user, path_template: "~/.valid/settings.json", layout: merged_into_shared_file, status: current}
+  gated-merged:
+    skill:
+      - {scope: user, path_template: "~/.valid/settings.md", layout: merged_into_shared_file, status: current}
+`), 0644); err != nil {
+		t.Fatalf("write matrix fixture: %v", err)
+	}
+	t.Setenv(acif.InstallEntryPointsPathEnv, matrixPath)
+
+	tests := []struct {
+		providerSlug string
+		want         string
+		wantOK       bool
+	}{
+		{"valid-dir", "/home/u/.valid/skills", true},
+		{"valid-file", "/home/u/.valid/rules", true},
+		{"invalid-nonfinal", "", false},
+		{"invalid-missing", "", false},
+		{"gated-merged", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.providerSlug, func(t *testing.T) {
+			got, ok := matrixInstallDir(tc.providerSlug, catalog.Skills, "/home/u")
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Errorf("matrixInstallDir = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	got, ok := matrixInstallDir("valid-merged", catalog.Hooks, "/home/u")
+	if !ok || got != provider.JSONMergeSentinel {
+		t.Errorf("matrixInstallDir(valid-merged hooks) = %q, %v; want JSON merge sentinel, true", got, ok)
+	}
+}
+
+func TestResolverDefaultUsesMatrixBeforeLegacy(t *testing.T) {
+	unsetACIFInstallEntryPointsEnv(t)
+
+	prov := stubProvider("claude-code")
+	r := NewResolver(&Config{}, "")
+
+	got := r.InstallDir(prov, catalog.Skills, "/home/u")
+	want := "/home/u/.claude/skills"
+	if got != want {
+		t.Errorf("InstallDir default = %q, want matrix path %q", got, want)
+	}
+}
+
+func TestResolverOverridesBypassMatrix(t *testing.T) {
+	unsetACIFInstallEntryPointsEnv(t)
+
+	prov := stubProvider("claude-code")
+	tests := []struct {
+		name string
+		cfg  *Config
+		cli  string
+		want string
+	}{
+		{
+			name: "per type",
+			cfg: &Config{ProviderPaths: map[string]ProviderPathConfig{
+				"claude-code": {Paths: map[string]string{"skills": "/custom/skills"}},
+			}},
+			want: "/custom/skills",
+		},
+		{
+			name: "cli base dir",
+			cfg:  &Config{},
+			cli:  "/cli/base",
+			want: "/cli/base/.provider/skills",
+		},
+		{
+			name: "config base dir",
+			cfg: &Config{ProviderPaths: map[string]ProviderPathConfig{
+				"claude-code": {BaseDir: "/config/base"},
+			}},
+			want: "/config/base/.provider/skills",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewResolver(tc.cfg, tc.cli)
+			got := r.InstallDir(prov, catalog.Skills, "/home/u")
+			if got != tc.want {
+				t.Errorf("InstallDir = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolverDefaultPreservesProjectScopeSentinel(t *testing.T) {
+	unsetACIFInstallEntryPointsEnv(t)
+
+	prov := stubProvider("cline")
+	prov.InstallDir = func(_ string, ct catalog.ContentType) string {
+		if ct == catalog.Rules {
+			return provider.ProjectScopeSentinel
+		}
+		return ""
+	}
+
+	r := NewResolver(&Config{}, "")
+	got := r.InstallDir(prov, catalog.Rules, "/home/u")
+	if got != provider.ProjectScopeSentinel {
+		t.Errorf("InstallDir = %q, want project scope sentinel", got)
+	}
+}

--- a/cli/internal/config/matrix_drift_test.go
+++ b/cli/internal/config/matrix_drift_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/acif"
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+)
+
+var knownMismatches = map[string]struct{}{
+	"amp/rules":        {}, // tracked in syllago-t63g5
+	"codex/rules":      {}, // tracked in syllago-t63g5
+	"gemini-cli/rules": {}, // tracked in syllago-t63g5
+	"opencode/rules":   {}, // tracked in syllago-t63g5
+	"cline/rules":      {}, // tracked in syllago-t63g5
+	"roo-code/rules":   {}, // tracked in syllago-t63g5
+}
+
+func TestInstallMatrixMatchesLegacyProviderTables(t *testing.T) {
+	unsetACIFInstallEntryPointsEnv(t)
+
+	if len(knownMismatches) != 6 {
+		t.Fatalf("knownMismatches must contain exactly six tracked entries, got %d", len(knownMismatches))
+	}
+
+	contentTypes := []catalog.ContentType{
+		catalog.Skills,
+		catalog.Agents,
+		catalog.MCP,
+		catalog.Rules,
+		catalog.Hooks,
+		catalog.Commands,
+	}
+
+	const home = "/home/u"
+	var gaps []string
+	var mismatches []string
+	reproducedKnown := make(map[string]bool, len(knownMismatches))
+	for _, prov := range provider.AllProviders {
+		for _, ct := range contentTypes {
+			if prov.SupportsType == nil || !prov.SupportsType(ct) {
+				continue
+			}
+			legacy := prov.InstallDir(home, ct)
+			matrix, ok, err := rawMatrixInstallDir(prov.Slug, ct, home)
+			if err != nil {
+				t.Fatalf("matrix rows for %s/%s: %v", prov.Slug, ct, err)
+			}
+			if !ok {
+				gaps = append(gaps, fmt.Sprintf("  %s × %s", prov.Slug, ct))
+				continue
+			}
+			if legacy != matrix {
+				key := fmt.Sprintf("%s/%s", prov.Slug, ct)
+				if _, ok := knownMismatches[key]; ok {
+					reproducedKnown[key] = true
+					continue
+				}
+				mismatches = append(mismatches, fmt.Sprintf(
+					"%s %s: legacy InstallDir=%q, matrixInstallDir=%q; reconcile via an ACIF row-data amendment or a provider-table fix — never a local divergence",
+					prov.Slug, ct, legacy, matrix,
+				))
+			}
+		}
+	}
+
+	sort.Strings(gaps)
+	if len(gaps) > 0 {
+		t.Logf("ACIF install-entry-point GAPs:\n%s", strings.Join(gaps, "\n"))
+	}
+
+	sort.Strings(mismatches)
+	for _, mismatch := range mismatches {
+		t.Error(mismatch)
+	}
+
+	var resolved []string
+	for key := range knownMismatches {
+		if !reproducedKnown[key] {
+			resolved = append(resolved, key)
+		}
+	}
+	sort.Strings(resolved)
+	for _, key := range resolved {
+		t.Errorf("%s resolved — remove from knownMismatches", key)
+	}
+}
+
+func rawMatrixInstallDir(providerSlug string, ct catalog.ContentType, homeDir string) (string, bool, error) {
+	contentType := acifContentType(ct)
+	if contentType == "" {
+		return "", false, nil
+	}
+	rows, err := acif.InstallEntryRows(providerSlug, contentType)
+	if err != nil {
+		return "", false, err
+	}
+	for _, row := range rows {
+		if row.Status != "current" || row.Scope != "user" {
+			continue
+		}
+		if row.Layout == "merged_into_shared_file" {
+			return provider.JSONMergeSentinel, true, nil
+		}
+		dir, ok := matrixTemplateDir(row.PathTemplate, homeDir)
+		if !ok {
+			return "", true, nil
+		}
+		return dir, true, nil
+	}
+	return "", false, nil
+}

--- a/cli/internal/config/resolver.go
+++ b/cli/internal/config/resolver.go
@@ -47,7 +47,14 @@ func (r *PathResolver) InstallDir(prov provider.Provider, ct catalog.ContentType
 			return prov.InstallDir(filepath.Clean(baseDir), ct)
 		}
 	}
-	return prov.InstallDir(homeDir, ct)
+	legacy := prov.InstallDir(homeDir, ct)
+	if legacy == provider.ProjectScopeSentinel {
+		return legacy
+	}
+	if dir, ok := matrixInstallDir(prov.Slug, ct, homeDir); ok {
+		return dir
+	}
+	return legacy
 }
 
 // DiscoveryPaths resolves discovery paths for a content type.

--- a/cli/internal/installer/installer.go
+++ b/cli/internal/installer/installer.go
@@ -76,7 +76,8 @@ func (s Status) String() string {
 
 // IsJSONMerge returns true if the provider uses JSON merge for the given content type.
 func IsJSONMerge(prov provider.Provider, itemType catalog.ContentType) bool {
-	return prov.InstallDir("", itemType) == provider.JSONMergeSentinel
+	var resolver *config.PathResolver
+	return resolver.InstallDir(prov, itemType, "") == provider.JSONMergeSentinel
 }
 
 // resolveTargetWithBase computes the target path using a specific base directory.
@@ -369,7 +370,8 @@ func Uninstall(item catalog.ContentItem, prov provider.Provider, repoRoot string
 		if homeErr != nil {
 			return "", fmt.Errorf("getting home directory: %w", homeErr)
 		}
-		installDir := prov.InstallDir(home, item.Type)
+		var resolver *config.PathResolver
+		installDir := resolver.InstallDir(prov, item.Type, home)
 		rel, relErr := filepath.Rel(installDir, targetPath)
 		if relErr != nil || strings.HasPrefix(rel, "..") {
 			return "", fmt.Errorf("refusing to remove %s: outside install directory %s", targetPath, installDir)

--- a/cli/internal/loadout/preview.go
+++ b/cli/internal/loadout/preview.go
@@ -66,7 +66,8 @@ func previewSymlink(ref ResolvedRef, prov provider.Provider, homeDir string, res
 	if resolver != nil {
 		installDir = resolver.InstallDir(prov, ref.Type, homeDir)
 	} else {
-		installDir = prov.InstallDir(homeDir, ref.Type)
+		var defaultResolver *config.PathResolver
+		installDir = defaultResolver.InstallDir(prov, ref.Type, homeDir)
 	}
 	if installDir == "" || installDir == provider.JSONMergeSentinel || installDir == provider.ProjectScopeSentinel {
 		return PlannedAction{

--- a/cli/internal/moat/export.go
+++ b/cli/internal/moat/export.go
@@ -1,32 +1,16 @@
 package moat
 
-import "bytes"
+import "github.com/OpenScribbler/syllago/cli/internal/moathash"
 
 // FileHash returns the file-level MOAT hash as lowercase hex without an
 // algorithm prefix, classifying the file with the same text/binary heuristic
 // used by ContentHash.
 func FileHash(path string) (string, error) {
-	text, err := isText(path)
-	if err != nil {
-		return "", err
-	}
-	if text {
-		return hashText(path)
-	}
-	return hashBinary(path)
+	return moathash.FileHash(path)
 }
 
 // CanonicalText returns the bytes-level canonical text form used by MOAT:
 // strip a leading UTF-8 BOM, then normalize CRLF and lone CR to LF.
 func CanonicalText(data []byte) []byte {
-	chunk := bytes.TrimPrefix(data, utf8BOM)
-	var out bytes.Buffer
-	pendingCR := false
-	if len(chunk) > 0 {
-		normalizeChunk(&out, chunk, &pendingCR)
-	}
-	if pendingCR {
-		_ = out.WriteByte(0x0A)
-	}
-	return out.Bytes()
+	return moathash.CanonicalText(data)
 }

--- a/cli/internal/moat/export_test.go
+++ b/cli/internal/moat/export_test.go
@@ -16,7 +16,7 @@ func TestCanonicalText(t *testing.T) {
 	}{
 		{
 			name: "strips bom",
-			in:   append(append([]byte{}, utf8BOM...), []byte("hello\n")...),
+			in:   append(append([]byte{}, testUTF8BOM...), []byte("hello\n")...),
 			want: "hello\n",
 		},
 		{
@@ -45,7 +45,7 @@ func TestFileHashClassifiesTextAndBinary(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	raw := append(append([]byte{}, utf8BOM...), []byte("a\r\nb\r")...)
+	raw := append(append([]byte{}, testUTF8BOM...), []byte("a\r\nb\r")...)
 
 	textPath := filepath.Join(dir, "note.md")
 	if err := os.WriteFile(textPath, raw, 0o644); err != nil {

--- a/cli/internal/moat/hash.go
+++ b/cli/internal/moat/hash.go
@@ -16,46 +16,17 @@ package moat
 //      return "sha256:<hex>" of its SHA-256.
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
-	"io"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/OpenScribbler/syllago/cli/internal/moathash"
 	"golang.org/x/text/unicode/norm"
 )
-
-const (
-	chunkSize   = 65536 // 64 KiB text streaming buffer — boundary behavior is normative (TV-21).
-	nulScanSize = 8192  // 8 KiB NUL-probe window — matches git's binary heuristic (TV-20).
-)
-
-// utf8BOM is the UTF-8 byte-order mark (EF BB BF). Stripped from the first
-// chunk of any text file before hashing (TV-18).
-var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
-
-// textExtensions is the normative allowlist of extensions that receive text
-// normalization. Lowercased, dot-prefixed. Any other extension — or no
-// extension — is treated as binary.
-var textExtensions = map[string]bool{
-	".md": true, ".txt": true, ".rst": true,
-	".yaml": true, ".yml": true, ".json": true, ".toml": true,
-	".ini": true, ".cfg": true, ".conf": true,
-	".html": true, ".htm": true, ".xml": true, ".svg": true,
-	".css": true, ".scss": true, ".less": true,
-	".js": true, ".ts": true, ".jsx": true, ".tsx": true,
-	".mjs": true, ".cjs": true,
-	".py": true, ".rb": true, ".lua": true, ".rs": true, ".go": true,
-	".sh": true, ".bash": true, ".zsh": true, ".fish": true,
-	".csv": true, ".tsv": true, ".sql": true,
-	".lock": true, ".sum": true, ".mod": true,
-}
 
 // vcsDirs are directory names whose contents are excluded at any depth.
 // A local working copy may carry these; a registry using `git archive`
@@ -71,153 +42,6 @@ var vcsDirs = map[string]bool{
 // attackers could hide content outside the attested hash.
 var excludedFiles = map[string]bool{
 	"moat-attestation.json": true,
-}
-
-// finalExtension returns the lowercased final extension of name.
-//
-//	"foo.tar.gz"  → ".gz"
-//	".gitignore"  → ""    (dotfile: starts with "." and has exactly one dot)
-//	"Makefile"    → ""    (no dot at all)
-//	"SKILL.md"    → ".md"
-func finalExtension(name string) string {
-	if strings.HasPrefix(name, ".") && strings.Count(name, ".") == 1 {
-		return ""
-	}
-	return strings.ToLower(filepath.Ext(name))
-}
-
-// isText reports whether path should be hashed as text. True iff (a) the
-// final extension is in textExtensions AND (b) the first 8 KiB contain no
-// NUL byte. The NUL probe guards against binary files with text-looking
-// extensions (TV-20).
-func isText(path string) (bool, error) {
-	if !textExtensions[finalExtension(filepath.Base(path))] {
-		return false, nil
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		return false, err
-	}
-	defer func() { _ = f.Close() }()
-
-	buf := make([]byte, nulScanSize)
-	n, err := io.ReadFull(f, buf)
-	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
-		return false, err
-	}
-	return !bytes.Contains(buf[:n], []byte{0x00}), nil
-}
-
-// hashBinary returns the SHA-256 of the raw file bytes (no normalization).
-// Streaming; O(chunkSize) peak memory.
-func hashBinary(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = f.Close() }()
-
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
-}
-
-// hashText returns the SHA-256 of path's canonical text form: UTF-8 BOM
-// stripped, line endings normalized to LF. The normalization is a single
-// streaming left-to-right pass with greedy CRLF matching and pending-CR
-// handling across chunk boundaries. Peak memory is O(chunkSize).
-//
-// Normalization rules:
-//
-//	CR LF → LF  (including when CR ends one chunk and LF begins the next)
-//	CR    → LF  (lone CR, anywhere including EOF)
-//	LF    → LF  (unchanged)
-//
-// io.ReadFull is used so each non-final chunk is exactly chunkSize bytes,
-// making the boundary behavior in TV-21 deterministic regardless of the
-// filesystem's short-read behavior.
-func hashText(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = f.Close() }()
-
-	h := sha256.New()
-	first := true
-	pendingCR := false
-	buf := make([]byte, chunkSize)
-
-	for {
-		n, readErr := io.ReadFull(f, buf)
-		if n > 0 {
-			chunk := buf[:n]
-			if first {
-				chunk = bytes.TrimPrefix(chunk, utf8BOM)
-				first = false
-			}
-			if len(chunk) > 0 {
-				normalizeChunk(h, chunk, &pendingCR)
-			}
-		}
-		if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {
-			break
-		}
-		if readErr != nil {
-			return "", fmt.Errorf("reading %s: %w", path, readErr)
-		}
-	}
-
-	if pendingCR {
-		// Lone CR at EOF: flush as LF (TV-22).
-		_, _ = h.Write([]byte{0x0A})
-	}
-
-	return hex.EncodeToString(h.Sum(nil)), nil
-}
-
-// normalizeChunk writes the CRLF-normalized form of chunk into h, updating
-// *pendingCR for the chunk-boundary case. The output buffer is at most
-// len(chunk)+1 bytes.
-func normalizeChunk(h io.Writer, chunk []byte, pendingCR *bool) {
-	out := make([]byte, 0, len(chunk)+1)
-	i := 0
-
-	// Resolve CR carried over from the end of the previous chunk.
-	if *pendingCR {
-		*pendingCR = false
-		if chunk[0] == 0x0A {
-			out = append(out, 0x0A) // previous CR + this LF = CRLF → LF
-			i = 1
-		} else {
-			out = append(out, 0x0A) // previous CR was a lone CR
-		}
-	}
-
-	for i < len(chunk) {
-		b := chunk[i]
-		if b != 0x0D {
-			out = append(out, b)
-			i++
-			continue
-		}
-		// CR: emit LF now if we can see the next byte; otherwise defer.
-		if i+1 < len(chunk) {
-			out = append(out, 0x0A)
-			if chunk[i+1] == 0x0A {
-				i += 2 // CRLF consumed
-			} else {
-				i++ // lone CR
-			}
-		} else {
-			*pendingCR = true
-			i++
-		}
-	}
-
-	_, _ = h.Write(out)
 }
 
 // ContentHash returns the MOAT directory-tree content hash for dir, formatted
@@ -279,17 +103,7 @@ func ContentHash(dir string) (string, error) {
 			return nil
 		}
 
-		isText, err := isText(path)
-		if err != nil {
-			return fmt.Errorf("classifying %s: %w", posixRel, err)
-		}
-
-		var fileHash string
-		if isText {
-			fileHash, err = hashText(path)
-		} else {
-			fileHash, err = hashBinary(path)
-		}
+		fileHash, err := moathash.FileHash(path)
 		if err != nil {
 			return fmt.Errorf("hashing %s: %w", posixRel, err)
 		}

--- a/cli/internal/moat/hash_test.go
+++ b/cli/internal/moat/hash_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 )
 
+var testUTF8BOM = []byte{0xEF, 0xBB, 0xBF}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -108,73 +110,6 @@ func assertContentHashErrorContains(t *testing.T, dir, substr string) {
 }
 
 // ---------------------------------------------------------------------------
-// Small unit tests — primitives the TV tests rely on.
-// ---------------------------------------------------------------------------
-
-func TestFinalExtension(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name, want string
-	}{
-		{"SKILL.md", ".md"},
-		{"foo.tar.gz", ".gz"},
-		{"README", ""},
-		{"Makefile", ""},
-		{".gitignore", ""}, // dotfile, no other dot
-		{".env.example", ".example"},
-		{"a-b", ""},
-		{"a.b", ".b"},
-		{"UPPER.MD", ".md"}, // extension comparison is case-insensitive
-		{"", ""},
-	}
-	for _, c := range cases {
-		if got := finalExtension(c.name); got != c.want {
-			t.Errorf("finalExtension(%q) = %q, want %q", c.name, got, c.want)
-		}
-	}
-}
-
-func TestIsText(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	mustWrite := func(name string, data []byte) string {
-		t.Helper()
-		p := filepath.Join(dir, name)
-		if err := os.WriteFile(p, data, 0o644); err != nil {
-			t.Fatalf("write %s: %v", p, err)
-		}
-		return p
-	}
-
-	cases := []struct {
-		name string
-		data []byte
-		want bool
-	}{
-		{"plain.md", []byte("# hello\n"), true},
-		{"config.yaml", []byte("x: 1\n"), true},
-		{"script.sh", []byte("echo hi\n"), true},
-		{"readme", []byte("no extension\n"), false},
-		{".gitignore", []byte("*.log\n"), false},
-		{"data.bin", []byte("binary"), false},
-		{"icon.png", []byte("\x89PNG\r\n\x1a\n"), false},
-		// NUL probe: .json would be text, but a NUL in the first 8 KiB forces binary.
-		{"nul.json", []byte("{\"k\":\"v\x00\"}\n"), false},
-	}
-	for _, c := range cases {
-		p := mustWrite(c.name, c.data)
-		got, err := isText(p)
-		if err != nil {
-			t.Fatalf("isText(%s): %v", c.name, err)
-		}
-		if got != c.want {
-			t.Errorf("isText(%s) = %v, want %v", c.name, got, c.want)
-		}
-	}
-}
-
-// ---------------------------------------------------------------------------
 // TV-01 / TV-02 — per-file hash (§7.2) exercised through a binary-file dir.
 // ContentHash only supports directory hashes; these TVs verify the
 // underlying SHA-256 of raw bytes that feeds the manifest.
@@ -198,7 +133,7 @@ func TestContentHash_TV01_PerFileASCII_InDir(t *testing.T) {
 func TestContentHash_TV02_PerFileBOM_InDir(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	content := append(append([]byte{}, utf8BOM...), []byte("résumé\n")...)
+	content := append(append([]byte{}, testUTF8BOM...), []byte("résumé\n")...)
 	writeFixture(t, dir, map[string][]byte{"file.bin": content})
 
 	wantFile := "c08423edeb854b637067004a3f998a7ce42cd0c71828ba9ce7f655bf409f2a3a"
@@ -514,7 +449,7 @@ func TestContentHash_TV18_BOMStripping(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	body := []byte("def hello():\n    pass\n")
-	withBOM := append(append([]byte{}, utf8BOM...), body...)
+	withBOM := append(append([]byte{}, testUTF8BOM...), body...)
 	writeFixture(t, dir, map[string][]byte{"module.py": withBOM})
 
 	want := manifestHashFromEntries([][2]string{{"module.py", sha256HexOf(body)}})

--- a/cli/internal/moathash/hash.go
+++ b/cli/internal/moathash/hash.go
@@ -1,0 +1,176 @@
+package moathash
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	chunkSize   = 65536
+	nulScanSize = 8192
+)
+
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+var textExtensions = map[string]bool{
+	".md": true, ".txt": true, ".rst": true,
+	".yaml": true, ".yml": true, ".json": true, ".toml": true,
+	".ini": true, ".cfg": true, ".conf": true,
+	".html": true, ".htm": true, ".xml": true, ".svg": true,
+	".css": true, ".scss": true, ".less": true,
+	".js": true, ".ts": true, ".jsx": true, ".tsx": true,
+	".mjs": true, ".cjs": true,
+	".py": true, ".rb": true, ".lua": true, ".rs": true, ".go": true,
+	".sh": true, ".bash": true, ".zsh": true, ".fish": true,
+	".csv": true, ".tsv": true, ".sql": true,
+	".lock": true, ".sum": true, ".mod": true,
+}
+
+func finalExtension(name string) string {
+	if strings.HasPrefix(name, ".") && strings.Count(name, ".") == 1 {
+		return ""
+	}
+	return strings.ToLower(filepath.Ext(name))
+}
+
+func isText(path string) (bool, error) {
+	if !textExtensions[finalExtension(filepath.Base(path))] {
+		return false, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	buf := make([]byte, nulScanSize)
+	n, err := io.ReadFull(f, buf)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return false, err
+	}
+	return !bytes.Contains(buf[:n], []byte{0x00}), nil
+}
+
+func hashBinary(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func hashText(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	first := true
+	pendingCR := false
+	buf := make([]byte, chunkSize)
+
+	for {
+		n, readErr := io.ReadFull(f, buf)
+		if n > 0 {
+			chunk := buf[:n]
+			if first {
+				chunk = bytes.TrimPrefix(chunk, utf8BOM)
+				first = false
+			}
+			if len(chunk) > 0 {
+				normalizeChunk(h, chunk, &pendingCR)
+			}
+		}
+		if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {
+			break
+		}
+		if readErr != nil {
+			return "", fmt.Errorf("reading %s: %w", path, readErr)
+		}
+	}
+
+	if pendingCR {
+		_, _ = h.Write([]byte{0x0A})
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func normalizeChunk(h io.Writer, chunk []byte, pendingCR *bool) {
+	out := make([]byte, 0, len(chunk)+1)
+	i := 0
+
+	if *pendingCR {
+		*pendingCR = false
+		if chunk[0] == 0x0A {
+			out = append(out, 0x0A)
+			i = 1
+		} else {
+			out = append(out, 0x0A)
+		}
+	}
+
+	for i < len(chunk) {
+		b := chunk[i]
+		if b != 0x0D {
+			out = append(out, b)
+			i++
+			continue
+		}
+		if i+1 < len(chunk) {
+			out = append(out, 0x0A)
+			if chunk[i+1] == 0x0A {
+				i += 2
+			} else {
+				i++
+			}
+		} else {
+			*pendingCR = true
+			i++
+		}
+	}
+
+	_, _ = h.Write(out)
+}
+
+// FileHash returns the MOAT file-level hash as lowercase hex without an
+// algorithm prefix.
+func FileHash(path string) (string, error) {
+	text, err := isText(path)
+	if err != nil {
+		return "", err
+	}
+	if text {
+		return hashText(path)
+	}
+	return hashBinary(path)
+}
+
+// CanonicalText returns the bytes-level canonical text form used by MOAT.
+func CanonicalText(data []byte) []byte {
+	chunk := bytes.TrimPrefix(data, utf8BOM)
+	var out bytes.Buffer
+	pendingCR := false
+	if len(chunk) > 0 {
+		normalizeChunk(&out, chunk, &pendingCR)
+	}
+	if pendingCR {
+		_ = out.WriteByte(0x0A)
+	}
+	return out.Bytes()
+}

--- a/cli/internal/moathash/hash_test.go
+++ b/cli/internal/moathash/hash_test.go
@@ -1,0 +1,70 @@
+package moathash
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFinalExtension(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"SKILL.md", ".md"},
+		{"foo.tar.gz", ".gz"},
+		{"README", ""},
+		{"Makefile", ""},
+		{".gitignore", ""},
+		{".env.example", ".example"},
+		{"a-b", ""},
+		{"a.b", ".b"},
+		{"UPPER.MD", ".md"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := finalExtension(c.name); got != c.want {
+			t.Errorf("finalExtension(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestIsText(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	mustWrite := func(name string, data []byte) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, data, 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+		return p
+	}
+
+	cases := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{"plain.md", []byte("# hello\n"), true},
+		{"config.yaml", []byte("x: 1\n"), true},
+		{"script.sh", []byte("echo hi\n"), true},
+		{"readme", []byte("no extension\n"), false},
+		{".gitignore", []byte("*.log\n"), false},
+		{"data.bin", []byte("binary"), false},
+		{"icon.png", []byte("\x89PNG\r\n\x1a\n"), false},
+		{"nul.json", []byte("{\"k\":\"v\x00\"}\n"), false},
+	}
+	for _, c := range cases {
+		p := mustWrite(c.name, c.data)
+		got, err := isText(p)
+		if err != nil {
+			t.Fatalf("isText(%s): %v", c.name, err)
+		}
+		if got != c.want {
+			t.Errorf("isText(%s) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Migrates default install-path resolution onto the ACIF install-entry-points matrix (`acif.ResolveInstallTargets` data), matrix-first with legacy provider-table fallback — zero behavior change today by construction (verified: full test suite green, plus an end-to-end check that a doctored matrix row moves a real install while the stock matrix produces byte-identical paths).
- Implements [ACIF-INSTALL] §12 refresh-over-vendored: best-effort fetch of the published export at install/apply time, silent vendored fallback offline, env override highest.
- Adds a drift test tying the legacy tables to the matrix: 28 gaps logged (ACIF row-amendment worklist), 6 known semantic mismatches pinned and tracked in syllago-t63g5; new divergence fails CI.
- Extracts `internal/moathash` (moat delegates to it) to break the config→acif import cycle.

## Test plan
- `make test` full suite: PASS
- New unit tests: acifresolve (type mapping, sentinel gating, template trimming), installrefresh (httptest 200/garbage/non-200/refused), drift test
- End-to-end: install with `ACIF_INSTALL_ENTRY_POINTS` pointing at a modified export lands content at the modified path; blackholed-network install is silent and identical to online

Closes syllago-cxrc1. Follow-up: syllago-t63g5 (reconcile the 6 mismatches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
