### PR TITLE
fix(registry): write MOAT lockfile at project root so doctor sees sync freshness

### DIFF
--- a/cli/cmd/syllago/registry_cmd.go
+++ b/cli/cmd/syllago/registry_cmd.go
@@ -190,7 +190,12 @@ Use --sync to clone immediately (original behaviour).`,
 			if !pinned && !yes {
 				fmt.Fprintf(output.Writer, "Run `syllago registry sync --yes %s` to verify and pin the signing identity.\n", outcome.Registry.Name)
 			} else {
-				root, rootErr := findContentRepoRoot()
+				// Lockfile root is the bare project root (spec §Lockfile:
+				// <project root>/.syllago/moat-lockfile.json) — NOT
+				// findContentRepoRoot(), which appends the project config's
+				// content_root and would relocate the lockfile where doctor
+				// (moat.LoadAndScan(projectRoot, ...)) never looks.
+				lockfileRoot, rootErr := findProjectRoot()
 				if rootErr != nil {
 					return rootErr
 				}
@@ -204,7 +209,7 @@ Use --sync to clone immediately (original behaviour).`,
 				}
 				cacheDir, _ := config.GlobalDirPath()
 				fmt.Fprintf(output.Writer, "Verifying signing identity for %s...\n", outcome.Registry.Name)
-				code, syncErr := syncMOATRegistry(cmd.Context(), output.Writer, output.ErrWriter, freshCfg, reg, root, cacheDir, time.Now(), yes)
+				code, syncErr := syncMOATRegistry(cmd.Context(), output.Writer, output.ErrWriter, freshCfg, reg, lockfileRoot, cacheDir, time.Now(), yes)
 				if syncErr != nil {
 					return syncErr
 				}
@@ -441,7 +446,13 @@ and "syllago install" to activate updated content.`,
   syllago registry sync my-rules`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		root, err := findContentRepoRoot()
+		// Lockfile root is the bare project root (spec §Lockfile:
+		// <project root>/.syllago/moat-lockfile.json) — NOT
+		// findContentRepoRoot(), which appends the project config's
+		// content_root and would relocate the lockfile where doctor
+		// (moat.LoadAndScan(projectRoot, ...)) never looks, leaving the
+		// "manifest cache stale" warning stuck after a successful sync.
+		lockfileRoot, err := findProjectRoot()
 		if err != nil {
 			return err
 		}
@@ -467,7 +478,7 @@ and "syllago install" to activate updated content.`,
 			if reg == nil {
 				return output.NewStructuredError(output.ErrRegistryNotFound, fmt.Sprintf("registry %q not found in config", name), "Run 'syllago registry list' to see configured registries")
 			}
-			code, err := syncGitOrMOATRegistry(cmd.Context(), cfg, reg, root, cacheDir, yes)
+			code, err := syncGitOrMOATRegistry(cmd.Context(), cfg, reg, lockfileRoot, cacheDir, yes)
 			if err != nil {
 				return err
 			}
@@ -487,7 +498,7 @@ and "syllago install" to activate updated content.`,
 		hasErrors := false
 		for i := range cfg.Registries {
 			r := &cfg.Registries[i]
-			code, err := syncGitOrMOATRegistry(cmd.Context(), cfg, r, root, cacheDir, yes)
+			code, err := syncGitOrMOATRegistry(cmd.Context(), cfg, r, lockfileRoot, cacheDir, yes)
 			if err != nil {
 				if r.IsMOAT() {
 					return err
@@ -537,8 +548,10 @@ func ensureRegistryCloned(r *config.Registry, out io.Writer) (bool, error) {
 // clone lands for the first time it runs the content-discovery steps that
 // `registry add` skips for register-only registries (manifest stub + no-content
 // warning). Returns a non-zero MOAT gate exit code when a verification gate
-// trips.
-func syncGitOrMOATRegistry(ctx context.Context, cfg *config.Config, r *config.Registry, root, cacheDir string, yes bool) (int, error) {
+// trips. lockfileRoot is the bare project root whose
+// .syllago/moat-lockfile.json records MOAT trust state — never the
+// content_root-adjusted content directory.
+func syncGitOrMOATRegistry(ctx context.Context, cfg *config.Config, r *config.Registry, lockfileRoot, cacheDir string, yes bool) (int, error) {
 	justCloned := false
 	if r.IsGit() {
 		cloned, err := ensureRegistryCloned(r, output.Writer)
@@ -553,7 +566,7 @@ func syncGitOrMOATRegistry(ctx context.Context, cfg *config.Config, r *config.Re
 
 	if r.IsMOAT() {
 		fmt.Fprintf(output.Writer, "Syncing %s (moat)...\n", r.Name)
-		return syncMOATRegistry(ctx, output.Writer, output.ErrWriter, cfg, r, root, cacheDir, time.Now(), yes)
+		return syncMOATRegistry(ctx, output.Writer, output.ErrWriter, cfg, r, lockfileRoot, cacheDir, time.Now(), yes)
 	}
 
 	// Plain git registry.

--- a/cli/cmd/syllago/registry_sync_lockfile_root_test.go
+++ b/cli/cmd/syllago/registry_sync_lockfile_root_test.go
@@ -1,0 +1,96 @@
+package main
+
+// Regression tests for the MOAT lockfile root (spec §Lockfile).
+//
+// The lockfile is project-scoped state pinned at
+// <project root>/.syllago/moat-lockfile.json (moat.LockfileRelPath). Doctor
+// reads it from the bare project root (doctor.CheckTrust →
+// moat.LoadAndScan(projectRoot, projectRoot, now)). The sync command used to
+// derive its lockfile root from findContentRepoRoot(), which appends the
+// project config's content_root — so with `"content_root": "content"` the
+// lockfile landed at <root>/content/.syllago/moat-lockfile.json and doctor's
+// "manifest cache stale" warning never cleared after a successful sync.
+//
+// Strategy mirrors registry_sync_moat_test.go: stub registryops.SyncOneFn
+// (the orchestrator's moat.Sync seam) with a canned fresh result, but drive
+// the real `syllago registry sync` RunE so the root plumbed into
+// SyncOpts.LockfileRoot is the one under test.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+)
+
+func TestRegistrySyncCmd_LockfileAtProjectRoot_NotContentRoot(t *testing.T) {
+	// No t.Parallel — mutates SyncOneFn, GlobalDirOverride, findProjectRoot,
+	// and output writers.
+	root := tempProjectRoot(t)
+	withFakeRepoRoot(t, root)
+	output.SetForTest(t)
+
+	// Project config sets content_root, so findContentRepoRoot() resolves to
+	// <root>/content. The lockfile must still land at the bare project root.
+	if err := os.MkdirAll(filepath.Join(root, "content"), 0755); err != nil {
+		t.Fatalf("mkdir content root: %v", err)
+	}
+
+	pinned := incomingProfile()
+	reg := moatRegFixture("https://registry.example.com/manifest.json")
+	reg.SigningProfile = &pinned
+	cfg := &config.Config{
+		ContentRoot: "content",
+		Registries:  []config.Registry{reg},
+	}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("save initial cfg: %v", err)
+	}
+
+	fetchedAt := time.Now().UTC().Truncate(time.Second)
+	withStubbedMoatSync(t, func(_ context.Context, r *config.Registry, lf *moat.Lockfile, _ []byte, _ *moat.Fetcher, _ time.Time) (moat.SyncResult, error) {
+		// Mirror moat.Sync's documented side effect: record the successful
+		// fetch in the lockfile so staleness classification has a clock.
+		lf.Registries[r.ManifestURI] = moat.RegistryLockState{FetchedAt: fetchedAt}
+		return moat.SyncResult{
+			ManifestURL:     r.ManifestURI,
+			ETag:            `"v1"`,
+			FetchedAt:       fetchedAt,
+			IncomingProfile: incomingProfile(),
+			Staleness:       moat.StalenessFresh,
+			Manifest:        &moat.Manifest{},
+		}, nil
+	})
+
+	registrySyncCmd.SetContext(context.Background())
+	if err := registrySyncCmd.RunE(registrySyncCmd, []string{"example"}); err != nil {
+		t.Fatalf("registry sync: %v", err)
+	}
+
+	// Write side: the lockfile must be at the spec location...
+	wantPath := filepath.Join(root, ".syllago", "moat-lockfile.json")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Errorf("lockfile not written at project root (%s): %v", wantPath, err)
+	}
+	// ...and NOT relocated under content_root, where doctor never looks.
+	strayPath := filepath.Join(root, "content", ".syllago", "moat-lockfile.json")
+	if _, err := os.Stat(strayPath); err == nil {
+		t.Errorf("lockfile written under content_root (%s); doctor reads the project root and would report stale forever", strayPath)
+	}
+
+	// Read side: doctor.CheckTrust loads the lockfile via
+	// moat.LockfilePath(projectRoot) and classifies with moat.CheckRegistry.
+	// Same path + same call here — the just-synced registry must be Fresh.
+	lf, err := moat.LoadLockfile(moat.LockfilePath(root))
+	if err != nil {
+		t.Fatalf("load lockfile from project root: %v", err)
+	}
+	if got := moat.CheckRegistry(lf, reg.ManifestURI, nil, fetchedAt.Add(time.Hour)); got != moat.StalenessFresh {
+		t.Errorf("doctor-side staleness = %s; want Fresh", got)
+	}
+}

--- a/cli/cmd/syllago/registry_sync_moat.go
+++ b/cli/cmd/syllago/registry_sync_moat.go
@@ -56,12 +56,16 @@ var moatSyncFn = moat.Sync
 //
 // All persistence happens inside registryops.SyncOne — see that function's
 // doc for the side-effect list.
+// lockfileRoot is the bare project root (spec §Lockfile pins the MOAT
+// lockfile at <project root>/.syllago/moat-lockfile.json — the same path
+// doctor's CheckTrust reads). Callers must pass findProjectRoot(), never
+// findContentRepoRoot(), which content_root would redirect elsewhere.
 func syncMOATRegistry(
 	ctx context.Context,
 	out, errW io.Writer,
 	cfg *config.Config,
 	reg *config.Registry,
-	cfgRoot, cacheDir string,
+	lockfileRoot, cacheDir string,
 	now time.Time,
 	yes bool,
 ) (int, error) {
@@ -74,7 +78,7 @@ func syncMOATRegistry(
 
 	outcome, err := registryops.SyncOne(ctx, reg.Name, registryops.SyncOpts{
 		AcceptTOFU:   yes,
-		LockfileRoot: cfgRoot,
+		LockfileRoot: lockfileRoot,
 		CacheDir:     cacheDir,
 		Now:          now,
 	})

--- a/cli/internal/tui/moat_sync.go
+++ b/cli/internal/tui/moat_sync.go
@@ -71,8 +71,9 @@ func (a App) doMOATSyncCmd(name string, acceptTOFU bool) tea.Cmd {
 }
 
 // runMOATSync calls the shared orchestrator and shapes the outcome into a
-// moatSyncDoneMsg. projectRoot is the lockfile root (matches the CLI
-// dispatcher's cfgRoot from findContentRepoRoot); the manifest cache lives
+// moatSyncDoneMsg. projectRoot is the lockfile root — the bare project root
+// (App.projectRoot, from findProjectRoot), matching the CLI dispatcher and
+// doctor's CheckTrust read path per spec §Lockfile; the manifest cache lives
 // under config.GlobalDirPath() and the orchestrator resolves it itself.
 func runMOATSync(ctx context.Context, name, projectRoot string, acceptTOFU bool) tea.Msg {
 	outcome, err := registryops.SyncOne(ctx, name, registryops.SyncOpts{


### PR DESCRIPTION
## Bug

With a project config that sets `content_root`, `syllago registry sync` and `syllago doctor` operate on two different MOAT lockfiles, so doctor's "manifest cache stale" warning never clears after a successful sync:

- **sync wrote** via `findContentRepoRoot()`, which appends `content_root` → `<root>/content/.syllago/moat-lockfile.json`
- **doctor reads** `moat.LockfilePath(projectRoot)` → `<root>/.syllago/moat-lockfile.json` (the spec §Lockfile location)

Observed live: a verified sync stamped today's `fetched_at` under `content/` while the project-root lockfile sat untouched since April, keeping the stale warning permanently lit.

## Fix

Both CLI sync entry points (`registry sync` and `registry add --sync`'s auto-sync chain) now derive the lockfile root from `findProjectRoot()`, matching doctor, the TUI sync path, `registry remove`, and the install inline sync — all of which were already correct. The parameter is renamed `cfgRoot`/`root` → `lockfileRoot` with spec-citing comments so the contract is visible at every hop. `findContentRepoRoot()` is unchanged for its content-scanning uses. The TUI file change is comment-only (its doc comment claimed it matched the old, wrong CLI behavior).

## Test

`TestRegistrySyncCmd_LockfileAtProjectRoot_NotContentRoot` (written first, failed against the unfixed code) drives the real `registry sync` RunE with `"content_root": "content"` set and asserts: lockfile at the project root, no stray lockfile under `content/`, and Fresh classification through doctor's exact read path (`moat.LoadLockfile(moat.LockfilePath(root))` + `moat.CheckRegistry`).

Part of #542 item 6 groundwork — last-sync bookkeeping needs one canonical location before `registry status` can build on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)