### PR TITLE
feat(installstore): unified install-record store package (#542 item 2a)

### DIFF
--- a/cli/internal/installstore/hash.go
+++ b/cli/internal/installstore/hash.go
@@ -1,0 +1,32 @@
+package installstore
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"github.com/OpenScribbler/syllago/cli/internal/moathash"
+)
+
+// HashContent returns the canonical content hash for an installed item's
+// library source, formatted "sha256:<64 lowercase hex>".
+func HashContent(path string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("symlink rejected: %s", path)
+	}
+	if info.IsDir() {
+		return moat.ContentHash(path)
+	}
+	if info.Mode().IsRegular() {
+		hash, err := moathash.FileHash(path)
+		if err != nil {
+			return "", err
+		}
+		return "sha256:" + hash, nil
+	}
+	return "", fmt.Errorf("unsupported content path type: %s", path)
+}

--- a/cli/internal/installstore/hash_test.go
+++ b/cli/internal/installstore/hash_test.go
@@ -1,0 +1,85 @@
+package installstore
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/moat"
+)
+
+var installStoreHashPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+func TestHashContent(t *testing.T) {
+	t.Run("directory matches moat content hash", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "SKILL.md"), []byte("# Writer\n"))
+		writeFile(t, filepath.Join(dir, "lib", "helper.py"), []byte("print('ok')\n"))
+
+		want, err := moat.ContentHash(dir)
+		if err != nil {
+			t.Fatalf("moat.ContentHash: %v", err)
+		}
+		got, err := HashContent(dir)
+		if err != nil {
+			t.Fatalf("HashContent(dir): %v", err)
+		}
+		if got != want {
+			t.Fatalf("HashContent(dir) = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("text files are canonicalized and prefixed", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		lfPath := filepath.Join(dir, "lf.txt")
+		crlfPath := filepath.Join(dir, "crlf.txt")
+		writeFile(t, lfPath, []byte("alpha\nbeta\n"))
+		writeFile(t, crlfPath, []byte("alpha\r\nbeta\r\n"))
+
+		lfHash, err := HashContent(lfPath)
+		if err != nil {
+			t.Fatalf("HashContent(lf): %v", err)
+		}
+		crlfHash, err := HashContent(crlfPath)
+		if err != nil {
+			t.Fatalf("HashContent(crlf): %v", err)
+		}
+		if lfHash != crlfHash {
+			t.Fatalf("LF hash %s != CRLF hash %s", lfHash, crlfHash)
+		}
+		if !installStoreHashPattern.MatchString(lfHash) {
+			t.Fatalf("hash %q does not match sha256:<64 lowercase hex>", lfHash)
+		}
+	})
+
+	t.Run("symlink argument returns error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		target := filepath.Join(dir, "target.txt")
+		link := filepath.Join(dir, "link.txt")
+		writeFile(t, target, []byte("target\n"))
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("Symlink not available: %v", err)
+		}
+
+		_, err := HashContent(link)
+		if err == nil {
+			t.Fatal("HashContent(symlink) returned nil error")
+		}
+		if !strings.Contains(strings.ToLower(err.Error()), "symlink") {
+			t.Fatalf("HashContent(symlink) error = %q, want symlink mention", err.Error())
+		}
+	})
+
+	t.Run("missing path returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := HashContent(filepath.Join(t.TempDir(), "missing.txt"))
+		if err == nil {
+			t.Fatal("HashContent(missing) returned nil error")
+		}
+	})
+}

--- a/cli/internal/installstore/store.go
+++ b/cli/internal/installstore/store.go
@@ -1,0 +1,320 @@
+package installstore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+)
+
+const CurrentVersion = 1
+
+// Coord identifies an installed item: identity is coordinates, not paths.
+// Registry is the configured registry name; empty string means content that
+// originated in the local library with no registry.
+type Coord struct {
+	Registry string `json:"registry,omitempty"`
+	Type     string `json:"type"`
+	Name     string `json:"name"`
+}
+
+// Mechanism is how a placement was materialized in a provider.
+type Mechanism string
+
+const (
+	MechanismSymlink    Mechanism = "symlink"
+	MechanismHookMerge  Mechanism = "hook_merge"
+	MechanismMCPMerge   Mechanism = "mcp_merge"
+	MechanismRuleAppend Mechanism = "rule_append"
+)
+
+// Placement records one materialization of a record in a provider.
+type Placement struct {
+	Provider    string    `json:"provider"`
+	Mechanism   Mechanism `json:"mechanism"`
+	Path        string    `json:"path"`
+	Key         string    `json:"key,omitempty"`
+	Scope       string    `json:"scope,omitempty"`
+	InstalledAt time.Time `json:"installed_at"`
+}
+
+// MOATProvenance is carried for MOAT-registry installs so trust can be
+// re-verified later without re-deriving it from the lockfile.
+type MOATProvenance struct {
+	ManifestURI string    `json:"manifest_uri"`
+	SourceURI   string    `json:"source_uri"`
+	TrustTier   string    `json:"trust_tier,omitempty"`
+	AttestedAt  time.Time `json:"attested_at,omitempty"`
+}
+
+// Record is one installed content item.
+type Record struct {
+	Coord
+	ContentHash string          `json:"content_hash"`
+	LibraryPath string          `json:"library_path"`
+	MOAT        *MOATProvenance `json:"moat,omitempty"`
+	InstalledAt time.Time       `json:"installed_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+	Placements  []Placement     `json:"placements,omitempty"`
+}
+
+// Store is the on-disk install-record store.
+type Store struct {
+	Version int      `json:"version"`
+	Records []Record `json:"records"`
+
+	path string
+}
+
+// DefaultPath returns the global install-record store path.
+func DefaultPath() (string, error) {
+	dir, err := config.GlobalDirPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "installs.json"), nil
+}
+
+// Load reads the install-record store at path. A missing file returns an
+// empty store bound to path so callers can save it directly.
+func Load(path string) (*Store, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &Store{Version: CurrentVersion, Records: []Record{}, path: path}, nil
+		}
+		return nil, fmt.Errorf("reading install store %s: %w", path, err)
+	}
+
+	var s Store
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("install store json %s: %w", path, err)
+	}
+	if s.Version > CurrentVersion {
+		return nil, fmt.Errorf("install store version %d is newer than supported version %d", s.Version, CurrentVersion)
+	}
+	if s.Version == 0 {
+		s.Version = CurrentVersion
+	}
+	if s.Records == nil {
+		s.Records = []Record{}
+	}
+	s.path = path
+	return &s, nil
+}
+
+// Save atomically writes the store to the path it was loaded from.
+func (s *Store) Save() error {
+	if s == nil {
+		return errors.New("install store is nil")
+	}
+	if s.path == "" {
+		return errors.New("install store path is empty")
+	}
+	if s.Version == 0 {
+		s.Version = CurrentVersion
+	}
+	if s.Records == nil {
+		s.Records = []Record{}
+	}
+	s.sortForSave()
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling install store: %w", err)
+	}
+
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating install store dir: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, "installs-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp install store: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp install store: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing temp install store: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("syncing temp install store: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp install store: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		return fmt.Errorf("renaming install store into place: %w", err)
+	}
+	return nil
+}
+
+// Find returns the record matching c, or nil if none exists.
+func (s *Store) Find(c Coord) *Record {
+	if s == nil {
+		return nil
+	}
+	for i := range s.Records {
+		if s.Records[i].Coord == c {
+			return &s.Records[i]
+		}
+	}
+	return nil
+}
+
+// Upsert replaces the record with matching coordinates or appends it.
+func (s *Store) Upsert(rec Record) {
+	if s.Version == 0 {
+		s.Version = CurrentVersion
+	}
+	for i := range s.Records {
+		if s.Records[i].Coord == rec.Coord {
+			if rec.InstalledAt.IsZero() {
+				rec.InstalledAt = s.Records[i].InstalledAt
+			}
+			s.Records[i] = rec
+			return
+		}
+	}
+	s.Records = append(s.Records, rec)
+}
+
+// Remove deletes the record matching c and reports whether it existed.
+func (s *Store) Remove(c Coord) bool {
+	if s == nil {
+		return false
+	}
+	for i := range s.Records {
+		if s.Records[i].Coord != c {
+			continue
+		}
+		copy(s.Records[i:], s.Records[i+1:])
+		s.Records[len(s.Records)-1] = Record{}
+		s.Records = s.Records[:len(s.Records)-1]
+		return true
+	}
+	return false
+}
+
+// AddPlacement adds or replaces a placement for an existing record.
+func (s *Store) AddPlacement(c Coord, p Placement) error {
+	rec := s.Find(c)
+	if rec == nil {
+		return fmt.Errorf("install record not found for coord registry=%q type=%q name=%q", c.Registry, c.Type, c.Name)
+	}
+	for i := range rec.Placements {
+		if samePlacementIdentity(rec.Placements[i], p.Provider, p.Mechanism, p.Path, p.Key) {
+			rec.Placements[i] = p
+			return nil
+		}
+	}
+	rec.Placements = append(rec.Placements, p)
+	return nil
+}
+
+// RemovePlacement removes a placement matching the placement identity.
+func (s *Store) RemovePlacement(c Coord, provider string, m Mechanism, path, key string) bool {
+	rec := s.Find(c)
+	if rec == nil {
+		return false
+	}
+	for i := range rec.Placements {
+		if !samePlacementIdentity(rec.Placements[i], provider, m, path, key) {
+			continue
+		}
+		copy(rec.Placements[i:], rec.Placements[i+1:])
+		rec.Placements[len(rec.Placements)-1] = Placement{}
+		rec.Placements = rec.Placements[:len(rec.Placements)-1]
+		return true
+	}
+	return false
+}
+
+// ByProvider returns records with at least one placement for slug.
+func (s *Store) ByProvider(slug string) []Record {
+	if s == nil {
+		return nil
+	}
+	var out []Record
+	for _, rec := range s.Records {
+		for _, p := range rec.Placements {
+			if p.Provider != slug {
+				continue
+			}
+			out = append(out, cloneRecord(rec))
+			break
+		}
+	}
+	return out
+}
+
+// ByRegistry returns records whose registry matches registry. An empty
+// registry selects local-library records.
+func (s *Store) ByRegistry(registry string) []Record {
+	if s == nil {
+		return nil
+	}
+	var out []Record
+	for _, rec := range s.Records {
+		if rec.Registry == registry {
+			out = append(out, cloneRecord(rec))
+		}
+	}
+	return out
+}
+
+func (s *Store) sortForSave() {
+	sort.Slice(s.Records, func(i, j int) bool {
+		a, b := s.Records[i], s.Records[j]
+		if a.Registry != b.Registry {
+			return a.Registry < b.Registry
+		}
+		if a.Type != b.Type {
+			return a.Type < b.Type
+		}
+		return a.Name < b.Name
+	})
+	for i := range s.Records {
+		sort.Slice(s.Records[i].Placements, func(a, b int) bool {
+			left, right := s.Records[i].Placements[a], s.Records[i].Placements[b]
+			if left.Provider != right.Provider {
+				return left.Provider < right.Provider
+			}
+			if left.Mechanism != right.Mechanism {
+				return left.Mechanism < right.Mechanism
+			}
+			if left.Path != right.Path {
+				return left.Path < right.Path
+			}
+			return left.Key < right.Key
+		})
+	}
+}
+
+func samePlacementIdentity(p Placement, provider string, m Mechanism, path, key string) bool {
+	return p.Provider == provider && p.Mechanism == m && p.Path == path && p.Key == key
+}
+
+func cloneRecord(rec Record) Record {
+	if rec.MOAT != nil {
+		moat := *rec.MOAT
+		rec.MOAT = &moat
+	}
+	if rec.Placements != nil {
+		rec.Placements = append([]Placement(nil), rec.Placements...)
+	}
+	return rec
+}

--- a/cli/internal/installstore/store_test.go
+++ b/cli/internal/installstore/store_test.go
@@ -1,0 +1,471 @@
+package installstore
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+)
+
+func fixedTime(hour int) time.Time {
+	return time.Date(2026, 8, 22, hour, 0, 0, 0, time.UTC)
+}
+
+func testCoord(registry, typ, name string) Coord {
+	return Coord{Registry: registry, Type: typ, Name: name}
+}
+
+func testRecord(c Coord, installedAt time.Time) Record {
+	return Record{
+		Coord:       c,
+		ContentHash: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		LibraryPath: filepath.ToSlash(filepath.Join(c.Type, c.Name)),
+		InstalledAt: installedAt,
+		UpdatedAt:   installedAt.Add(time.Hour),
+	}
+}
+
+func mustLoadStore(t *testing.T, path string) *Store {
+	t.Helper()
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(%s): %v", path, err)
+	}
+	return s
+}
+
+func mustSaveStore(t *testing.T, s *Store) {
+	t.Helper()
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return data
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func TestLoad(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file returns empty store that can save", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "nested", "installs.json")
+
+		s, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load missing: %v", err)
+		}
+		if s.Version != CurrentVersion {
+			t.Fatalf("Version = %d, want %d", s.Version, CurrentVersion)
+		}
+		if len(s.Records) != 0 {
+			t.Fatalf("Records length = %d, want 0", len(s.Records))
+		}
+
+		if err := s.Save(); err != nil {
+			t.Fatalf("Save after missing Load: %v", err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat(%s): %v", path, err)
+		}
+		if got := info.Mode().Perm(); got != 0o644 {
+			t.Fatalf("saved mode = %o, want 0644", got)
+		}
+	})
+
+	t.Run("corrupt json returns error", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "installs.json")
+		writeFile(t, path, []byte(`{"version":`))
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load corrupt JSON returned nil error")
+		}
+	})
+
+	t.Run("newer version returns error mentioning both versions", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "installs.json")
+		writeFile(t, path, []byte(`{"version":99,"records":[]}`))
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load newer version returned nil error")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "99") || !strings.Contains(msg, "1") {
+			t.Fatalf("error = %q, want both version numbers", msg)
+		}
+	})
+}
+
+func TestStoreRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state", "installs.json")
+	s := mustLoadStore(t, path)
+	local := testRecord(testCoord("", "rules", "local-style"), fixedTime(9))
+	local.ContentHash = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	local.Placements = []Placement{{
+		Provider:    "codex",
+		Mechanism:   MechanismRuleAppend,
+		Path:        "/tmp/project/AGENTS.md",
+		Key:         "syllago:local-style",
+		Scope:       "/tmp/project",
+		InstalledAt: fixedTime(10),
+	}}
+
+	moatRec := testRecord(testCoord("core", "skills", "reviewer"), fixedTime(11))
+	moatRec.MOAT = &MOATProvenance{
+		ManifestURI: "https://example.com/moat-manifest.json",
+		SourceURI:   "https://example.com/reviewer.tar.gz",
+		TrustTier:   "SIGNED",
+		AttestedAt:  fixedTime(8),
+	}
+	moatRec.Placements = []Placement{
+		{
+			Provider:    "claude",
+			Mechanism:   MechanismSymlink,
+			Path:        "/tmp/home/.claude/skills/reviewer",
+			InstalledAt: fixedTime(12),
+		},
+		{
+			Provider:    "codex",
+			Mechanism:   MechanismHookMerge,
+			Path:        "/tmp/home/.codex/settings.json",
+			Key:         "PreToolUse",
+			InstalledAt: fixedTime(13),
+		},
+	}
+	s.Records = []Record{local, moatRec}
+
+	mustSaveStore(t, s)
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load round-trip: %v", err)
+	}
+	if !reflect.DeepEqual(s, loaded) {
+		t.Fatalf("round-trip mismatch\n got: %#v\nwant: %#v", loaded, s)
+	}
+}
+
+func TestStoreSaveDeterministic(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a.json")
+	pathB := filepath.Join(dir, "b.json")
+
+	coordA := testCoord("zeta", "skills", "z")
+	coordB := testCoord("", "rules", "local")
+	coordC := testCoord("alpha", "commands", "build")
+
+	recA := testRecord(coordA, fixedTime(1))
+	recA.Placements = []Placement{
+		{Provider: "codex", Mechanism: MechanismMCPMerge, Path: "/settings.json", Key: "server-b", InstalledAt: fixedTime(4)},
+		{Provider: "claude", Mechanism: MechanismSymlink, Path: "/skills/z", InstalledAt: fixedTime(3)},
+		{Provider: "codex", Mechanism: MechanismMCPMerge, Path: "/settings.json", Key: "server-a", InstalledAt: fixedTime(2)},
+	}
+	recB := testRecord(coordB, fixedTime(5))
+	recC := testRecord(coordC, fixedTime(6))
+
+	first := mustLoadStore(t, pathA)
+	first.Records = []Record{recA, recC, recB}
+	mustSaveStore(t, first)
+
+	second := mustLoadStore(t, pathB)
+	recAAlt := recA
+	recAAlt.Placements = []Placement{recA.Placements[2], recA.Placements[0], recA.Placements[1]}
+	second.Records = []Record{recB, recAAlt, recC}
+	mustSaveStore(t, second)
+
+	if a, b := mustReadFile(t, pathA), mustReadFile(t, pathB); !bytes.Equal(a, b) {
+		t.Fatalf("saved bytes differ\nA:\n%s\nB:\n%s", a, b)
+	}
+}
+
+func TestStoreSaveDefensiveBranches(t *testing.T) {
+	t.Parallel()
+
+	var nilStore *Store
+	if err := nilStore.Save(); err == nil {
+		t.Fatal("nil Store Save returned nil error")
+	}
+
+	if err := (&Store{Version: CurrentVersion}).Save(); err == nil {
+		t.Fatal("empty-path Store Save returned nil error")
+	}
+
+	path := filepath.Join(t.TempDir(), "installs.json")
+	s := mustLoadStore(t, path)
+	s.Version = 0
+	s.Records = nil
+	mustSaveStore(t, s)
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load saved zero-version store: %v", err)
+	}
+	if loaded.Version != CurrentVersion {
+		t.Fatalf("Version = %d, want %d", loaded.Version, CurrentVersion)
+	}
+	if len(loaded.Records) != 0 {
+		t.Fatalf("Records length = %d, want 0", len(loaded.Records))
+	}
+}
+
+func TestStoreUpsert(t *testing.T) {
+	t.Parallel()
+
+	c := testCoord("core", "skills", "writer")
+	s := &Store{Version: CurrentVersion}
+
+	inserted := testRecord(c, fixedTime(1))
+	s.Upsert(inserted)
+	if got := s.Find(c); got == nil || got.ContentHash != inserted.ContentHash {
+		t.Fatalf("fresh insert not found: %#v", got)
+	}
+
+	replacement := testRecord(c, time.Time{})
+	replacement.ContentHash = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	replacement.UpdatedAt = fixedTime(4)
+	s.Upsert(replacement)
+	got := s.Find(c)
+	if got == nil {
+		t.Fatal("replacement missing")
+	}
+	if got.InstalledAt != inserted.InstalledAt {
+		t.Fatalf("InstalledAt = %v, want preserved %v", got.InstalledAt, inserted.InstalledAt)
+	}
+	if got.ContentHash != replacement.ContentHash {
+		t.Fatalf("ContentHash = %s, want %s", got.ContentHash, replacement.ContentHash)
+	}
+
+	override := testRecord(c, fixedTime(8))
+	s.Upsert(override)
+	got = s.Find(c)
+	if got == nil {
+		t.Fatal("override missing")
+	}
+	if got.InstalledAt != override.InstalledAt {
+		t.Fatalf("InstalledAt = %v, want override %v", got.InstalledAt, override.InstalledAt)
+	}
+}
+
+func TestStoreFindAndRemove(t *testing.T) {
+	t.Parallel()
+
+	c := testCoord("core", "skills", "writer")
+	missing := testCoord("core", "skills", "missing")
+	s := &Store{Version: CurrentVersion, Records: []Record{testRecord(c, fixedTime(1))}}
+
+	got := s.Find(c)
+	if got == nil {
+		t.Fatal("Find present returned nil")
+	}
+	got.ContentHash = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	if s.Records[0].ContentHash != got.ContentHash {
+		t.Fatal("Find did not return a pointer into the store slice")
+	}
+	if got := s.Find(missing); got != nil {
+		t.Fatalf("Find missing = %#v, want nil", got)
+	}
+
+	if !s.Remove(c) {
+		t.Fatal("Remove present = false, want true")
+	}
+	if len(s.Records) != 0 {
+		t.Fatalf("Records length after remove = %d, want 0", len(s.Records))
+	}
+	if s.Remove(missing) {
+		t.Fatal("Remove missing = true, want false")
+	}
+}
+
+func TestStoreAddPlacement(t *testing.T) {
+	t.Parallel()
+
+	c := testCoord("core", "skills", "writer")
+	missing := testCoord("core", "skills", "missing")
+	s := &Store{Version: CurrentVersion, Records: []Record{testRecord(c, fixedTime(1))}}
+
+	err := s.AddPlacement(missing, Placement{Provider: "codex", Mechanism: MechanismSymlink, Path: "/x"})
+	if err == nil {
+		t.Fatal("AddPlacement missing record returned nil error")
+	}
+	for _, want := range []string{"core", "skills", "missing"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("missing-record error = %q, want substring %q", err.Error(), want)
+		}
+	}
+
+	p := Placement{
+		Provider:    "codex",
+		Mechanism:   MechanismHookMerge,
+		Path:        "/tmp/settings.json",
+		Key:         "PreToolUse",
+		InstalledAt: fixedTime(2),
+	}
+	if err := s.AddPlacement(c, p); err != nil {
+		t.Fatalf("AddPlacement first: %v", err)
+	}
+	replacement := p
+	replacement.Scope = "/tmp/project"
+	replacement.InstalledAt = fixedTime(3)
+	if err := s.AddPlacement(c, replacement); err != nil {
+		t.Fatalf("AddPlacement replacement: %v", err)
+	}
+	rec := s.Find(c)
+	if rec == nil {
+		t.Fatal("record missing after placement add")
+	}
+	if len(rec.Placements) != 1 {
+		t.Fatalf("Placements length = %d, want 1", len(rec.Placements))
+	}
+	if rec.Placements[0].Scope != replacement.Scope || rec.Placements[0].InstalledAt != replacement.InstalledAt {
+		t.Fatalf("placement was not replaced: %#v", rec.Placements[0])
+	}
+
+	distinctKey := replacement
+	distinctKey.Key = "PostToolUse"
+	if err := s.AddPlacement(c, distinctKey); err != nil {
+		t.Fatalf("AddPlacement distinct key: %v", err)
+	}
+	if len(rec.Placements) != 2 {
+		t.Fatalf("Placements length after distinct key = %d, want 2", len(rec.Placements))
+	}
+}
+
+func TestStoreRemovePlacement(t *testing.T) {
+	t.Parallel()
+
+	c := testCoord("core", "skills", "writer")
+	p1 := Placement{Provider: "codex", Mechanism: MechanismHookMerge, Path: "/tmp/settings.json", Key: "PreToolUse", InstalledAt: fixedTime(2)}
+	p2 := Placement{Provider: "codex", Mechanism: MechanismHookMerge, Path: "/tmp/settings.json", Key: "PostToolUse", InstalledAt: fixedTime(3)}
+	s := &Store{Version: CurrentVersion, Records: []Record{testRecord(c, fixedTime(1))}}
+	s.Records[0].Placements = []Placement{p1, p2}
+
+	if !s.RemovePlacement(c, p1.Provider, p1.Mechanism, p1.Path, p1.Key) {
+		t.Fatal("RemovePlacement present = false, want true")
+	}
+	if len(s.Records[0].Placements) != 1 || s.Records[0].Placements[0].Key != p2.Key {
+		t.Fatalf("placements after first remove = %#v", s.Records[0].Placements)
+	}
+	if s.RemovePlacement(c, p1.Provider, p1.Mechanism, p1.Path, p1.Key) {
+		t.Fatal("RemovePlacement absent = true, want false")
+	}
+	if !s.RemovePlacement(c, p2.Provider, p2.Mechanism, p2.Path, p2.Key) {
+		t.Fatal("RemovePlacement last = false, want true")
+	}
+	if rec := s.Find(c); rec == nil {
+		t.Fatal("record was removed with last placement")
+	} else if len(rec.Placements) != 0 {
+		t.Fatalf("placements length = %d, want 0", len(rec.Placements))
+	}
+	if s.RemovePlacement(testCoord("core", "skills", "missing"), p2.Provider, p2.Mechanism, p2.Path, p2.Key) {
+		t.Fatal("RemovePlacement missing record = true, want false")
+	}
+}
+
+func TestStoreQueries(t *testing.T) {
+	t.Parallel()
+
+	local := testRecord(testCoord("", "rules", "local"), fixedTime(1))
+	local.Placements = []Placement{{Provider: "codex", Mechanism: MechanismRuleAppend, Path: "/tmp/AGENTS.md"}}
+	core := testRecord(testCoord("core", "skills", "writer"), fixedTime(2))
+	core.MOAT = &MOATProvenance{
+		ManifestURI: "https://example.com/moat.json",
+		SourceURI:   "https://example.com/writer.tgz",
+		TrustTier:   "SIGNED",
+	}
+	core.Placements = []Placement{
+		{Provider: "codex", Mechanism: MechanismSymlink, Path: "/tmp/codex/writer"},
+		{Provider: "claude", Mechanism: MechanismSymlink, Path: "/tmp/claude/writer"},
+	}
+	other := testRecord(testCoord("other", "commands", "build"), fixedTime(3))
+	other.Placements = []Placement{{Provider: "claude", Mechanism: MechanismSymlink, Path: "/tmp/claude/build"}}
+	unplaced := testRecord(testCoord("core", "rules", "empty"), fixedTime(4))
+	s := &Store{Version: CurrentVersion, Records: []Record{local, core, other, unplaced}}
+
+	cases := []struct {
+		name string
+		got  []Record
+		want []Coord
+	}{
+		{"by provider codex", s.ByProvider("codex"), []Coord{local.Coord, core.Coord}},
+		{"by provider missing", s.ByProvider("missing"), nil},
+		{"by registry core", s.ByRegistry("core"), []Coord{core.Coord, unplaced.Coord}},
+		{"by registry local", s.ByRegistry(""), []Coord{local.Coord}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := coordsOf(tc.got); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("coords = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+
+	results := s.ByRegistry("core")
+	if len(results) != 2 {
+		t.Fatalf("ByRegistry(core) length = %d, want 2", len(results))
+	}
+	results[0].MOAT.TrustTier = "MUTATED"
+	results[0].Placements[0].Path = "/mutated"
+	if s.Records[1].MOAT.TrustTier != "SIGNED" {
+		t.Fatalf("ByRegistry returned aliased MOAT pointer")
+	}
+	if s.Records[1].Placements[0].Path == "/mutated" {
+		t.Fatalf("ByRegistry returned aliased placements slice")
+	}
+}
+
+func TestDefaultPathHonorsGlobalDirOverride(t *testing.T) {
+	prev := config.GlobalDirOverride
+	config.GlobalDirOverride = t.TempDir()
+	t.Cleanup(func() {
+		config.GlobalDirOverride = prev
+	})
+
+	want := filepath.Join(config.GlobalDirOverride, "installs.json")
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath() error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("DefaultPath() = %s, want %s", got, want)
+	}
+}
+
+func coordsOf(records []Record) []Coord {
+	if len(records) == 0 {
+		return nil
+	}
+	coords := make([]Coord, 0, len(records))
+	for _, rec := range records {
+		coords = append(coords, rec.Coord)
+	}
+	return coords
+}

--- a/cli/internal/rulestore/hashlint_test.go
+++ b/cli/internal/rulestore/hashlint_test.go
@@ -33,6 +33,11 @@ func TestNoRawHashFormatting(t *testing.T) {
 		// which never touch .history/ filenames.
 		filepath.Join(root, "internal/moatinstall/fetch.go"): true,
 		filepath.Join(root, "internal/moat/hash.go"):         true,
+		// installstore builds the install-record content hash in the same
+		// canonical MOAT form (moathash.FileHash + "sha256:" prefix) so
+		// record hashes stay comparable to registry content_hash values —
+		// MOAT domain, never .history/ filenames.
+		filepath.Join(root, "internal/installstore/hash.go"): true,
 		// capfeed builds the GitHub attestations API URL path segment
 		// ("sha256:<digest>", GitHub's REST format) — Capability Feed
 		// verification, not library-rule storage.


### PR DESCRIPTION
## Summary

First chunk of issue #542 item 2 (content-addressed installs). Adds `cli/internal/installstore`, the future single source of truth for "what content is installed where":

- **Identity = coordinates**: `Coord{Registry, Type, Name}` (empty registry = local library content), never paths — a moved path re-links instead of dying.
- **Integrity = content hash**: `HashContent` reuses the production-tested MOAT tree-merkle (`moat.ContentHash`) for directories and the same per-file canonicalization (`moathash.FileHash`) for single files, so install-record hashes are directly comparable to MOAT registry `content_hash` values.
- **MOAT provenance** (`manifest_uri`, `source_uri`, trust tier, attested-at) is carried on the record for later re-verification.
- **Placements** model all four install mechanisms (symlink, hook_merge, mcp_merge, rule_append) with provider, path, key, and scope.
- Store file: `~/.syllago/installs.json`, versioned schema (refuses to load a newer version rather than clobber it), atomic temp+rename saves, deterministic ordering for stable diffs.

Pure logic + tests (82% coverage); wiring into install/uninstall/remove is the next chunk. The rulestore hash-format lint allowlist gains an entry for `installstore/hash.go` (MOAT-domain hash construction, same category as the existing `moatinstall/fetch.go` entry).

## Test plan

- `go test ./internal/installstore/...` — 11 test functions covering load/save round-trip, version guard, save determinism (shuffled input → identical bytes), upsert/find/remove, placement dedupe and removal, provider/registry queries, hash parity with `moat.ContentHash`, CRLF/LF canonicalization, symlink rejection.
- Full `make test` suite green.

Part of #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
