### PR TITLE
feat(ccplugin): read-only Claude Code plugin reader (#542 item 8a)

### DIFF
--- a/cli/internal/ccplugin/ccplugin.go
+++ b/cli/internal/ccplugin/ccplugin.go
@@ -1,0 +1,260 @@
+package ccplugin
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Plugin is one installed Claude Code plugin scope-entry, read-only.
+type Plugin struct {
+	Name        string
+	Marketplace string
+	ID          string
+	Enabled     bool
+	Scope       string
+	InstallPath string
+	Version     string
+	InstalledAt time.Time
+	Skills      []Skill
+}
+
+// Skill is a skill directory a plugin provides.
+type Skill struct {
+	Name string
+	Path string
+}
+
+type installedPluginsLedger struct {
+	Plugins map[string][]installedPluginEntry `json:"plugins"`
+}
+
+type installedPluginEntry struct {
+	Scope       string `json:"scope"`
+	InstallPath string `json:"installPath"`
+	Version     string `json:"version"`
+	InstalledAt string `json:"installedAt"`
+}
+
+type settingsFile struct {
+	EnabledPlugins map[string]bool `json:"enabledPlugins"`
+}
+
+// Load reads Claude Code's installed plugin ledger and settings under home.
+func Load(home string) ([]Plugin, error) {
+	claudeDir := filepath.Join(home, ".claude")
+
+	enabled, err := loadEnabledPlugins(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	ledgerPath := filepath.Join(claudeDir, "plugins", "installed_plugins.json")
+	body, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []Plugin{}, nil
+		}
+		return nil, fmt.Errorf("read Claude Code plugin ledger %s: %w", ledgerPath, err)
+	}
+
+	var ledger installedPluginsLedger
+	if err := json.Unmarshal(body, &ledger); err != nil {
+		return nil, fmt.Errorf("parse Claude Code plugin ledger %s: %w", ledgerPath, err)
+	}
+
+	plugins := make([]Plugin, 0)
+	for id, entries := range ledger.Plugins {
+		name, marketplace := splitPluginID(id)
+		for _, entry := range entries {
+			plugins = append(plugins, Plugin{
+				Name:        name,
+				Marketplace: marketplace,
+				ID:          id,
+				Enabled:     enabled[id],
+				Scope:       entry.Scope,
+				InstallPath: entry.InstallPath,
+				Version:     entry.Version,
+				InstalledAt: parseRFC3339(entry.InstalledAt),
+				Skills:      loadSkills(entry.InstallPath),
+			})
+		}
+	}
+
+	sort.Slice(plugins, func(i, j int) bool {
+		if plugins[i].Marketplace != plugins[j].Marketplace {
+			return plugins[i].Marketplace < plugins[j].Marketplace
+		}
+		if plugins[i].Name != plugins[j].Name {
+			return plugins[i].Name < plugins[j].Name
+		}
+		if plugins[i].Scope != plugins[j].Scope {
+			return plugins[i].Scope < plugins[j].Scope
+		}
+		if plugins[i].InstallPath != plugins[j].InstallPath {
+			return plugins[i].InstallPath < plugins[j].InstallPath
+		}
+		return plugins[i].Version < plugins[j].Version
+	})
+
+	return plugins, nil
+}
+
+func loadEnabledPlugins(path string) (map[string]bool, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]bool{}, nil
+		}
+		return nil, fmt.Errorf("read Claude Code settings %s: %w", path, err)
+	}
+
+	var settings settingsFile
+	if err := json.Unmarshal(body, &settings); err != nil {
+		return nil, fmt.Errorf("parse Claude Code settings %s: %w", path, err)
+	}
+	if settings.EnabledPlugins == nil {
+		return map[string]bool{}, nil
+	}
+	return settings.EnabledPlugins, nil
+}
+
+func splitPluginID(id string) (string, string) {
+	idx := strings.LastIndex(id, "@")
+	if idx < 0 {
+		return id, ""
+	}
+	return id[:idx], id[idx+1:]
+}
+
+func parseRFC3339(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
+}
+
+func loadSkills(installPath string) []Skill {
+	if installPath == "" {
+		return nil
+	}
+	info, err := os.Stat(installPath)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+
+	form, ok := loadManifestSkillsForm(installPath)
+	if !ok {
+		return conventionSkills(installPath)
+	}
+
+	switch value := form.(type) {
+	case string:
+		return skillsUnderDirectory(pluginPath(installPath, value))
+	case []string:
+		return skillsFromDirectories(installPath, value)
+	default:
+		return conventionSkills(installPath)
+	}
+}
+
+func loadManifestSkillsForm(installPath string) (any, bool) {
+	manifestPath := filepath.Join(installPath, ".claude-plugin", "plugin.json")
+	body, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, false
+	}
+
+	var manifest map[string]json.RawMessage
+	if err := json.Unmarshal(body, &manifest); err != nil {
+		return nil, false
+	}
+	rawSkills, ok := manifest["skills"]
+	if !ok {
+		return nil, false
+	}
+
+	var directory string
+	if err := json.Unmarshal(rawSkills, &directory); err == nil {
+		return directory, true
+	}
+
+	var directories []string
+	if err := json.Unmarshal(rawSkills, &directories); err == nil {
+		return directories, true
+	}
+
+	return nil, false
+}
+
+func conventionSkills(installPath string) []Skill {
+	return skillsUnderDirectory(filepath.Join(installPath, "skills"))
+}
+
+func skillsUnderDirectory(skillsDir string) []Skill {
+	matches, err := filepath.Glob(filepath.Join(skillsDir, "*", "SKILL.md"))
+	if err != nil {
+		return nil
+	}
+
+	skills := make([]Skill, 0, len(matches))
+	for _, match := range matches {
+		dir := filepath.Dir(match)
+		skills = append(skills, Skill{
+			Name: filepath.Base(dir),
+			Path: dir,
+		})
+	}
+	sortSkills(skills)
+	return skills
+}
+
+func skillsFromDirectories(installPath string, directories []string) []Skill {
+	skills := make([]Skill, 0, len(directories))
+	for _, directory := range directories {
+		dir := pluginPath(installPath, directory)
+		info, err := os.Stat(filepath.Join(dir, "SKILL.md"))
+		if err != nil || info.IsDir() {
+			continue
+		}
+		skills = append(skills, Skill{
+			Name: filepath.Base(dir),
+			Path: dir,
+		})
+	}
+	sortSkills(skills)
+	return skills
+}
+
+// pluginPath resolves a manifest-relative content path. Manifests are
+// third-party data, so a path escaping the plugin's own install directory
+// resolves to "" (callers then find no skills there).
+func pluginPath(installPath, manifestPath string) string {
+	if manifestPath == "" {
+		return installPath
+	}
+	joined := filepath.Clean(filepath.Join(installPath, filepath.FromSlash(manifestPath)))
+	rel, err := filepath.Rel(installPath, joined)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return ""
+	}
+	return joined
+}
+
+func sortSkills(skills []Skill) {
+	sort.Slice(skills, func(i, j int) bool {
+		if skills[i].Name != skills[j].Name {
+			return skills[i].Name < skills[j].Name
+		}
+		return skills[i].Path < skills[j].Path
+	})
+}

--- a/cli/internal/ccplugin/ccplugin_test.go
+++ b/cli/internal/ccplugin/ccplugin_test.go
@@ -1,0 +1,456 @@
+package ccplugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadMissingState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no claude dir", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := Load(t.TempDir())
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("Load() returned %d plugins, want 0: %#v", len(got), got)
+		}
+	})
+
+	t.Run("ledger present settings absent", func(t *testing.T) {
+		t.Parallel()
+
+		home := t.TempDir()
+		installPath := makePluginInstall(t, home, "demo", nil)
+		writeLedger(t, home, map[string][]ledgerFixtureEntry{
+			"demo@local": {{
+				Scope:       "user",
+				InstallPath: installPath,
+				Version:     "1.2.3",
+			}},
+		})
+
+		got, err := Load(home)
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("Load() returned %d plugins, want 1: %#v", len(got), got)
+		}
+		if got[0].Enabled {
+			t.Fatalf("Enabled = true, want false when settings.json is absent")
+		}
+	})
+}
+
+func TestLoadMultipleScopeEntries(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	installPath := makePluginInstall(t, home, "demo", nil)
+	writeLedger(t, home, map[string][]ledgerFixtureEntry{
+		"demo@local": {
+			{Scope: "project", InstallPath: installPath, Version: "a"},
+			{Scope: "user", InstallPath: installPath, Version: "b"},
+		},
+	})
+
+	got, err := Load(home)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Load() returned %d plugins, want 2: %#v", len(got), got)
+	}
+	if got[0].Scope != "project" || got[1].Scope != "user" {
+		t.Fatalf("Scopes = %q, %q; want project, user", got[0].Scope, got[1].Scope)
+	}
+}
+
+func TestLoadEnabledPlugins(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		settings map[string]bool
+		want     map[string]bool
+	}{
+		{
+			name:     "true false and missing",
+			settings: map[string]bool{"on@local": true, "off@local": false},
+			want:     map[string]bool{"on@local": true, "off@local": false, "missing@local": false},
+		},
+		{
+			name:     "missing enabledPlugins key",
+			settings: nil,
+			want:     map[string]bool{"on@local": false, "off@local": false, "missing@local": false},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			home := t.TempDir()
+			plugins := map[string][]ledgerFixtureEntry{}
+			for id := range tc.want {
+				plugins[id] = []ledgerFixtureEntry{{
+					Scope:       "user",
+					InstallPath: makePluginInstall(t, home, strings.TrimSuffix(id, "@local"), nil),
+				}}
+			}
+			writeLedger(t, home, plugins)
+			if tc.settings == nil {
+				writeRawSettings(t, home, `{"other": true}`)
+			} else {
+				writeSettings(t, home, tc.settings)
+			}
+
+			got, err := Load(home)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			gotEnabled := map[string]bool{}
+			for _, plugin := range got {
+				gotEnabled[plugin.ID] = plugin.Enabled
+			}
+			if !reflect.DeepEqual(gotEnabled, tc.want) {
+				t.Fatalf("Enabled map = %#v, want %#v", gotEnabled, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadManifestSkillForms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		manifest        map[string]any
+		corruptManifest bool
+		makeSkills      func(t *testing.T, installPath string) map[string]string
+		wantNames       []string
+	}{
+		{
+			name:     "absent key uses convention",
+			manifest: nil,
+			makeSkills: func(t *testing.T, installPath string) map[string]string {
+				alpha := writeSkill(t, filepath.Join(installPath, "skills", "alpha"))
+				beta := writeSkill(t, filepath.Join(installPath, "skills", "beta"))
+				return map[string]string{"alpha": alpha, "beta": beta}
+			},
+			wantNames: []string{"alpha", "beta"},
+		},
+		{
+			name:     "string directory",
+			manifest: map[string]any{"skills": "./tool-skills/"},
+			makeSkills: func(t *testing.T, installPath string) map[string]string {
+				review := writeSkill(t, filepath.Join(installPath, "tool-skills", "review"))
+				return map[string]string{"review": review}
+			},
+			wantNames: []string{"review"},
+		},
+		{
+			name: "array of nested skill directories",
+			manifest: map[string]any{
+				"skills": []string{
+					"./skills/engineering/tdd",
+					"./skills/writing/release-notes",
+					"./skills/no-skill-md",
+				},
+			},
+			makeSkills: func(t *testing.T, installPath string) map[string]string {
+				tdd := writeSkill(t, filepath.Join(installPath, "skills", "engineering", "tdd"))
+				releaseNotes := writeSkill(t, filepath.Join(installPath, "skills", "writing", "release-notes"))
+				if err := os.MkdirAll(filepath.Join(installPath, "skills", "no-skill-md"), 0o755); err != nil {
+					t.Fatalf("mkdir no-skill-md: %v", err)
+				}
+				return map[string]string{"tdd": tdd, "release-notes": releaseNotes}
+			},
+			wantNames: []string{"release-notes", "tdd"},
+		},
+		{
+			name:     "string directory escaping install path is refused",
+			manifest: map[string]any{"skills": "../escape-string/"},
+			makeSkills: func(t *testing.T, installPath string) map[string]string {
+				writeSkill(t, filepath.Join(installPath, "..", "escape-string", "stolen"))
+				return map[string]string{}
+			},
+			wantNames: []string{},
+		},
+		{
+			name:     "array entry escaping install path is refused",
+			manifest: map[string]any{"skills": []string{"../escape-array/stolen"}},
+			makeSkills: func(t *testing.T, installPath string) map[string]string {
+				writeSkill(t, filepath.Join(installPath, "..", "escape-array", "stolen"))
+				return map[string]string{}
+			},
+			wantNames: []string{},
+		},
+		{
+			name:            "unparsable manifest falls back to convention",
+			corruptManifest: true,
+			makeSkills: func(t *testing.T, installPath string) map[string]string {
+				fallback := writeSkill(t, filepath.Join(installPath, "skills", "fallback"))
+				return map[string]string{"fallback": fallback}
+			},
+			wantNames: []string{"fallback"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			home := t.TempDir()
+			installPath := makePluginInstall(t, home, tc.name, tc.manifest)
+			if tc.corruptManifest {
+				writeRawFile(t, filepath.Join(installPath, ".claude-plugin", "plugin.json"), `{"skills":`)
+			}
+			wantPaths := tc.makeSkills(t, installPath)
+			writeLedger(t, home, map[string][]ledgerFixtureEntry{
+				"demo@local": {{Scope: "user", InstallPath: installPath}},
+			})
+
+			got, err := Load(home)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("Load() returned %d plugins, want 1: %#v", len(got), got)
+			}
+
+			gotNames := make([]string, 0, len(got[0].Skills))
+			for _, skill := range got[0].Skills {
+				gotNames = append(gotNames, skill.Name)
+				if wantPath := wantPaths[skill.Name]; skill.Path != wantPath {
+					t.Fatalf("Skill %q path = %q, want %q", skill.Name, skill.Path, wantPath)
+				}
+			}
+			if !reflect.DeepEqual(gotNames, tc.wantNames) {
+				t.Fatalf("Skill names = %#v, want %#v", gotNames, tc.wantNames)
+			}
+		})
+	}
+}
+
+func TestLoadMissingInstallPath(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	missingPath := filepath.Join(home, "cache", "missing")
+	writeLedger(t, home, map[string][]ledgerFixtureEntry{
+		"missing@local": {{Scope: "user", InstallPath: missingPath}},
+	})
+
+	got, err := Load(home)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Load() returned %d plugins, want 1: %#v", len(got), got)
+	}
+	if len(got[0].Skills) != 0 {
+		t.Fatalf("Skills = %#v, want none", got[0].Skills)
+	}
+}
+
+func TestLoadVersionAndTimestamps(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	installPath := makePluginInstall(t, home, "demo", nil)
+	writeLedger(t, home, map[string][]ledgerFixtureEntry{
+		"absent@local":  {{Scope: "user", InstallPath: installPath}},
+		"unknown@local": {{Scope: "user", InstallPath: installPath, Version: "unknown", InstalledAt: "not-a-time"}},
+		"sha@local":     {{Scope: "user", InstallPath: installPath, Version: "a1b2c3d4", InstalledAt: "2026-08-22T12:34:56Z"}},
+	})
+
+	got, err := Load(home)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	versions := map[string]string{}
+	installed := map[string]time.Time{}
+	for _, plugin := range got {
+		versions[plugin.ID] = plugin.Version
+		installed[plugin.ID] = plugin.InstalledAt
+	}
+	wantVersions := map[string]string{
+		"absent@local":  "",
+		"unknown@local": "unknown",
+		"sha@local":     "a1b2c3d4",
+	}
+	if !reflect.DeepEqual(versions, wantVersions) {
+		t.Fatalf("Versions = %#v, want %#v", versions, wantVersions)
+	}
+	if !installed["unknown@local"].IsZero() {
+		t.Fatalf("unparsable InstalledAt = %v, want zero", installed["unknown@local"])
+	}
+	wantTime := time.Date(2026, 8, 22, 12, 34, 56, 0, time.UTC)
+	if !installed["sha@local"].Equal(wantTime) {
+		t.Fatalf("InstalledAt = %v, want %v", installed["sha@local"], wantTime)
+	}
+}
+
+func TestLoadCorruptJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ledger", func(t *testing.T) {
+		t.Parallel()
+
+		home := t.TempDir()
+		writeRawLedger(t, home, `{"plugins":`)
+		_, err := Load(home)
+		if err == nil {
+			t.Fatalf("Load() error = nil, want error")
+		}
+	})
+
+	t.Run("settings", func(t *testing.T) {
+		t.Parallel()
+
+		home := t.TempDir()
+		installPath := makePluginInstall(t, home, "demo", nil)
+		writeLedger(t, home, map[string][]ledgerFixtureEntry{
+			"demo@local": {{Scope: "user", InstallPath: installPath}},
+		})
+		writeRawSettings(t, home, `{"enabledPlugins":`)
+
+		_, err := Load(home)
+		if err == nil {
+			t.Fatalf("Load() error = nil, want error")
+		}
+	})
+}
+
+func TestLoadDeterministicSort(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	installPath := makePluginInstall(t, home, "demo", nil)
+	writeLedger(t, home, map[string][]ledgerFixtureEntry{
+		"zeta@market-b":  {{Scope: "user", InstallPath: installPath}},
+		"alpha@market-a": {{Scope: "workspace", InstallPath: installPath}, {Scope: "user", InstallPath: installPath}},
+		"beta@market-a":  {{Scope: "user", InstallPath: installPath}},
+	})
+
+	got, err := Load(home)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	gotOrder := make([]string, 0, len(got))
+	for _, plugin := range got {
+		gotOrder = append(gotOrder, plugin.ID+"/"+plugin.Scope)
+	}
+	wantOrder := []string{
+		"alpha@market-a/user",
+		"alpha@market-a/workspace",
+		"beta@market-a/user",
+		"zeta@market-b/user",
+	}
+	if !reflect.DeepEqual(gotOrder, wantOrder) {
+		t.Fatalf("Order = %#v, want %#v", gotOrder, wantOrder)
+	}
+}
+
+type ledgerFixtureEntry struct {
+	Scope       string `json:"scope,omitempty"`
+	InstallPath string `json:"installPath,omitempty"`
+	Version     string `json:"version,omitempty"`
+	InstalledAt string `json:"installedAt,omitempty"`
+}
+
+func makePluginInstall(t *testing.T, home, name string, manifest map[string]any) string {
+	t.Helper()
+
+	installPath := filepath.Join(home, "plugin-cache", name)
+	if err := os.MkdirAll(filepath.Join(installPath, ".claude-plugin"), 0o755); err != nil {
+		t.Fatalf("mkdir plugin install: %v", err)
+	}
+	if manifest == nil {
+		manifest = map[string]any{"name": name}
+	} else if _, ok := manifest["name"]; !ok {
+		manifest["name"] = name
+	}
+	if err := writeJSON(filepath.Join(installPath, ".claude-plugin", "plugin.json"), manifest); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return installPath
+}
+
+func writeSkill(t *testing.T, dir string) string {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("Use this skill.\n"), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	return dir
+}
+
+func writeLedger(t *testing.T, home string, plugins map[string][]ledgerFixtureEntry) {
+	t.Helper()
+
+	body := map[string]any{
+		"version": 2,
+		"plugins": plugins,
+	}
+	if err := writeJSON(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"), body); err != nil {
+		t.Fatalf("write ledger: %v", err)
+	}
+}
+
+func writeRawLedger(t *testing.T, home, body string) {
+	t.Helper()
+	writeRawFile(t, filepath.Join(home, ".claude", "plugins", "installed_plugins.json"), body)
+}
+
+func writeSettings(t *testing.T, home string, enabled map[string]bool) {
+	t.Helper()
+
+	body := map[string]any{"enabledPlugins": enabled}
+	if err := writeJSON(filepath.Join(home, ".claude", "settings.json"), body); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+}
+
+func writeRawSettings(t *testing.T, home, body string) {
+	t.Helper()
+	writeRawFile(t, filepath.Join(home, ".claude", "settings.json"), body)
+}
+
+func writeRawFile(t *testing.T, path, body string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func writeJSON(path string, value any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	body, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, body, 0o644)
+}

--- a/cli/internal/ccplugin/collision.go
+++ b/cli/internal/ccplugin/collision.go
@@ -1,0 +1,61 @@
+package ccplugin
+
+import (
+	"sort"
+	"strings"
+)
+
+// Collision reports a plugin skill whose name matches a syllago library
+// skill. Comparison is case-insensitive (the catalog's precedence dedupe
+// lowercases names -- match that convention).
+type Collision struct {
+	SkillName string
+	PluginID  string
+	SkillPath string
+}
+
+// SkillCollisions reports enabled plugin skills whose names match library skills.
+func SkillCollisions(plugins []Plugin, librarySkillNames []string) []Collision {
+	libraryNames := make(map[string]struct{}, len(librarySkillNames))
+	for _, name := range librarySkillNames {
+		libraryNames[strings.ToLower(name)] = struct{}{}
+	}
+
+	var collisions []Collision
+	seen := make(map[string]struct{})
+	for _, plugin := range plugins {
+		if !plugin.Enabled {
+			continue
+		}
+		for _, skill := range plugin.Skills {
+			skillName := strings.ToLower(skill.Name)
+			if _, ok := libraryNames[skillName]; !ok {
+				continue
+			}
+
+			key := skillName + "\x00" + plugin.ID + "\x00" + skill.Path
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+
+			collisions = append(collisions, Collision{
+				SkillName: skillName,
+				PluginID:  plugin.ID,
+				SkillPath: skill.Path,
+			})
+		}
+	}
+
+	sort.Slice(collisions, func(i, j int) bool {
+		if collisions[i].SkillName != collisions[j].SkillName {
+			return collisions[i].SkillName < collisions[j].SkillName
+		}
+		if collisions[i].PluginID != collisions[j].PluginID {
+			return collisions[i].PluginID < collisions[j].PluginID
+		}
+		return collisions[i].SkillPath < collisions[j].SkillPath
+	})
+
+	return collisions
+}

--- a/cli/internal/ccplugin/collision_test.go
+++ b/cli/internal/ccplugin/collision_test.go
@@ -1,0 +1,87 @@
+package ccplugin
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSkillCollisions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		plugins           []Plugin
+		librarySkillNames []string
+		want              []Collision
+	}{
+		{
+			name: "case-insensitive match enabled only sorted and deduped",
+			plugins: []Plugin{
+				{
+					ID:      "second@market",
+					Enabled: true,
+					Skills: []Skill{
+						{Name: "Deploy", Path: "/plugins/second/Deploy"},
+						{Name: "Build", Path: "/plugins/second/Build"},
+					},
+				},
+				{
+					ID:      "disabled@market",
+					Enabled: false,
+					Skills: []Skill{
+						{Name: "Deploy", Path: "/plugins/disabled/Deploy"},
+					},
+				},
+				{
+					ID:      "first@market",
+					Enabled: true,
+					Skills: []Skill{
+						{Name: "deploy", Path: "/plugins/first/deploy"},
+					},
+				},
+			},
+			librarySkillNames: []string{"DEPLOY", "deploy", "other", "BUILD"},
+			want: []Collision{
+				{SkillName: "build", PluginID: "second@market", SkillPath: "/plugins/second/Build"},
+				{SkillName: "deploy", PluginID: "first@market", SkillPath: "/plugins/first/deploy"},
+				{SkillName: "deploy", PluginID: "second@market", SkillPath: "/plugins/second/Deploy"},
+			},
+		},
+		{
+			name: "no match",
+			plugins: []Plugin{
+				{
+					ID:      "demo@market",
+					Enabled: true,
+					Skills:  []Skill{{Name: "lint", Path: "/plugins/demo/lint"}},
+				},
+			},
+			librarySkillNames: []string{"test"},
+			want:              nil,
+		},
+		{
+			name: "disabled plugin excluded",
+			plugins: []Plugin{
+				{
+					ID:      "demo@market",
+					Enabled: false,
+					Skills:  []Skill{{Name: "test", Path: "/plugins/demo/test"}},
+				},
+			},
+			librarySkillNames: []string{"test"},
+			want:              nil,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := SkillCollisions(tc.plugins, tc.librarySkillNames)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("SkillCollisions() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

First chunk of issue #542 item 8 (plugin awareness — decided as read-only). Adds `cli/internal/ccplugin`, a reader for Claude Code's own plugin state, verified against a live installation:

- **Ledger**: `~/.claude/plugins/installed_plugins.json` (v2) — keyed `name@marketplace`, value is an array of scope entries; one `Plugin` row per entry. `version` is treated as an opaque string (semver, git sha, `unknown`, or absent all occur in the wild).
- **Enablement**: `enabledPlugins` in `~/.claude/settings.json` — disabled plugins remain listed with `false`, and a plugin missing from the map counts as not enabled.
- **Skill discovery**: handles all three observed `skills` manifest forms — absent key (`skills/*/SKILL.md` convention), string directory, and array of nested skill directories (the form a naive glob would miss entirely). Manifest paths escaping the plugin's install directory resolve to nothing — manifests are third-party data.
- **`SkillCollisions`**: flags enabled plugin skills colliding with library skill names, case-insensitive per the catalog's precedence convention.

Read-only by design: no install/convert/uninstall of plugins. Wiring into `syllago list` (a `plugin` source arm plus collision warnings — kept out of `catalog.Items` so `applyPrecedence` can't silently swallow same-named skills) is the next chunk.

## Test plan

- `go test ./internal/ccplugin/...` — 88.7% coverage: missing-state normality, multi-scope entries, enablement matrix, all three manifest skill forms plus corrupt-manifest fallback and path-escape refusal, opaque versions, corrupt-JSON errors, deterministic ordering, collision case-insensitivity/dedup/disabled-exclusion.
- Full `make test` suite green in this branch's worktree.

Part of #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
