### PR TITLE
feat: reality-based install-state checks — doctor --fix, safe remove, loud trust, dup-registry warning

### DIFF
--- a/cli/cmd/syllago/doctor_cmd.go
+++ b/cli/cmd/syllago/doctor_cmd.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/doctor"
+	"github.com/OpenScribbler/syllago/cli/internal/installer"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -23,12 +28,20 @@ pass, 1 if there are warnings, 2 if there are errors.`,
 }
 
 func init() {
+	doctorCmd.Flags().Bool("fix", false, "Repair broken provider links: re-link to library content or prune dead links")
+	doctorCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 	rootCmd.AddCommand(doctorCmd)
 }
 
 var osExit = os.Exit
 
 func runDoctor(cmd *cobra.Command, args []string) error {
+	fix, _ := cmd.Flags().GetBool("fix")
+	force, _ := cmd.Flags().GetBool("force")
+	if fix && output.JSON {
+		return output.NewStructuredError(output.ErrInputConflict, "--fix cannot be used with --json", "Run 'syllago doctor --fix' for repair, or omit --fix for JSON diagnostics")
+	}
+
 	projectRoot, _ := findProjectRoot()
 	result := doctor.Run(projectRoot)
 
@@ -40,6 +53,10 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Fprintln(output.Writer)
 		fmt.Fprintf(output.Writer, "  %s\n", result.Summary)
+	}
+
+	if fix {
+		return runDoctorFix(force)
 	}
 
 	errs, warns := 0, 0
@@ -60,6 +77,96 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	return nil
+}
+
+func runDoctorFix(force bool) error {
+	broken, err := doctor.BrokenProviderLinks()
+	if err != nil {
+		return output.NewStructuredErrorDetail(output.ErrSystemHomedir, "cannot determine home directory", "Ensure $HOME is set in your environment", err.Error())
+	}
+
+	libraryItems, err := doctorFixLibraryItems()
+	if err != nil {
+		return err
+	}
+
+	actions := installer.PlanLinkFixes(broken, libraryItems)
+	if len(actions) == 0 {
+		fmt.Fprintln(output.Writer, "Nothing to fix.")
+		return nil
+	}
+
+	for _, action := range actions {
+		switch action.Kind {
+		case installer.FixRelink:
+			fmt.Fprintf(output.Writer, "relink: %s -> %s\n", action.Link.Path, action.NewSource)
+		case installer.FixPrune:
+			fmt.Fprintf(output.Writer, "prune:  %s (target gone: %s)\n", action.Link.Path, action.Link.Target)
+		}
+	}
+
+	if !force {
+		if !isInteractive() {
+			return output.NewStructuredError(output.ErrInputTerminal, "doctor --fix requires confirmation", "Run 'syllago doctor --fix --force' to apply repairs non-interactively")
+		}
+		fmt.Fprint(output.Writer, "Continue? [y/N] ")
+		scanner := bufio.NewScanner(os.Stdin)
+		if !scanner.Scan() {
+			return output.NewStructuredError(output.ErrInputTerminal, "no input received", "Run with --force to skip confirmation")
+		}
+		answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+		if answer != "y" && answer != "yes" {
+			fmt.Fprintln(output.Writer, "Cancelled.")
+			return nil
+		}
+	}
+
+	errs := installer.ApplyLinkFixes(actions)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			fmt.Fprintln(output.ErrWriter, err)
+		}
+		osExit(1)
+		return nil
+	}
+
+	relinked, pruned := countLinkFixKinds(actions)
+	fmt.Fprintf(output.Writer, "Fixed: %d relinked, %d pruned\n", relinked, pruned)
+	telemetry.Enrich("action_count", len(actions))
+	return nil
+}
+
+func doctorFixLibraryItems() ([]catalog.ContentItem, error) {
+	emptyProjectRoot, err := os.MkdirTemp("", "syllago-doctor-fix-*")
+	if err != nil {
+		return nil, output.NewStructuredErrorDetail(output.ErrSystemIO, "creating temp dir failed", "Check filesystem permissions and disk space", err.Error())
+	}
+	defer func() { _ = os.RemoveAll(emptyProjectRoot) }()
+
+	cat, err := catalog.ScanWithGlobalAndRegistries(emptyProjectRoot, emptyProjectRoot, nil)
+	if err != nil {
+		return nil, output.NewStructuredErrorDetail(output.ErrCatalogScanFailed, "scanning library failed", "Check that ~/.syllago/content/ exists and is readable", err.Error())
+	}
+
+	var items []catalog.ContentItem
+	for _, item := range cat.Items {
+		if item.Source == "global" {
+			items = append(items, item)
+		}
+	}
+	return items, nil
+}
+
+func countLinkFixKinds(actions []installer.FixAction) (relinked, pruned int) {
+	for _, action := range actions {
+		switch action.Kind {
+		case installer.FixRelink:
+			relinked++
+		case installer.FixPrune:
+			pruned++
+		}
+	}
+	return relinked, pruned
 }
 
 const (

--- a/cli/cmd/syllago/doctor_cmd_test.go
+++ b/cli/cmd/syllago/doctor_cmd_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/installer"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
@@ -249,6 +250,10 @@ func TestCheckContentDrift_SkipsEntriesWithoutHash(t *testing.T) {
 }
 
 func TestDoctorCheckRegistriesNone(t *testing.T) {
+	orig := config.GlobalDirOverride
+	config.GlobalDirOverride = t.TempDir()
+	t.Cleanup(func() { config.GlobalDirOverride = orig })
+
 	c := checkRegistriesWith("")
 	if c.Status != checkOK {
 		t.Errorf("expected ok with no registries, got %s", c.Status)

--- a/cli/cmd/syllago/doctor_cmd_test.go
+++ b/cli/cmd/syllago/doctor_cmd_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/installer"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
 )
 
 func TestDoctorCheckLibrary(t *testing.T) {
@@ -425,5 +426,170 @@ func TestCheckNamingQuality_AllNamed(t *testing.T) {
 	c := checkNamingQuality(dir)
 	if c.Status != checkOK {
 		t.Errorf("Status = %s, want ok when no hooks/MCP items; message: %s", c.Status, c.Message)
+	}
+}
+
+func TestRunDoctorFixForce_RelinksDeadProviderLink(t *testing.T) {
+	resetDoctorFlags(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	contentDir := filepath.Join(home, ".syllago", "content")
+	skillDir := filepath.Join(contentDir, "skills", "repair-me")
+	writeDoctorCmdFile(t, filepath.Join(skillDir, "SKILL.md"), "# Repair Me\n")
+
+	installDir := filepath.Join(home, ".claude", "skills")
+	linkPath := filepath.Join(installDir, "repair-me")
+	oldTarget := filepath.Join(home, ".syllago", "content", "skills", "gone")
+	symlinkDoctorCmd(t, oldTarget, linkPath)
+
+	withDoctorCmdGlobals(t, home, contentDir, []provider.Provider{
+		doctorCmdProvider("claude-code", map[catalog.ContentType]string{catalog.Skills: installDir}),
+	})
+
+	stdout, _ := output.SetForTest(t)
+	captureOsExit(t)
+	mustSetDoctorFlag(t, "fix", "true")
+	mustSetDoctorFlag(t, "force", "true")
+
+	if err := doctorCmd.RunE(doctorCmd, nil); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("Readlink: %v", err)
+	}
+	if target != skillDir {
+		t.Fatalf("target = %q, want %q", target, skillDir)
+	}
+	if !strings.Contains(stdout.String(), "relink: "+linkPath+" -> "+skillDir) {
+		t.Fatalf("output missing relink plan:\n%s", stdout.String())
+	}
+}
+
+func TestRunDoctorFixForce_PrunesDeadProviderLinkWithoutLibraryMatch(t *testing.T) {
+	resetDoctorFlags(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	contentDir := filepath.Join(home, ".syllago", "content")
+	if err := os.MkdirAll(contentDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	installDir := filepath.Join(home, ".claude", "skills")
+	linkPath := filepath.Join(installDir, "gone")
+	oldTarget := filepath.Join(home, ".syllago", "content", "skills", "gone")
+	symlinkDoctorCmd(t, oldTarget, linkPath)
+
+	withDoctorCmdGlobals(t, home, contentDir, []provider.Provider{
+		doctorCmdProvider("claude-code", map[catalog.ContentType]string{catalog.Skills: installDir}),
+	})
+
+	stdout, _ := output.SetForTest(t)
+	captureOsExit(t)
+	mustSetDoctorFlag(t, "fix", "true")
+	mustSetDoctorFlag(t, "force", "true")
+
+	if err := doctorCmd.RunE(doctorCmd, nil); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+
+	if _, err := os.Lstat(linkPath); !os.IsNotExist(err) {
+		t.Fatalf("Lstat err = %v, want link removed", err)
+	}
+	if !strings.Contains(stdout.String(), "prune:  "+linkPath+" (target gone: "+oldTarget+")") {
+		t.Fatalf("output missing prune plan:\n%s", stdout.String())
+	}
+}
+
+func TestRunDoctorFix_NothingBroken(t *testing.T) {
+	resetDoctorFlags(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	contentDir := filepath.Join(home, ".syllago", "content")
+	if err := os.MkdirAll(contentDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	installDir := filepath.Join(home, ".claude", "skills")
+	withDoctorCmdGlobals(t, home, contentDir, []provider.Provider{
+		doctorCmdProvider("claude-code", map[catalog.ContentType]string{catalog.Skills: installDir}),
+	})
+
+	stdout, _ := output.SetForTest(t)
+	captureOsExit(t)
+	mustSetDoctorFlag(t, "fix", "true")
+
+	if err := doctorCmd.RunE(doctorCmd, nil); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "Nothing to fix.") {
+		t.Fatalf("output missing nothing-to-fix message:\n%s", stdout.String())
+	}
+}
+
+func resetDoctorFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = doctorCmd.Flags().Set("fix", "false")
+		_ = doctorCmd.Flags().Set("force", "false")
+	})
+}
+
+func mustSetDoctorFlag(t *testing.T, name, value string) {
+	t.Helper()
+	if err := doctorCmd.Flags().Set(name, value); err != nil {
+		t.Fatalf("setting --%s: %v", name, err)
+	}
+}
+
+func withDoctorCmdGlobals(t *testing.T, projectRoot, contentDir string, providers []provider.Provider) {
+	t.Helper()
+
+	origContentDir := catalog.GlobalContentDirOverride
+	catalog.GlobalContentDirOverride = contentDir
+	t.Cleanup(func() { catalog.GlobalContentDirOverride = origContentDir })
+
+	origProviders := append([]provider.Provider(nil), provider.AllProviders...)
+	provider.AllProviders = providers
+	t.Cleanup(func() { provider.AllProviders = origProviders })
+
+	origRoot := findProjectRoot
+	findProjectRoot = func() (string, error) { return projectRoot, nil }
+	t.Cleanup(func() { findProjectRoot = origRoot })
+}
+
+func doctorCmdProvider(slug string, dirs map[catalog.ContentType]string) provider.Provider {
+	return provider.Provider{
+		Name:   slug,
+		Slug:   slug,
+		Detect: func(string) bool { return true },
+		InstallDir: func(home string, ct catalog.ContentType) string {
+			return dirs[ct]
+		},
+	}
+}
+
+func writeDoctorCmdFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func symlinkDoctorCmd(t *testing.T, target, linkPath string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(target, linkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
 	}
 }

--- a/cli/cmd/syllago/inspect.go
+++ b/cli/cmd/syllago/inspect.go
@@ -103,6 +103,7 @@ func runInspect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	cat := scan.Catalog
+	cat.PrintWarnings()
 
 	item, err := findItemByPath(cat, args[0])
 	if err != nil {

--- a/cli/cmd/syllago/registry_cmd.go
+++ b/cli/cmd/syllago/registry_cmd.go
@@ -160,6 +160,9 @@ Use --sync to clone immediately (original behaviour).`,
 		if outcome.NoContentFound {
 			fmt.Fprintf(output.ErrWriter, "Warning: registry %q doesn't appear to contain any recognized content. Added anyway.\n", outcome.Registry.Name)
 		}
+		for _, similar := range outcome.SimilarRegistries {
+			fmt.Fprintf(output.ErrWriter, "Warning: registry %q looks like a duplicate of existing registry %q (same name or URL after normalization). Remove one with 'syllago registry remove'.\n", outcome.Registry.Name, similar)
+		}
 
 		if outcome.Cloned {
 			if registry.IsPrivate(outcome.Visibility) {

--- a/cli/cmd/syllago/registry_cmd_test.go
+++ b/cli/cmd/syllago/registry_cmd_test.go
@@ -153,6 +153,32 @@ func TestRegistryAddExpandsAlias(t *testing.T) {
 	}
 }
 
+func TestRegistryAddWarnsOnNearDuplicate(t *testing.T) {
+	tmp := t.TempDir()
+	withGlobalConfigDir(t, tmp)
+	cfg := &config.Config{
+		Providers: []string{"claude-code"},
+		Registries: []config.Registry{
+			{Name: "syllago-community", URL: "https://github.com/example/existing.git"},
+		},
+	}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("config.SaveGlobal: %v", err)
+	}
+
+	registryAddCmd.Flags().Set("name", "Syllago_Community")
+	t.Cleanup(func() { registryAddCmd.Flags().Set("name", "") })
+	_, stderr := output.SetForTest(t)
+
+	if err := registryAddCmd.RunE(registryAddCmd, []string{"local-repo"}); err != nil {
+		t.Fatalf("registryAddCmd.RunE: %v", err)
+	}
+
+	if got := stderr.String(); !strings.Contains(got, `looks like a duplicate of existing registry "syllago-community"`) {
+		t.Fatalf("stderr = %q, want near-duplicate warning", got)
+	}
+}
+
 // withGlobalConfigDir redirects config.LoadGlobal/SaveGlobal at `dir` for the
 // duration of t. Use this in registry CRUD tests that previously relied on
 // `os.Chdir(tmp)` + project-local `.syllago/config.json`.

--- a/cli/cmd/syllago/registry_sync_moat.go
+++ b/cli/cmd/syllago/registry_sync_moat.go
@@ -131,5 +131,12 @@ func syncMOATRegistry(
 			reg.Name, res.RevocationsAdded, res.PrivateContentCount)
 	}
 
+	for _, w := range outcome.ContentCacheReport.Warnings {
+		fmt.Fprintf(errW, "Warning: %s\n", w)
+	}
+	if outcome.ContentCacheErr != nil {
+		fmt.Fprintf(errW, "Warning: content cache: %s\n", outcome.ContentCacheErr)
+	}
+
 	return 0, nil
 }

--- a/cli/cmd/syllago/registry_sync_moat_test.go
+++ b/cli/cmd/syllago/registry_sync_moat_test.go
@@ -135,6 +135,59 @@ func TestSyncMOAT_HappyPath_PinnedProfile(t *testing.T) {
 	}
 }
 
+func TestSyncMOAT_PrintsContentCacheWarnings(t *testing.T) {
+	root := tempProjectRoot(t)
+	pinned := incomingProfile()
+	reg := moatRegFixture("https://registry.example.com/manifest.json")
+	reg.SigningProfile = &pinned
+	cfg := &config.Config{Registries: []config.Registry{reg}}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("save initial cfg: %v", err)
+	}
+
+	origClone := moat.CloneRepoFn
+	moat.CloneRepoFn = func(context.Context, string, string) error {
+		return errors.New("fixture clone failed")
+	}
+	t.Cleanup(func() { moat.CloneRepoFn = origClone })
+
+	withStubbedMoatSync(t, func(_ context.Context, _ *config.Registry, _ *moat.Lockfile, _ []byte, _ *moat.Fetcher, _ time.Time) (moat.SyncResult, error) {
+		fetchedAt := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+		return moat.SyncResult{
+			ManifestURL:      "https://registry.example.com/manifest.json",
+			ETag:             `"v42"`,
+			FetchedAt:        fetchedAt,
+			IncomingProfile:  incomingProfile(),
+			Staleness:        moat.StalenessFresh,
+			ManifestBytes:    []byte(`{"schema_version":1}`),
+			BundleBytes:      []byte(`{"bundle":true}`),
+			RevocationsAdded: 1,
+			Manifest: &moat.Manifest{
+				Content: []moat.ContentEntry{
+					{
+						Name:        "cache-me",
+						Type:        "skill",
+						ContentHash: "sha256:unused",
+						SourceURI:   "https://github.com/example/source.git",
+					},
+				},
+			},
+		}, nil
+	})
+
+	var out, errW bytes.Buffer
+	code, err := syncMOATRegistry(context.Background(), &out, &errW, cfg, &cfg.Registries[0], root, "", time.Now(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d; want 0", code)
+	}
+	if got := errW.String(); !strings.Contains(got, "Warning: MOAT cache: clone failed for https://github.com/example/source.git: fixture clone failed") {
+		t.Fatalf("stderr = %q, want content-cache warning", got)
+	}
+}
+
 func TestSyncMOAT_NotModified(t *testing.T) {
 	root := tempProjectRoot(t)
 	pinned := incomingProfile()

--- a/cli/cmd/syllago/remove_cmd.go
+++ b/cli/cmd/syllago/remove_cmd.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
@@ -100,16 +101,29 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 	item := matches[0]
 
+	providerNames := providerNamesBySlug(provider.AllProviders)
+	installedByProvider := make(map[string]bool)
 	var installedIn []string
 	for _, prov := range provider.AllProviders {
 		if installer.CheckStatus(item, prov, globalDir) == installer.StatusInstalled {
 			installedIn = append(installedIn, prov.Name)
+			installedByProvider[prov.Slug] = true
 		}
+	}
+
+	home, _ := os.UserHomeDir()
+	providerLinks := installer.ScanProviderLinks(provider.AllProviders, home, []string{item.Path})
+	extraProviderLinks := extraRemoveProviderLinks(item, providerLinks, installedByProvider)
+	for _, link := range extraProviderLinks {
+		installedIn = append(installedIn, providerLinkLabel(link, providerNames))
 	}
 
 	if dryRun {
 		if len(installedIn) > 0 {
 			fmt.Fprintf(output.Writer, "[dry-run] Would uninstall from: %s\n", strings.Join(installedIn, ", "))
+		}
+		for _, link := range extraProviderLinks {
+			fmt.Fprintf(output.Writer, "[dry-run] Would remove provider link: %s\n", link.Path)
 		}
 		fmt.Fprintf(output.Writer, "[dry-run] Would remove from library: %s (%s)\n", name, item.Type.Label())
 		return nil
@@ -148,6 +162,22 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	home, _ = os.UserHomeDir()
+	remainingLinks := installer.ScanProviderLinks(provider.AllProviders, home, []string{item.Path})
+	var linkRemoveErrs []string
+	for _, link := range remainingLinks {
+		if err := os.Remove(link.Path); err != nil {
+			msg := fmt.Sprintf("failed to remove provider link %s: %s", link.Path, err)
+			fmt.Fprintf(output.ErrWriter, "  warning: %s\n", msg)
+			linkRemoveErrs = append(linkRemoveErrs, msg)
+			continue
+		}
+		uninstalledFrom = append(uninstalledFrom, providerLinkLabel(link, providerNames))
+	}
+	if len(linkRemoveErrs) > 0 {
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, fmt.Sprintf("%q is still installed and was not removed", name), "Remove the provider link(s) manually, then retry 'syllago remove'", strings.Join(linkRemoveErrs, "; "))
+	}
+
 	removedPath := item.Path
 	if err := catalog.RemoveLibraryItem(item.Path); err != nil {
 		return output.NewStructuredErrorDetail(output.ErrSystemIO, "removing from library failed", "Check filesystem permissions", err.Error())
@@ -174,4 +204,45 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	telemetry.Enrich("content_type", typeFilter)
 	telemetry.Enrich("dry_run", dryRun)
 	return nil
+}
+
+func providerNamesBySlug(providers []provider.Provider) map[string]string {
+	names := make(map[string]string, len(providers))
+	for _, prov := range providers {
+		if prov.Slug == "" {
+			continue
+		}
+		names[prov.Slug] = prov.Name
+	}
+	return names
+}
+
+func providerLinkLabel(link installer.ScannedLink, names map[string]string) string {
+	name := names[link.Provider]
+	if name == "" {
+		name = link.Provider
+	}
+	return fmt.Sprintf("%s (%s)", name, filepath.Base(link.Path))
+}
+
+func extraRemoveProviderLinks(item catalog.ContentItem, links []installer.ScannedLink, installedByProvider map[string]bool) []installer.ScannedLink {
+	expectedLeaf := expectedRemoveInstallLeaf(item)
+	extra := make([]installer.ScannedLink, 0, len(links))
+	for _, link := range links {
+		if installedByProvider[link.Provider] && link.ContentType == item.Type && filepath.Base(link.Path) == expectedLeaf {
+			continue
+		}
+		extra = append(extra, link)
+	}
+	return extra
+}
+
+func expectedRemoveInstallLeaf(item catalog.ContentItem) string {
+	if item.Type == catalog.Agents {
+		return item.Name + ".md"
+	}
+	if item.Type.IsUniversal() {
+		return item.Name
+	}
+	return filepath.Base(item.Path)
 }

--- a/cli/cmd/syllago/remove_cmd_test.go
+++ b/cli/cmd/syllago/remove_cmd_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
 )
 
 // setupGlobalLibraryWithSkill creates a temp global content dir with one skill.
@@ -38,6 +39,28 @@ func withNonInteractive(t *testing.T) {
 	orig := isInteractive
 	isInteractive = func() bool { return false }
 	t.Cleanup(func() { isInteractive = orig })
+}
+
+func withRemoveProvider(t *testing.T, installBase string) {
+	t.Helper()
+
+	orig := append([]provider.Provider(nil), provider.AllProviders...)
+	provider.AllProviders = []provider.Provider{
+		{
+			Name: "Remove Test Provider",
+			Slug: "remove-test-provider",
+			InstallDir: func(home string, ct catalog.ContentType) string {
+				if ct == catalog.Skills {
+					return filepath.Join(installBase, string(ct))
+				}
+				return ""
+			},
+			SupportsType: func(ct catalog.ContentType) bool {
+				return ct == catalog.Skills
+			},
+		},
+	}
+	t.Cleanup(func() { provider.AllProviders = orig })
 }
 
 func TestRemoveRequiresName(t *testing.T) {
@@ -161,6 +184,149 @@ func TestRemoveForceSkipsConfirmation(t *testing.T) {
 	out := stdout.String()
 	if !strings.Contains(out, "my-skill") {
 		t.Errorf("expected item name in output, got: %s", out)
+	}
+}
+
+func TestRemoveForceRemovesProviderSymlinkWithDifferentLeafName(t *testing.T) {
+	globalDir, skillDir := setupGlobalLibraryWithSkill(t, "linked-skill")
+	withGlobalDirOverride(t, globalDir)
+	withNonInteractive(t)
+	t.Setenv("HOME", t.TempDir())
+
+	installBase := t.TempDir()
+	withRemoveProvider(t, installBase)
+
+	linkPath := filepath.Join(installBase, "skills", "renamed-link")
+	os.MkdirAll(filepath.Dir(linkPath), 0755)
+	os.Symlink(skillDir, linkPath)
+
+	output.SetForTest(t)
+
+	removeCmd.SilenceUsage = true
+	removeCmd.SilenceErrors = true
+	resetRemoveFlags(t)
+	removeCmd.Flags().Set("force", "true")
+
+	err := removeCmd.RunE(removeCmd, []string{"linked-skill"})
+	if err != nil {
+		t.Fatalf("force remove failed: %v", err)
+	}
+
+	if _, statErr := os.Lstat(linkPath); !os.IsNotExist(statErr) {
+		t.Fatalf("provider symlink still exists after remove: %v", statErr)
+	}
+	if _, statErr := os.Stat(skillDir); !os.IsNotExist(statErr) {
+		t.Fatal("skill directory still exists after remove")
+	}
+}
+
+func TestRemoveForceRemovesBrokenProviderSymlinkIntoItem(t *testing.T) {
+	globalDir, skillDir := setupGlobalLibraryWithSkill(t, "broken-linked-skill")
+	withGlobalDirOverride(t, globalDir)
+	withNonInteractive(t)
+	t.Setenv("HOME", t.TempDir())
+
+	installBase := t.TempDir()
+	withRemoveProvider(t, installBase)
+
+	linkPath := filepath.Join(installBase, "skills", "dead-link")
+	os.MkdirAll(filepath.Dir(linkPath), 0755)
+	os.Symlink(filepath.Join(skillDir, "missing.md"), linkPath)
+
+	output.SetForTest(t)
+
+	removeCmd.SilenceUsage = true
+	removeCmd.SilenceErrors = true
+	resetRemoveFlags(t)
+	removeCmd.Flags().Set("force", "true")
+
+	err := removeCmd.RunE(removeCmd, []string{"broken-linked-skill"})
+	if err != nil {
+		t.Fatalf("force remove failed: %v", err)
+	}
+
+	if _, statErr := os.Lstat(linkPath); !os.IsNotExist(statErr) {
+		t.Fatalf("broken provider symlink still exists after remove: %v", statErr)
+	}
+	if _, statErr := os.Stat(skillDir); !os.IsNotExist(statErr) {
+		t.Fatal("skill directory still exists after remove")
+	}
+}
+
+func TestRemoveDryRunListsProviderSymlinkAndLeavesDisk(t *testing.T) {
+	globalDir, skillDir := setupGlobalLibraryWithSkill(t, "dry-linked-skill")
+	withGlobalDirOverride(t, globalDir)
+	withNonInteractive(t)
+	t.Setenv("HOME", t.TempDir())
+
+	installBase := t.TempDir()
+	withRemoveProvider(t, installBase)
+
+	linkPath := filepath.Join(installBase, "skills", "preview-link")
+	os.MkdirAll(filepath.Dir(linkPath), 0755)
+	os.Symlink(skillDir, linkPath)
+
+	stdout, _ := output.SetForTest(t)
+
+	removeCmd.SilenceUsage = true
+	removeCmd.SilenceErrors = true
+	resetRemoveFlags(t)
+	removeCmd.Flags().Set("dry-run", "true")
+
+	err := removeCmd.RunE(removeCmd, []string{"dry-linked-skill"})
+	if err != nil {
+		t.Fatalf("dry-run remove failed: %v", err)
+	}
+
+	out := stdout.String()
+	want := "[dry-run] Would remove provider link: " + linkPath
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected dry-run output to include %q, got:\n%s", want, out)
+	}
+	if _, statErr := os.Lstat(linkPath); statErr != nil {
+		t.Fatalf("provider symlink should remain after dry-run: %v", statErr)
+	}
+	if _, statErr := os.Stat(skillDir); statErr != nil {
+		t.Fatalf("skill directory should remain after dry-run: %v", statErr)
+	}
+}
+
+func TestRemoveLeavesForeignProviderSymlinkUntouched(t *testing.T) {
+	globalDir, skillDir := setupGlobalLibraryWithSkill(t, "foreign-linked-skill")
+	withGlobalDirOverride(t, globalDir)
+	withNonInteractive(t)
+	t.Setenv("HOME", t.TempDir())
+
+	installBase := t.TempDir()
+	withRemoveProvider(t, installBase)
+
+	foreignTarget := filepath.Join(t.TempDir(), "foreign-skill")
+	os.MkdirAll(foreignTarget, 0755)
+	linkPath := filepath.Join(installBase, "skills", "foreign-link")
+	os.MkdirAll(filepath.Dir(linkPath), 0755)
+	os.Symlink(foreignTarget, linkPath)
+
+	output.SetForTest(t)
+
+	removeCmd.SilenceUsage = true
+	removeCmd.SilenceErrors = true
+	resetRemoveFlags(t)
+	removeCmd.Flags().Set("force", "true")
+
+	err := removeCmd.RunE(removeCmd, []string{"foreign-linked-skill"})
+	if err != nil {
+		t.Fatalf("force remove failed: %v", err)
+	}
+
+	info, statErr := os.Lstat(linkPath)
+	if statErr != nil {
+		t.Fatalf("foreign symlink should survive remove: %v", statErr)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected foreign link to remain a symlink, mode=%s", info.Mode())
+	}
+	if _, statErr := os.Stat(skillDir); !os.IsNotExist(statErr) {
+		t.Fatal("skill directory still exists after remove")
 	}
 }
 

--- a/cli/commands.json
+++ b/cli/commands.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
-  "generatedAt": "2026-07-09T21:45:03Z",
-  "syllagoVersion": "dev",
+  "generatedAt": "2026-08-21T21:26:09Z",
+  "syllagoVersion": "0.14.0",
   "commands": [
     {
       "name": "add",
@@ -1099,11 +1099,28 @@
       "displayName": "Doctor",
       "slug": "doctor",
       "parent": null,
-      "synopsis": "syllago doctor",
+      "synopsis": "syllago doctor [flags]",
       "description": "Check your syllago setup for problems",
       "longDescription": "Validates your syllago installation: library, config, providers,\ninstalled content integrity, and registry configuration.\n\nEach check reports [ok], [warn], or [err]. Exit code is 0 if all checks\npass, 1 if there are warnings, 2 if there are errors.",
       "aliases": [],
-      "flags": [],
+      "flags": [
+        {
+          "name": "--fix",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Repair broken provider links: re-link to library content or prune dead links"
+        },
+        {
+          "name": "--force",
+          "shorthand": "-f",
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Skip confirmation prompt"
+        }
+      ],
       "inheritedFlags": [
         {
           "name": "--json",

--- a/cli/content-format.json
+++ b/cli/content-format.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
-  "generated_at": "2026-05-07T17:06:07Z",
-  "syllago_version": "0.12.0",
+  "generated_at": "2026-08-21T21:26:09Z",
+  "syllago_version": "0.14.0",
   "enums": {
     "effort": [
       "low",

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
@@ -13,6 +14,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/moat"
 	"github.com/OpenScribbler/syllago/cli/internal/moatinstall"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/OpenScribbler/syllago/cli/internal/registryops"
 )
 
 // CheckStatus is the outcome of a single health check.
@@ -54,6 +56,7 @@ func Run(projectRoot string) Result {
 	}
 	checks = append(checks, CheckRegistriesWith(projectRoot))
 	checks = append(checks, CheckNamingQuality(projectRoot))
+	checks = append(checks, CheckTrust(projectRoot))
 
 	warns, errs := 0, 0
 	for _, c := range checks {
@@ -356,10 +359,17 @@ func CheckRegistriesWith(projectRoot string) CheckResult {
 		parts = append(parts, fmt.Sprintf("%d unknown", unknown))
 	}
 
+	details := findSimilarRegistryPairs(merged.Registries)
+	status := CheckOK
+	if len(details) > 0 {
+		status = CheckWarn
+	}
+
 	return CheckResult{
 		Name:    "registries",
-		Status:  CheckOK,
+		Status:  status,
 		Message: fmt.Sprintf("Registries: %d configured (%s)", len(merged.Registries), JoinWords(parts)),
+		Details: details,
 	}
 }
 
@@ -392,6 +402,122 @@ func CheckNamingQuality(projectRoot string) CheckResult {
 		}
 	}
 	return CheckResult{Name: "naming", Status: CheckOK, Message: "Naming: all hooks/MCP items have display names"}
+}
+
+// CheckTrust reports MOAT trust health: bundled trusted-root staleness and
+// per-registry manifest-cache staleness. Today this state is only visible in
+// `syllago list` warnings; doctor is the diagnostic surface and must show it.
+func CheckTrust(projectRoot string) CheckResult {
+	now := time.Now()
+	status := CheckOK
+	var details []string
+
+	info := moat.BundledTrustedRoot(now)
+	switch info.Status {
+	case moat.TrustedRootStatusFresh:
+	case moat.TrustedRootStatusWarn, moat.TrustedRootStatusEscalated:
+		status = worseStatus(status, CheckWarn)
+		if msg := moat.StalenessMessage(info); msg != "" {
+			details = append(details, msg)
+		}
+	case moat.TrustedRootStatusExpired, moat.TrustedRootStatusMissing, moat.TrustedRootStatusCorrupt:
+		status = worseStatus(status, CheckErr)
+		if msg := moat.StalenessMessage(info); msg != "" {
+			details = append(details, msg)
+		}
+	}
+
+	freshRegistries := 0
+	scan, err := moat.LoadAndScan(projectRoot, projectRoot, now)
+	if err != nil {
+		status = worseStatus(status, CheckWarn)
+		details = append(details, fmt.Sprintf("Trust: could not scan registries: %v", err))
+	} else if scan.Catalog != nil {
+		names := make([]string, 0, len(scan.Catalog.RegistryTrusts))
+		for name := range scan.Catalog.RegistryTrusts {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			rt := scan.Catalog.RegistryTrusts[name]
+			if rt == nil {
+				continue
+			}
+			switch rt.Staleness {
+			case "Fresh":
+				freshRegistries++
+			case "Stale", "Missing":
+				status = worseStatus(status, CheckWarn)
+				details = append(details, fmt.Sprintf("registry %s: manifest cache %s — run 'syllago registry sync %s'",
+					name, registryStalenessLabel(rt.Staleness), name))
+			case "Expired":
+				status = worseStatus(status, CheckErr)
+				details = append(details, fmt.Sprintf("registry %s: manifest cache expired — trust decisions disabled until 'syllago registry sync %s'", name, name))
+			}
+		}
+	}
+
+	if status == CheckOK {
+		if freshRegistries == 0 {
+			return CheckResult{Name: "trust", Status: CheckOK, Message: "Trust: root fresh, no MOAT registries"}
+		}
+		return CheckResult{Name: "trust", Status: CheckOK, Message: fmt.Sprintf("Trust: root fresh, %d registries fresh", freshRegistries)}
+	}
+
+	return CheckResult{
+		Name:    "trust",
+		Status:  status,
+		Message: fmt.Sprintf("Trust: %d problems", len(details)),
+		Details: details,
+	}
+}
+
+func findSimilarRegistryPairs(registries []config.Registry) []string {
+	var details []string
+	for i := 0; i < len(registries); i++ {
+		for j := i + 1; j < len(registries); j++ {
+			a := registries[i]
+			b := registries[j]
+			if a.Name == b.Name {
+				continue
+			}
+			sameName := registryops.NormalizeRegistryIdentity(a.Name) == registryops.NormalizeRegistryIdentity(b.Name)
+			sameURL := a.URL != "" && b.URL != "" && registryops.NormalizeRegistryURL(a.URL) == registryops.NormalizeRegistryURL(b.URL)
+			if sameName || sameURL {
+				details = append(details, fmt.Sprintf("possible duplicate: %s and %s", a.Name, b.Name))
+			}
+		}
+	}
+	return details
+}
+
+func worseStatus(a, b CheckStatus) CheckStatus {
+	if checkStatusRank(b) > checkStatusRank(a) {
+		return b
+	}
+	return a
+}
+
+func checkStatusRank(status CheckStatus) int {
+	switch status {
+	case CheckErr:
+		return 2
+	case CheckWarn:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func registryStalenessLabel(staleness string) string {
+	switch staleness {
+	case "Stale":
+		return "stale"
+	case "Missing":
+		return "missing"
+	default:
+		return staleness
+	}
 }
 
 // JoinWords joins a list of words with ", " separators.

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/installer"
 	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"github.com/OpenScribbler/syllago/cli/internal/moatinstall"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
 )
 
@@ -45,6 +46,7 @@ func Run(projectRoot string) Result {
 	checks = append(checks, CheckLibrary())
 	checks = append(checks, CheckConfigWith(projectRoot))
 	checks = append(checks, CheckProviders())
+	checks = append(checks, CheckProviderLinks())
 	if projectRoot != "" {
 		checks = append(checks, CheckSymlinks(projectRoot))
 		checks = append(checks, CheckContentDrift(projectRoot))
@@ -150,6 +152,72 @@ func CheckProviders() CheckResult {
 		msg += fmt.Sprintf(", %d not found", notFound)
 	}
 	return CheckResult{Name: "providers", Status: CheckOK, Message: msg}
+}
+
+// CheckProviderLinks scans real provider install directories for syllago-owned
+// symlinks and reports dead ones. This is the reality-based complement to
+// CheckSymlinks, which audits recorded state.
+func CheckProviderLinks() CheckResult {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return CheckResult{Name: "provider-links", Status: CheckErr, Message: "Provider links: cannot determine home directory"}
+	}
+	return checkProviderLinksAt(home, provider.AllProviders, SyllagoOwnedRoots(home))
+}
+
+// SyllagoOwnedRoots returns the roots a syllago-created symlink may target:
+// the syllago home (library + registry checkouts) and the MOAT source cache.
+func SyllagoOwnedRoots(home string) []string {
+	roots := []string{filepath.Join(home, ".syllago")}
+	if cacheDir, err := moatinstall.SourceCacheDir(); err == nil && cacheDir != "" {
+		roots = append(roots, cacheDir)
+	}
+	return roots
+}
+
+// BrokenProviderLinks scans provider install directories and returns only
+// broken syllago-owned symlinks.
+func BrokenProviderLinks() ([]installer.ScannedLink, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	links := installer.ScanProviderLinks(provider.AllProviders, home, SyllagoOwnedRoots(home))
+	return brokenProviderLinks(links), nil
+}
+
+func checkProviderLinksAt(home string, providers []provider.Provider, roots []string) CheckResult {
+	links := installer.ScanProviderLinks(providers, home, roots)
+	if len(links) == 0 {
+		return CheckResult{Name: "provider-links", Status: CheckOK, Message: "Provider links: none found"}
+	}
+
+	broken := brokenProviderLinks(links)
+	if len(broken) == 0 {
+		return CheckResult{Name: "provider-links", Status: CheckOK, Message: fmt.Sprintf("Provider links: %d healthy", len(links))}
+	}
+
+	details := make([]string, 0, len(broken)+1)
+	for _, link := range broken {
+		details = append(details, fmt.Sprintf("broken: %s -> %s", link.Path, link.Target))
+	}
+	details = append(details, "Run 'syllago doctor --fix' to repair")
+	return CheckResult{
+		Name:    "provider-links",
+		Status:  CheckErr,
+		Message: fmt.Sprintf("Provider links: %d broken of %d total", len(broken), len(links)),
+		Details: details,
+	}
+}
+
+func brokenProviderLinks(links []installer.ScannedLink) []installer.ScannedLink {
+	var broken []installer.ScannedLink
+	for _, link := range links {
+		if link.Class == installer.LinkBroken {
+			broken = append(broken, link)
+		}
+	}
+	return broken
 }
 
 // CheckSymlinks verifies installed symlinks are not broken.

--- a/cli/internal/doctor/doctor_test.go
+++ b/cli/internal/doctor/doctor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
 )
 
@@ -77,6 +78,46 @@ func TestCheckProviderLinksAt_ReportsBroken(t *testing.T) {
 	}
 }
 
+func TestCheckTrustRunsWithoutMOATRegistries(t *testing.T) {
+	projectRoot := t.TempDir()
+	withDoctorGlobalConfigDir(t, t.TempDir())
+	if err := config.SaveGlobal(&config.Config{}); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	result := CheckTrust(projectRoot)
+
+	if result.Name != "trust" {
+		t.Fatalf("Name = %q, want trust", result.Name)
+	}
+	if result.Message == "" {
+		t.Fatal("Message is empty")
+	}
+}
+
+func TestCheckRegistriesWithWarnsOnNearDuplicates(t *testing.T) {
+	projectRoot := t.TempDir()
+	withDoctorGlobalConfigDir(t, t.TempDir())
+	cfg := &config.Config{
+		Registries: []config.Registry{
+			{Name: "Syllago_Community", URL: "https://github.com/example/one.git"},
+			{Name: "syllago-community", URL: "https://github.com/example/two.git"},
+		},
+	}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	result := CheckRegistriesWith(projectRoot)
+
+	if result.Status != CheckWarn {
+		t.Fatalf("Status = %s, want %s: %#v", result.Status, CheckWarn, result)
+	}
+	if len(result.Details) != 1 || !strings.Contains(result.Details[0], "possible duplicate: Syllago_Community and syllago-community") {
+		t.Fatalf("Details = %#v, want possible duplicate detail", result.Details)
+	}
+}
+
 func writeDoctorFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
@@ -95,4 +136,11 @@ func symlinkDoctor(t *testing.T, target, linkPath string) {
 	if err := os.Symlink(target, linkPath); err != nil {
 		t.Fatalf("Symlink: %v", err)
 	}
+}
+
+func withDoctorGlobalConfigDir(t *testing.T, dir string) {
+	t.Helper()
+	orig := config.GlobalDirOverride
+	config.GlobalDirOverride = dir
+	t.Cleanup(func() { config.GlobalDirOverride = orig })
 }

--- a/cli/internal/doctor/doctor_test.go
+++ b/cli/internal/doctor/doctor_test.go
@@ -1,0 +1,98 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+)
+
+func doctorLinkProvider(slug string, dirs map[catalog.ContentType]string) provider.Provider {
+	return provider.Provider{
+		Name: slug,
+		Slug: slug,
+		InstallDir: func(home string, ct catalog.ContentType) string {
+			return dirs[ct]
+		},
+	}
+}
+
+func TestCheckProviderLinksAt_AllHealthy(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, ".syllago")
+	source := filepath.Join(root, "content", "skills", "healthy")
+	installDir := filepath.Join(tmp, ".claude", "skills")
+	linkPath := filepath.Join(installDir, "healthy")
+	writeDoctorFile(t, source, "skill")
+	symlinkDoctor(t, source, linkPath)
+
+	result := checkProviderLinksAt(tmp, []provider.Provider{
+		doctorLinkProvider("claude-code", map[catalog.ContentType]string{catalog.Skills: installDir}),
+	}, []string{root})
+
+	if result.Name != "provider-links" {
+		t.Fatalf("Name = %q, want provider-links", result.Name)
+	}
+	if result.Status != CheckOK {
+		t.Fatalf("Status = %s, want %s: %#v", result.Status, CheckOK, result)
+	}
+	if result.Message != "Provider links: 1 healthy" {
+		t.Fatalf("Message = %q, want healthy count", result.Message)
+	}
+}
+
+func TestCheckProviderLinksAt_ReportsBroken(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, ".syllago")
+	installDir := filepath.Join(tmp, ".claude", "skills")
+	linkPath := filepath.Join(installDir, "broken")
+	target := filepath.Join(root, "content", "skills", "broken")
+	symlinkDoctor(t, target, linkPath)
+
+	result := checkProviderLinksAt(tmp, []provider.Provider{
+		doctorLinkProvider("claude-code", map[catalog.ContentType]string{catalog.Skills: installDir}),
+	}, []string{root})
+
+	if result.Status != CheckErr {
+		t.Fatalf("Status = %s, want %s: %#v", result.Status, CheckErr, result)
+	}
+	if result.Message != "Provider links: 1 broken of 1 total" {
+		t.Fatalf("Message = %q, want broken count", result.Message)
+	}
+	if len(result.Details) != 2 {
+		t.Fatalf("Details = %#v, want broken line plus fix hint", result.Details)
+	}
+	if !strings.Contains(result.Details[0], "broken: "+linkPath+" -> "+target) {
+		t.Fatalf("Details[0] = %q, want broken detail", result.Details[0])
+	}
+	if result.Details[1] != "Run 'syllago doctor --fix' to repair" {
+		t.Fatalf("Details[1] = %q, want fix hint", result.Details[1])
+	}
+}
+
+func writeDoctorFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func symlinkDoctor(t *testing.T, target, linkPath string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(target, linkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+}

--- a/cli/internal/installer/installer.go
+++ b/cli/internal/installer/installer.go
@@ -244,11 +244,7 @@ func Install(item catalog.ContentItem, prov provider.Provider, repoRoot string, 
 		return "", err
 	}
 
-	// Agents install the AGENT.md file, not the whole directory
-	sourcePath := item.Path
-	if item.Type == catalog.Agents {
-		sourcePath = filepath.Join(item.Path, "AGENT.md")
-	}
+	sourcePath := SourcePathFor(item)
 
 	switch method {
 	case MethodCopy:
@@ -313,11 +309,7 @@ func InstallWithResolver(item catalog.ContentItem, prov provider.Provider, repoR
 		}
 	}
 
-	// Agents install the AGENT.md file, not the whole directory
-	sourcePath := item.Path
-	if item.Type == catalog.Agents {
-		sourcePath = filepath.Join(item.Path, "AGENT.md")
-	}
+	sourcePath := SourcePathFor(item)
 
 	switch method {
 	case MethodCopy:

--- a/cli/internal/installer/installer.go
+++ b/cli/internal/installer/installer.go
@@ -349,8 +349,20 @@ func Uninstall(item catalog.ContentItem, prov provider.Provider, repoRoot string
 		return "", fmt.Errorf("not installed: %s", targetPath)
 	}
 
-	// Remove symlinks or regular files (copies)
-	if info.Mode()&os.ModeSymlink != 0 || info.Mode().IsRegular() {
+	// Remove symlinks only when they still point at this library item.
+	if info.Mode()&os.ModeSymlink != 0 {
+		actualTarget, err := resolveSymlinkTarget(targetPath)
+		if err != nil {
+			return "", fmt.Errorf("reading symlink %s: %w", targetPath, err)
+		}
+		if !symlinkTargetBelongsToItem(actualTarget, item) {
+			return "", fmt.Errorf("refusing to remove %s: symlink points to %s, not to %s", targetPath, actualTarget, item.Path)
+		}
+		return targetPath, os.Remove(targetPath)
+	}
+
+	// Remove regular files (copies)
+	if info.Mode().IsRegular() {
 		return targetPath, os.Remove(targetPath)
 	}
 
@@ -372,6 +384,13 @@ func Uninstall(item catalog.ContentItem, prov provider.Provider, repoRoot string
 	}
 
 	return "", fmt.Errorf("unexpected file type at %s, remove manually", targetPath)
+}
+
+func symlinkTargetBelongsToItem(target string, item catalog.ContentItem) bool {
+	target = filepath.Clean(target)
+	sourcePath := filepath.Clean(SourcePathFor(item))
+	itemPath := filepath.Clean(item.Path)
+	return target == sourcePath || target == itemPath || pathWithinRoot(target, itemPath)
 }
 
 // installWithRenderTo reads canonical content, renders it for the target provider,

--- a/cli/internal/installer/installer_test.go
+++ b/cli/internal/installer/installer_test.go
@@ -3,6 +3,7 @@ package installer
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
@@ -425,6 +426,82 @@ func TestUninstall_RemovesSymlink(t *testing.T) {
 	// Verify symlink is gone
 	if _, err := os.Lstat(targetPath); !os.IsNotExist(err) {
 		t.Error("symlink should be removed")
+	}
+}
+
+func TestUninstall_RefusesForeignSymlinkCollision(t *testing.T) {
+	tmp := t.TempDir()
+	repoRoot := filepath.Join(tmp, "repo")
+	os.MkdirAll(repoRoot, 0755)
+	t.Setenv("HOME", tmp)
+
+	prov := testProvider("test")
+
+	sourcePath := filepath.Join(repoRoot, "rules", "test", "remove-rule")
+	foreignPath := filepath.Join(tmp, "foreign", "remove-rule")
+	os.MkdirAll(sourcePath, 0755)
+	os.MkdirAll(foreignPath, 0755)
+
+	item := catalog.ContentItem{
+		Name: "remove-rule",
+		Type: catalog.Rules,
+		Path: sourcePath,
+	}
+
+	targetPath := filepath.Join(tmp, ".testprovider", "rules", "remove-rule")
+	os.MkdirAll(filepath.Dir(targetPath), 0755)
+	os.Symlink(foreignPath, targetPath)
+
+	_, err := Uninstall(item, prov, repoRoot)
+	if err == nil {
+		t.Fatal("expected refusing-to-remove error, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to remove") {
+		t.Fatalf("expected refusing-to-remove error, got: %v", err)
+	}
+
+	info, statErr := os.Lstat(targetPath)
+	if statErr != nil {
+		t.Fatalf("foreign symlink should survive: %v", statErr)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected target to remain a symlink, mode=%s", info.Mode())
+	}
+}
+
+func TestUninstall_RemovesAgentSymlinkToSourceFile(t *testing.T) {
+	tmp := t.TempDir()
+	repoRoot := filepath.Join(tmp, "repo")
+	os.MkdirAll(repoRoot, 0755)
+	t.Setenv("HOME", tmp)
+
+	prov := testProvider("test")
+
+	sourcePath := filepath.Join(repoRoot, "agents", "test", "remove-agent")
+	os.MkdirAll(sourcePath, 0755)
+	agentFile := filepath.Join(sourcePath, "AGENT.md")
+	os.WriteFile(agentFile, []byte("# Agent"), 0644)
+
+	item := catalog.ContentItem{
+		Name: "remove-agent",
+		Type: catalog.Agents,
+		Path: sourcePath,
+	}
+
+	targetPath := filepath.Join(tmp, ".testprovider", "agents", "remove-agent.md")
+	os.MkdirAll(filepath.Dir(targetPath), 0755)
+	os.Symlink(agentFile, targetPath)
+
+	desc, err := Uninstall(item, prov, repoRoot)
+	if err != nil {
+		t.Fatalf("Uninstall agent: %v", err)
+	}
+	if desc != targetPath {
+		t.Errorf("expected desc %s, got %s", targetPath, desc)
+	}
+
+	if _, err := os.Lstat(targetPath); !os.IsNotExist(err) {
+		t.Error("agent symlink should be removed")
 	}
 }
 

--- a/cli/internal/installer/linkscan.go
+++ b/cli/internal/installer/linkscan.go
@@ -1,0 +1,196 @@
+package installer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+)
+
+// LinkClass classifies a syllago-owned symlink found in a provider install directory.
+type LinkClass string
+
+const (
+	LinkHealthy LinkClass = "healthy" // target exists
+	LinkBroken  LinkClass = "broken"  // target missing
+)
+
+// ScannedLink is one symlink in a provider install directory whose target
+// resolves into a syllago-owned root.
+type ScannedLink struct {
+	Provider    string
+	ContentType catalog.ContentType
+	Path        string
+	Target      string
+	Class       LinkClass
+}
+
+// FixKind is the repair applied to a broken link.
+type FixKind string
+
+const (
+	FixRelink FixKind = "relink" // library still has the item; point the link at it
+	FixPrune  FixKind = "prune"  // no library match; remove the dead link
+)
+
+// FixAction is one planned repair for a broken provider link.
+type FixAction struct {
+	Kind      FixKind
+	Link      ScannedLink
+	NewSource string
+}
+
+// ScanProviderLinks walks each provider's install directory for every content
+// type and returns the symlinks whose target resolves into any of roots.
+// Symlinks pointing elsewhere (user-owned) and non-symlink entries are ignored.
+func ScanProviderLinks(providers []provider.Provider, home string, roots []string) []ScannedLink {
+	var links []ScannedLink
+	seen := make(map[string]bool)
+
+	for _, prov := range providers {
+		if prov.InstallDir == nil {
+			continue
+		}
+		for _, ct := range catalog.AllContentTypes() {
+			dir := prov.InstallDir(home, ct)
+			if dir == "" || dir == provider.JSONMergeSentinel || dir == provider.ProjectScopeSentinel {
+				continue
+			}
+
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				continue
+			}
+
+			for _, entry := range entries {
+				if entry.Type()&os.ModeSymlink == 0 {
+					continue
+				}
+
+				linkPath := filepath.Join(dir, entry.Name())
+				if absPath, err := filepath.Abs(linkPath); err == nil {
+					linkPath = absPath
+				} else {
+					linkPath = filepath.Clean(linkPath)
+				}
+				if seen[linkPath] {
+					continue
+				}
+
+				target, err := resolveSymlinkTarget(linkPath)
+				if err != nil {
+					continue
+				}
+				if !targetWithinAnyRoot(target, roots) {
+					continue
+				}
+
+				class := LinkHealthy
+				if _, err := os.Stat(linkPath); err != nil {
+					class = LinkBroken
+				}
+
+				links = append(links, ScannedLink{
+					Provider:    prov.Slug,
+					ContentType: ct,
+					Path:        linkPath,
+					Target:      target,
+					Class:       class,
+				})
+				seen[linkPath] = true
+			}
+		}
+	}
+
+	sort.Slice(links, func(i, j int) bool {
+		if links[i].Provider != links[j].Provider {
+			return links[i].Provider < links[j].Provider
+		}
+		if links[i].ContentType != links[j].ContentType {
+			return links[i].ContentType < links[j].ContentType
+		}
+		return links[i].Path < links[j].Path
+	})
+	return links
+}
+
+// SourcePathFor returns the filesystem source path used when installing item.
+func SourcePathFor(item catalog.ContentItem) string {
+	if item.Type == catalog.Agents {
+		return filepath.Join(item.Path, "AGENT.md")
+	}
+	return item.Path
+}
+
+// PlanLinkFixes maps each broken link to a repair: relink when the library
+// (libraryItems) still contains a matching item, prune otherwise.
+func PlanLinkFixes(broken []ScannedLink, libraryItems []catalog.ContentItem) []FixAction {
+	actions := make([]FixAction, 0, len(broken))
+	for _, link := range broken {
+		action := FixAction{Kind: FixPrune, Link: link}
+		if item, ok := findLinkFixMatch(link, libraryItems); ok {
+			sourcePath := SourcePathFor(item)
+			if _, err := os.Stat(sourcePath); err == nil {
+				action.Kind = FixRelink
+				action.NewSource = sourcePath
+			}
+		}
+		actions = append(actions, action)
+	}
+	return actions
+}
+
+// ApplyLinkFixes executes the plan. Returns the actions that failed with errors.
+func ApplyLinkFixes(actions []FixAction) []error {
+	var errs []error
+	for _, action := range actions {
+		switch action.Kind {
+		case FixRelink:
+			if err := CreateSymlink(action.NewSource, action.Link.Path); err != nil {
+				errs = append(errs, fmt.Errorf("relink %s -> %s: %w", action.Link.Path, action.NewSource, err))
+			}
+		case FixPrune:
+			if err := os.Remove(action.Link.Path); err != nil {
+				errs = append(errs, fmt.Errorf("prune %s: %w", action.Link.Path, err))
+			}
+		default:
+			errs = append(errs, fmt.Errorf("unknown fix kind %q for %s", action.Kind, action.Link.Path))
+		}
+	}
+	return errs
+}
+
+func targetWithinAnyRoot(target string, roots []string) bool {
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		if pathWithinRoot(target, root) {
+			return true
+		}
+	}
+	return false
+}
+
+func findLinkFixMatch(link ScannedLink, libraryItems []catalog.ContentItem) (catalog.ContentItem, bool) {
+	leaf := filepath.Base(link.Path)
+	for _, item := range libraryItems {
+		if item.Type != link.ContentType {
+			continue
+		}
+		if item.Type == catalog.Agents {
+			if item.Name == strings.TrimSuffix(leaf, ".md") {
+				return item, true
+			}
+			continue
+		}
+		if item.Name == leaf || filepath.Base(item.Path) == leaf {
+			return item, true
+		}
+	}
+	return catalog.ContentItem{}, false
+}

--- a/cli/internal/installer/linkscan_test.go
+++ b/cli/internal/installer/linkscan_test.go
@@ -1,0 +1,375 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+)
+
+func linkScanProvider(slug string, dirs map[catalog.ContentType]string) provider.Provider {
+	return provider.Provider{
+		Name: slug,
+		Slug: slug,
+		InstallDir: func(home string, ct catalog.ContentType) string {
+			return dirs[ct]
+		},
+	}
+}
+
+func TestScanProviderLinks_HealthyLinkIntoRoot(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "root")
+	source := filepath.Join(root, "skills", "alpha")
+	installDir := filepath.Join(tmp, "install")
+	linkPath := filepath.Join(installDir, "alpha")
+	mustWriteFile(t, source, "skill")
+	mustSymlink(t, source, linkPath)
+
+	links := ScanProviderLinks([]provider.Provider{
+		linkScanProvider("test", map[catalog.ContentType]string{catalog.Skills: installDir}),
+	}, tmp, []string{root})
+
+	if len(links) != 1 {
+		t.Fatalf("len(links) = %d, want 1: %#v", len(links), links)
+	}
+	got := links[0]
+	if got.Provider != "test" || got.ContentType != catalog.Skills || got.Path != linkPath || got.Target != source || got.Class != LinkHealthy {
+		t.Errorf("ScannedLink = %#v", got)
+	}
+}
+
+func TestScanProviderLinks_BrokenLinkIntoRoot(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "root")
+	target := filepath.Join(root, "missing")
+	installDir := filepath.Join(tmp, "install")
+	linkPath := filepath.Join(installDir, "missing")
+	mustSymlink(t, target, linkPath)
+
+	links := ScanProviderLinks([]provider.Provider{
+		linkScanProvider("test", map[catalog.ContentType]string{catalog.Skills: installDir}),
+	}, tmp, []string{root})
+
+	if len(links) != 1 {
+		t.Fatalf("len(links) = %d, want 1: %#v", len(links), links)
+	}
+	if links[0].Class != LinkBroken {
+		t.Errorf("Class = %q, want %q", links[0].Class, LinkBroken)
+	}
+}
+
+func TestScanProviderLinks_OutsideRootExcluded(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "root")
+	outside := filepath.Join(tmp, "outside", "skill")
+	installDir := filepath.Join(tmp, "install")
+	mustWriteFile(t, outside, "outside")
+	mustSymlink(t, outside, filepath.Join(installDir, "outside"))
+
+	links := ScanProviderLinks([]provider.Provider{
+		linkScanProvider("test", map[catalog.ContentType]string{catalog.Skills: installDir}),
+	}, tmp, []string{root})
+
+	if len(links) != 0 {
+		t.Fatalf("len(links) = %d, want 0: %#v", len(links), links)
+	}
+}
+
+func TestScanProviderLinks_RegularFileAndDirectoryExcluded(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "root")
+	installDir := filepath.Join(tmp, "install")
+	mustWriteFile(t, filepath.Join(installDir, "file"), "plain")
+	if err := os.MkdirAll(filepath.Join(installDir, "dir"), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	links := ScanProviderLinks([]provider.Provider{
+		linkScanProvider("test", map[catalog.ContentType]string{catalog.Skills: installDir}),
+	}, tmp, []string{root})
+
+	if len(links) != 0 {
+		t.Fatalf("len(links) = %d, want 0: %#v", len(links), links)
+	}
+}
+
+func TestScanProviderLinks_RelativeTargetResolvingIntoRootIncluded(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "root")
+	source := filepath.Join(root, "skills", "relative")
+	installDir := filepath.Join(tmp, "provider", "skills")
+	linkPath := filepath.Join(installDir, "relative")
+	mustWriteFile(t, source, "skill")
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	rel, err := filepath.Rel(installDir, source)
+	if err != nil {
+		t.Fatalf("Rel: %v", err)
+	}
+	if err := os.Symlink(rel, linkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	links := ScanProviderLinks([]provider.Provider{
+		linkScanProvider("test", map[catalog.ContentType]string{catalog.Skills: installDir}),
+	}, tmp, []string{root})
+
+	if len(links) != 1 {
+		t.Fatalf("len(links) = %d, want 1: %#v", len(links), links)
+	}
+	if links[0].Target != source {
+		t.Errorf("Target = %q, want %q", links[0].Target, source)
+	}
+}
+
+func TestScanProviderLinks_NonexistentInstallDirSkipped(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	links := ScanProviderLinks([]provider.Provider{
+		linkScanProvider("test", map[catalog.ContentType]string{catalog.Skills: filepath.Join(tmp, "missing")}),
+	}, tmp, []string{filepath.Join(tmp, "root")})
+
+	if len(links) != 0 {
+		t.Fatalf("len(links) = %d, want 0: %#v", len(links), links)
+	}
+}
+
+func TestScanProviderLinks_DedupesSharedDirectory(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "root")
+	source := filepath.Join(root, "skills", "shared")
+	installDir := filepath.Join(tmp, "install")
+	linkPath := filepath.Join(installDir, "shared")
+	mustWriteFile(t, source, "skill")
+	mustSymlink(t, source, linkPath)
+
+	links := ScanProviderLinks([]provider.Provider{
+		linkScanProvider("first", map[catalog.ContentType]string{catalog.Skills: installDir}),
+		linkScanProvider("second", map[catalog.ContentType]string{catalog.Skills: installDir}),
+	}, tmp, []string{root})
+
+	if len(links) != 1 {
+		t.Fatalf("len(links) = %d, want 1: %#v", len(links), links)
+	}
+	if links[0].Provider != "first" {
+		t.Errorf("Provider = %q, want first", links[0].Provider)
+	}
+}
+
+func TestScanProviderLinks_SortedDeterministically(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "root")
+	alphaDir := filepath.Join(tmp, "alpha")
+	zetaDir := filepath.Join(tmp, "zeta")
+	mustWriteFile(t, filepath.Join(root, "rules", "a"), "a")
+	mustWriteFile(t, filepath.Join(root, "rules", "b"), "b")
+	mustWriteFile(t, filepath.Join(root, "skills", "c"), "c")
+	mustSymlink(t, filepath.Join(root, "rules", "b"), filepath.Join(alphaDir, "b"))
+	mustSymlink(t, filepath.Join(root, "rules", "a"), filepath.Join(alphaDir, "a"))
+	mustSymlink(t, filepath.Join(root, "skills", "c"), filepath.Join(zetaDir, "c"))
+
+	links := ScanProviderLinks([]provider.Provider{
+		linkScanProvider("zeta", map[catalog.ContentType]string{catalog.Skills: zetaDir}),
+		linkScanProvider("alpha", map[catalog.ContentType]string{catalog.Rules: alphaDir}),
+	}, tmp, []string{root})
+
+	var got []string
+	for _, link := range links {
+		got = append(got, link.Provider+"/"+string(link.ContentType)+"/"+filepath.Base(link.Path))
+	}
+	want := []string{"alpha/rules/a", "alpha/rules/b", "zeta/skills/c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %#v, want %#v", got, want)
+	}
+}
+
+func TestPlanLinkFixes_BrokenSkillWithMatchingLibraryRelinks(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "content", "skills", "repair-me")
+	if err := os.MkdirAll(source, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	broken := []ScannedLink{{
+		ContentType: catalog.Skills,
+		Path:        filepath.Join(tmp, "install", "repair-me"),
+		Target:      filepath.Join(tmp, "root", "gone"),
+		Class:       LinkBroken,
+	}}
+
+	actions := PlanLinkFixes(broken, []catalog.ContentItem{{
+		Name:   "repair-me",
+		Type:   catalog.Skills,
+		Path:   source,
+		Source: "global",
+	}})
+
+	if len(actions) != 1 {
+		t.Fatalf("len(actions) = %d, want 1: %#v", len(actions), actions)
+	}
+	if actions[0].Kind != FixRelink || actions[0].NewSource != source {
+		t.Fatalf("action = %#v, want relink to %q", actions[0], source)
+	}
+}
+
+func TestPlanLinkFixes_BrokenAgentWithMatchingLibraryRelinksToAgentFile(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	itemDir := filepath.Join(tmp, "content", "agents", "foo")
+	source := filepath.Join(itemDir, "AGENT.md")
+	mustWriteFile(t, source, "agent")
+	broken := []ScannedLink{{
+		ContentType: catalog.Agents,
+		Path:        filepath.Join(tmp, "install", "foo.md"),
+		Target:      filepath.Join(tmp, "root", "gone.md"),
+		Class:       LinkBroken,
+	}}
+
+	actions := PlanLinkFixes(broken, []catalog.ContentItem{{
+		Name:   "foo",
+		Type:   catalog.Agents,
+		Path:   itemDir,
+		Source: "global",
+	}})
+
+	if len(actions) != 1 {
+		t.Fatalf("len(actions) = %d, want 1: %#v", len(actions), actions)
+	}
+	if actions[0].Kind != FixRelink || actions[0].NewSource != source {
+		t.Fatalf("action = %#v, want relink to %q", actions[0], source)
+	}
+}
+
+func TestPlanLinkFixes_NoLibraryMatchPrunes(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	actions := PlanLinkFixes([]ScannedLink{{
+		ContentType: catalog.Skills,
+		Path:        filepath.Join(tmp, "install", "gone"),
+		Target:      filepath.Join(tmp, "root", "gone"),
+		Class:       LinkBroken,
+	}}, nil)
+
+	if len(actions) != 1 {
+		t.Fatalf("len(actions) = %d, want 1", len(actions))
+	}
+	if actions[0].Kind != FixPrune {
+		t.Fatalf("Kind = %q, want %q", actions[0].Kind, FixPrune)
+	}
+}
+
+func TestPlanLinkFixes_MissingLibrarySourcePrunes(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	missingSource := filepath.Join(tmp, "content", "skills", "gone")
+	actions := PlanLinkFixes([]ScannedLink{{
+		ContentType: catalog.Skills,
+		Path:        filepath.Join(tmp, "install", "gone"),
+		Target:      filepath.Join(tmp, "root", "gone"),
+		Class:       LinkBroken,
+	}}, []catalog.ContentItem{{
+		Name:   "gone",
+		Type:   catalog.Skills,
+		Path:   missingSource,
+		Source: "global",
+	}})
+
+	if len(actions) != 1 {
+		t.Fatalf("len(actions) = %d, want 1", len(actions))
+	}
+	if actions[0].Kind != FixPrune {
+		t.Fatalf("Kind = %q, want %q", actions[0].Kind, FixPrune)
+	}
+}
+
+func TestApplyLinkFixes_RelinkRewritesSymlinkTarget(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	linkPath := filepath.Join(tmp, "install", "repair-me")
+	oldTarget := filepath.Join(tmp, "root", "gone")
+	newSource := filepath.Join(tmp, "content", "skills", "repair-me")
+	mustWriteFile(t, newSource, "skill")
+	mustSymlink(t, oldTarget, linkPath)
+
+	errs := ApplyLinkFixes([]FixAction{{
+		Kind:      FixRelink,
+		Link:      ScannedLink{Path: linkPath, Target: oldTarget},
+		NewSource: newSource,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("ApplyLinkFixes errors = %v", errs)
+	}
+
+	got, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("Readlink: %v", err)
+	}
+	if got != newSource {
+		t.Fatalf("target = %q, want %q", got, newSource)
+	}
+}
+
+func TestApplyLinkFixes_PruneRemovesLink(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	linkPath := filepath.Join(tmp, "install", "gone")
+	oldTarget := filepath.Join(tmp, "root", "gone")
+	mustSymlink(t, oldTarget, linkPath)
+
+	errs := ApplyLinkFixes([]FixAction{{
+		Kind: FixPrune,
+		Link: ScannedLink{Path: linkPath, Target: oldTarget},
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("ApplyLinkFixes errors = %v", errs)
+	}
+	if _, err := os.Lstat(linkPath); !os.IsNotExist(err) {
+		t.Fatalf("Lstat err = %v, want not exist", err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func mustSymlink(t *testing.T, target, linkPath string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(target, linkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+}

--- a/cli/internal/installer/symlink.go
+++ b/cli/internal/installer/symlink.go
@@ -57,18 +57,11 @@ func IsWindowsMount(path string) bool {
 
 // IsSymlinkedTo checks if the given path is a symlink pointing into the repoRoot.
 func IsSymlinkedTo(path, repoRoot string) bool {
-	target, err := os.Readlink(path)
+	target, err := resolveSymlinkTarget(path)
 	if err != nil {
 		return false
 	}
-	// Resolve to absolute if relative
-	if !filepath.IsAbs(target) {
-		target = filepath.Join(filepath.Dir(path), target)
-	}
-	// Clean both paths for comparison
-	target = filepath.Clean(target)
-	repoRoot = filepath.Clean(repoRoot)
-	return strings.HasPrefix(target, repoRoot+string(filepath.Separator)) || target == repoRoot
+	return pathWithinRoot(target, repoRoot)
 }
 
 // IsSymlinkedToAny checks if path is a symlink pointing into any of the given roots.
@@ -79,4 +72,21 @@ func IsSymlinkedToAny(path string, roots []string) bool {
 		}
 	}
 	return false
+}
+
+func resolveSymlinkTarget(path string) (string, error) {
+	target, err := os.Readlink(path)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(path), target)
+	}
+	return filepath.Clean(target), nil
+}
+
+func pathWithinRoot(path, root string) bool {
+	path = filepath.Clean(path)
+	root = filepath.Clean(root)
+	return strings.HasPrefix(path, root+string(filepath.Separator)) || path == root
 }

--- a/cli/internal/registryops/add.go
+++ b/cli/internal/registryops/add.go
@@ -121,6 +121,12 @@ type AddOutcome struct {
 	// caller can render a "Warning: no recognized content" line.
 	NoContentFound bool
 
+	// SimilarRegistries lists configured registries whose normalized name or
+	// URL near-duplicates this add (case/underscore-hyphen folding, same URL
+	// modulo .git suffix). The add still proceeds — the caller renders a
+	// warning so the user can spot an accidental double-add.
+	SimilarRegistries []string
+
 	// SelfDeclaredMOAT is true when the orchestrator upgraded the registry
 	// to MOAT via registry.yaml's manifest_uri field (no incoming
 	// SigningProfile from the caller). Callers print "Run sync --yes to pin"
@@ -160,6 +166,7 @@ func AddRegistry(ctx context.Context, opts AddOpts) (AddOutcome, error) {
 			return out, fmt.Errorf("%w: %q", ErrAddDuplicate, name)
 		}
 	}
+	out.SimilarRegistries = FindSimilarRegistries(cfg.Registries, name, opts.URL)
 
 	if !cfg.IsRegistryAllowed(opts.URL) {
 		return out, fmt.Errorf("%w: %q", ErrAddNotAllowed, opts.URL)

--- a/cli/internal/registryops/dupes.go
+++ b/cli/internal/registryops/dupes.go
@@ -1,0 +1,52 @@
+package registryops
+
+import (
+	"strings"
+
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+)
+
+// NormalizeRegistryIdentity folds a registry name for near-duplicate
+// comparison: lowercase, underscores folded to hyphens.
+func NormalizeRegistryIdentity(name string) string {
+	return strings.ReplaceAll(strings.ToLower(name), "_", "-")
+}
+
+// NormalizeRegistryURL folds a git URL for near-duplicate comparison:
+// lowercase, trailing "/" and ".git" stripped.
+func NormalizeRegistryURL(url string) string {
+	normalized := strings.ToLower(url)
+	for {
+		trimmed := strings.TrimSuffix(normalized, "/")
+		trimmed = strings.TrimSuffix(trimmed, ".git")
+		if trimmed == normalized {
+			return normalized
+		}
+		normalized = trimmed
+	}
+}
+
+// FindSimilarRegistries returns the names of configured registries that
+// near-duplicate the candidate name or URL without exact-matching the name.
+func FindSimilarRegistries(existing []config.Registry, name, url string) []string {
+	normalizedName := NormalizeRegistryIdentity(name)
+	normalizedURL := NormalizeRegistryURL(url)
+
+	var similar []string
+	for _, r := range existing {
+		if r.Name == name {
+			continue
+		}
+		if NormalizeRegistryIdentity(r.Name) == normalizedName {
+			similar = append(similar, r.Name)
+			continue
+		}
+		if r.URL == "" || url == "" {
+			continue
+		}
+		if NormalizeRegistryURL(r.URL) == normalizedURL {
+			similar = append(similar, r.Name)
+		}
+	}
+	return similar
+}

--- a/cli/internal/registryops/dupes_test.go
+++ b/cli/internal/registryops/dupes_test.go
@@ -1,0 +1,121 @@
+package registryops
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+)
+
+func TestNormalizeRegistryIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "Syllago_Community", want: "syllago-community"},
+		{name: "syllago-community", want: "syllago-community"},
+		{name: "owner/Syllago_Community", want: "owner/syllago-community"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := NormalizeRegistryIdentity(tt.name); got != tt.want {
+				t.Fatalf("NormalizeRegistryIdentity(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeRegistryURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+	}{
+		{
+			name: "lowercase and strip git suffix",
+			a:    "https://github.com/Org/Repo.git",
+			b:    "https://github.com/org/repo",
+		},
+		{
+			name: "strip trailing slash before git suffix",
+			a:    "HTTPS://Github.com/Org/Repo.git/",
+			b:    "https://github.com/org/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if gotA, gotB := NormalizeRegistryURL(tt.a), NormalizeRegistryURL(tt.b); gotA != gotB {
+				t.Fatalf("NormalizeRegistryURL(%q) = %q, NormalizeRegistryURL(%q) = %q; want equal", tt.a, gotA, tt.b, gotB)
+			}
+		})
+	}
+}
+
+func TestFindSimilarRegistries(t *testing.T) {
+	t.Parallel()
+
+	existing := []config.Registry{
+		{Name: "syllago-community", URL: "https://github.com/OpenScribbler/syllago-community.git"},
+		{Name: "same", URL: "https://github.com/example/same.git"},
+		{Name: "other", URL: "https://github.com/example/other.git"},
+		{Name: "empty-url", URL: ""},
+	}
+
+	tests := []struct {
+		name string
+		in   string
+		url  string
+		want []string
+	}{
+		{
+			name: "near-dup name found",
+			in:   "Syllago_Community",
+			url:  "https://github.com/example/different.git",
+			want: []string{"syllago-community"},
+		},
+		{
+			name: "near-dup url found",
+			in:   "different-name",
+			url:  "https://github.com/openscribbler/syllago-community",
+			want: []string{"syllago-community"},
+		},
+		{
+			name: "exact name excluded",
+			in:   "same",
+			url:  "https://github.com/example/same",
+			want: nil,
+		},
+		{
+			name: "unrelated entries excluded",
+			in:   "new-registry",
+			url:  "https://github.com/example/new.git",
+			want: nil,
+		},
+		{
+			name: "empty url skips url comparison",
+			in:   "new-registry",
+			url:  "",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := FindSimilarRegistries(existing, tt.in, tt.url); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("FindSimilarRegistries(..., %q, %q) = %#v, want %#v", tt.in, tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/internal/telemetry/catalog.go
+++ b/cli/internal/telemetry/catalog.go
@@ -161,9 +161,9 @@ func EventCatalog() []EventDef {
 				{
 					Name:        "action_count",
 					Type:        "int",
-					Description: "Number of actions performed by loadout",
+					Description: "Number of actions performed by loadout or doctor repair",
 					Example:     5,
-					Commands:    []string{"loadout_apply"},
+					Commands:    []string{"loadout_apply", "doctor"},
 				},
 				{
 					Name:        "registry_count",

--- a/cli/providers.json
+++ b/cli/providers.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
-  "generatedAt": "2026-05-07T17:06:07Z",
-  "syllagoVersion": "0.12.0",
+  "generatedAt": "2026-08-21T21:26:09Z",
+  "syllagoVersion": "0.14.0",
   "providers": [
     {
       "name": "Claude Code",
@@ -992,8 +992,19 @@
           ]
         },
         "skills": {
-          "supported": false,
-          "symlinkSupport": false
+          "supported": true,
+          "fileFormat": "md",
+          "installMethod": "filesystem",
+          "installPath": "{home}/.agents/skills",
+          "symlinkSupport": true,
+          "discoveryPaths": [
+            "{project}/.agents/skills"
+          ],
+          "frontmatterFields": [
+            "name",
+            "description",
+            "disable-model-invocation"
+          ]
         }
       }
     },
@@ -1667,9 +1678,8 @@
         "hooks": {
           "supported": true,
           "fileFormat": "ts",
-          "installMethod": "filesystem",
-          "installPath": "{home}/.pi/agent/extensions",
-          "symlinkSupport": true,
+          "installMethod": "json-merge",
+          "symlinkSupport": false,
           "discoveryPaths": [
             "{project}/.pi/extensions"
           ],
@@ -1808,8 +1818,24 @@
           "symlinkSupport": false
         },
         "hooks": {
-          "supported": false,
-          "symlinkSupport": false
+          "supported": true,
+          "fileFormat": "json",
+          "installMethod": "json-merge",
+          "symlinkSupport": false,
+          "discoveryPaths": [
+            "{project}/crush.json"
+          ],
+          "hookEvents": [
+            {
+              "canonical": "before_tool_execute",
+              "nativeName": "PreToolUse",
+              "category": "tool"
+            }
+          ],
+          "hookTypes": [
+            "command"
+          ],
+          "configLocation": "crush.json"
         },
         "loadouts": {
           "supported": false,

--- a/cli/syllago-yaml-schema.json
+++ b/cli/syllago-yaml-schema.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
-  "generated_at": "2026-05-07T17:06:08Z",
-  "syllago_version": "0.12.0",
+  "generated_at": "2026-08-21T21:26:09Z",
+  "syllago_version": "0.14.0",
   "schema": {
     "struct_name": "Meta",
     "format_version": 1,

--- a/cli/telemetry.json
+++ b/cli/telemetry.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
-  "generatedAt": "2026-07-09T00:52:23Z",
-  "syllagoVersion": "dev",
+  "generatedAt": "2026-08-21T21:26:09Z",
+  "syllagoVersion": "0.14.0",
   "events": [
     {
       "name": "command_executed",
@@ -193,10 +193,11 @@
         {
           "name": "action_count",
           "type": "int",
-          "description": "Number of actions performed by loadout",
+          "description": "Number of actions performed by loadout or doctor repair",
           "example": 5,
           "commands": [
-            "loadout_apply"
+            "loadout_apply",
+            "doctor"
           ]
         },
         {


### PR DESCRIPTION
Part of #542 — implements the four items that had no design blockers. The remaining items (2, 3, 6, 7, 8) fork on design decisions and are covered in the issue discussion.

## Item 1 — reality-based doctor + `--fix`
`doctor` audited only recorded install state, which plain `install` never writes. New `provider-links` check scans real provider install dirs for syllago-owned symlinks and reports dead ones as errors. `doctor --fix [--force]` re-links to matching library content or prunes dead links, with a printed plan and confirmation. Verified live: found 104 broken links of 119 total on a real machine that previously reported "all checks passed".

## Item 4 — remove implies uninstall + verified symlink deletion
`installer.Uninstall` refuses to delete a symlink unless its resolved target belongs to the item (protects user files and other content on name collisions). `remove` scans all provider dirs for links resolving into the item — any filename — removes them first, and aborts before deleting library content if link cleanup fails. Dry-run lists the links.

## Item 5 — loud trust failures
New doctor `trust` check surfaces bundled trusted-root staleness and per-registry manifest-cache staleness. `registry sync` now prints content-cache warnings that were previously discarded unread. `inspect` prints scan warnings like `list` does.

## Item 9 — duplicate-registry warning
`registry add` and `doctor` now detect near-duplicates (case/underscore-hyphen name folding, URL folding modulo `.git`). Warning, not error — forks and mirrors stay legitimate. Verified live: flagged a real accidental double-add.

Also includes a standalone chore commit regenerating `providers.json` / `content-format.json` / `syllago-yaml-schema.json`, which had drifted since v0.12.0 (no CI freshness gate covers them).

All commits: full `make test` green, `make fmt` clean, binary rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)