### PR TITLE
fix(ci): clear govulncheck failures via Go 1.26.6 + grpc v1.82.1

### DIFF
--- a/.github/workflows/capmon-pull.yml
+++ b/.github/workflows/capmon-pull.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache-dependency-path: cli/go.sum
 
       - name: Restore feed ETag cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache-dependency-path: cli/go.sum
 
       - name: Check Go claims against the Capability Feed mirror
@@ -86,7 +86,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -2,7 +2,7 @@ module github.com/OpenScribbler/syllago/cli
 
 go 1.26
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0
@@ -113,7 +113,7 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 // indirect
-	google.golang.org/grpc v1.82.0 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 )

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -434,8 +434,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 h1:PvEgGJf9C/1u5CHkInMg7UFYYUoiaQmW2LbtH0pjB78=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
-google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Problem

The `Go Test + Build` check has failed on every PR since 2026-08-05 — including plain dependabot bumps — because newly published vulnerability-database entries flag the repo's existing dependency set. Nothing in those PRs caused it; the vuln DB moved underneath us.

## Findings and fixes

| OSV | Where | Fix |
|-----|-------|-----|
| GO-2026-6218 | `net/url` (stdlib) | Go 1.26.6 |
| GO-2026-6090 | `crypto/tls` (stdlib) | Go 1.26.6 |
| GO-2026-5972 | `encoding/asn1` (stdlib) | Go 1.26.6 |
| GO-2026-5026 | `net/http` (stdlib) | Go 1.26.6 |
| GO-2026-6061 | `google.golang.org/grpc` v1.82.0 | grpc v1.82.1 |
| GO-2026-5932 | `x/crypto/openpgp`, no fixed version | already allowlisted in ci.yml |

## Changes

- `cli/go.mod`: `toolchain go1.26.5` → `go1.26.6`; grpc `v1.82.0` → `v1.82.1` (indirect), `go mod tidy`
- `.github/workflows/ci.yml`: three `go-version` pins `1.26.5` → `1.26.6`
- `.github/workflows/capmon-pull.yml`: `go-version` pin `1.26.5` → `1.26.6`

`release.yml` already floats on `1.26.x` and needs no change.

## Verification

- Full `make test` and `make build` pass with go1.26.6.
- Local `govulncheck -format json ./...` run through CI's exact jq filter returns zero non-allowlisted findings (only allowlisted GO-2026-5932 remains at call level).

Unblocks #543 and the dependabot queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)