### PR TITLE
chore(deps): bump github/codeql-action init and analyze together to v4.37.7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
           go-version: '1.26.x'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: go
 
@@ -39,4 +39,4 @@ jobs:
         run: go build ./cmd/syllago
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7


### PR DESCRIPTION
Supersedes #529 and #531. Dependabot split the `codeql-action/init` and `codeql-action/analyze` bumps of the same workflow into two PRs, but CodeQL requires init and analyze to run the same version within one run — so each half-PR fails its own CodeQL Analysis job (`Loaded a configuration file for version '4.37.0', but running version '4.37.7'`), and merging either alone would break CodeQL on main identically.

This bumps both pins to the same SHA (`ff2f1c62`, v4.37.7) in one commit. Dependabot will auto-close #529 and #531 once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)