### PR TITLE
feat(list): Claude Code plugin awareness (#542 item 8b)

### DIFF
--- a/cli/cmd/syllago/helpers.go
+++ b/cli/cmd/syllago/helpers.go
@@ -179,7 +179,7 @@ func filterByState(item catalog.ContentItem, states []string) bool {
 }
 
 // filterBySource returns true if the item matches the given source filter.
-// Valid source values: "library", "shared", "registry", "builtin", "all".
+// Valid source values: "library", "shared", "registry", "builtin", "plugin", "all".
 func filterBySource(item catalog.ContentItem, source string) bool {
 	switch source {
 	case "library":
@@ -190,6 +190,8 @@ func filterBySource(item catalog.ContentItem, source string) bool {
 		return item.Registry != ""
 	case "builtin":
 		return item.IsBuiltin()
+	case "plugin":
+		return false
 	case "all":
 		return true
 	default:

--- a/cli/cmd/syllago/list.go
+++ b/cli/cmd/syllago/list.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"sort"
 	"strings"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/ccplugin"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
 	"github.com/spf13/cobra"
@@ -30,8 +33,17 @@ By default, lists all content grouped by type. Use flags to filter.`,
 	RunE: runList,
 }
 
+// loadCCPlugins is a seam so tests can point plugin discovery at a fixture home.
+var loadCCPlugins = func() ([]ccplugin.Plugin, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	return ccplugin.Load(home)
+}
+
 func init() {
-	listCmd.Flags().String("source", "all", "Filter by source: library, shared, registry, builtin, all")
+	listCmd.Flags().String("source", "all", "Filter by source: library, shared, registry, builtin, plugin, all")
 	listCmd.Flags().String("type", "", "Filter to one content type (e.g., skills, rules)")
 	listCmd.Flags().StringSlice("filter", nil, "Filter by item state (repeatable): in-library, not-in-library, project")
 	rootCmd.AddCommand(listCmd)
@@ -39,7 +51,8 @@ func init() {
 
 // listResult is the JSON-serializable output for syllago list.
 type listResult struct {
-	Groups []listGroup `json:"groups"`
+	Groups  []listGroup       `json:"groups"`
+	Plugins []pluginListEntry `json:"plugins,omitempty"`
 }
 
 type listGroup struct {
@@ -55,6 +68,14 @@ type listItem struct {
 	Trust       string `json:"trust,omitempty"`      // "Verified" / "Revoked" / ""
 	TrustTier   string `json:"trust_tier,omitempty"` // full tier for drill-down ("Dual-Attested" etc.)
 	Revoked     bool   `json:"revoked,omitempty"`
+}
+
+type pluginListEntry struct {
+	Name        string   `json:"name"`
+	Marketplace string   `json:"marketplace"`
+	Version     string   `json:"version,omitempty"`
+	Scope       string   `json:"scope,omitempty"`
+	Skills      []string `json:"skills,omitempty"`
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -80,6 +101,23 @@ func runList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	cat := scan.Catalog
+
+	plugins, err := loadCCPlugins()
+	if err != nil {
+		fmt.Fprintf(output.ErrWriter, "warning: could not read Claude Code plugins: %v\n", err)
+		plugins = nil
+	}
+	enabledPlugins := enabledCCPlugins(plugins)
+
+	var librarySkillNames []string
+	for _, item := range cat.ByType(catalog.Skills) {
+		if item.Library {
+			librarySkillNames = append(librarySkillNames, item.Name)
+		}
+	}
+	for _, c := range ccplugin.SkillCollisions(plugins, librarySkillNames) {
+		cat.Warnings = append(cat.Warnings, fmt.Sprintf("plugin skill %q from Claude Code plugin %s shadows a library skill of the same name", c.SkillName, c.PluginID))
+	}
 	cat.PrintWarnings()
 
 	// Build grouped output across all content types.
@@ -118,6 +156,11 @@ func runList(cmd *cobra.Command, args []string) error {
 		})
 	}
 
+	showPlugins := typeFilter == "" && (sourceFilter == "all" || sourceFilter == "plugin")
+	if showPlugins {
+		result.Plugins = pluginListEntries(enabledPlugins)
+	}
+
 	totalItems := 0
 	for _, g := range result.Groups {
 		totalItems += g.Count
@@ -125,6 +168,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	telemetry.Enrich("source_filter", sourceFilter)
 	telemetry.Enrich("content_type", typeFilter)
 	telemetry.Enrich("item_count", totalItems)
+	telemetry.Enrich("plugin_count", len(enabledPlugins))
 	if len(filterStates) > 0 {
 		telemetry.Enrich("filter", strings.Join(filterStates, ","))
 	}
@@ -134,7 +178,12 @@ func runList(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if len(result.Groups) == 0 {
+	printedPlugins := showPlugins && len(enabledPlugins) > 0
+	if len(result.Groups) == 0 && !printedPlugins {
+		if showPlugins && sourceFilter == "plugin" {
+			fmt.Fprintln(output.ErrWriter, "No plugins found.")
+			return nil
+		}
 		fmt.Fprintln(output.ErrWriter, "No items found.")
 		return nil
 	}
@@ -153,7 +202,88 @@ func runList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if printedPlugins {
+		if len(result.Groups) > 0 {
+			fmt.Fprintln(output.Writer)
+		}
+		fmt.Fprintf(output.Writer, "Claude Code plugins (%d)\n", len(enabledPlugins))
+		for _, plugin := range enabledPlugins {
+			line := fmt.Sprintf("  %-28s %s", pluginDisplayID(plugin), pluginDisplayDetail(plugin))
+			fmt.Fprintln(output.Writer, strings.TrimRight(line, " "))
+		}
+	}
+
 	return nil
+}
+
+func enabledCCPlugins(plugins []ccplugin.Plugin) []ccplugin.Plugin {
+	enabled := make([]ccplugin.Plugin, 0, len(plugins))
+	for _, plugin := range plugins {
+		if plugin.Enabled {
+			enabled = append(enabled, plugin)
+		}
+	}
+	sort.Slice(enabled, func(i, j int) bool {
+		if enabled[i].ID != enabled[j].ID {
+			return enabled[i].ID < enabled[j].ID
+		}
+		if enabled[i].Scope != enabled[j].Scope {
+			return enabled[i].Scope < enabled[j].Scope
+		}
+		return enabled[i].InstallPath < enabled[j].InstallPath
+	})
+	return enabled
+}
+
+func pluginListEntries(plugins []ccplugin.Plugin) []pluginListEntry {
+	if len(plugins) == 0 {
+		return nil
+	}
+	entries := make([]pluginListEntry, 0, len(plugins))
+	for _, plugin := range plugins {
+		entries = append(entries, pluginListEntry{
+			Name:        plugin.Name,
+			Marketplace: plugin.Marketplace,
+			Version:     plugin.Version,
+			Scope:       plugin.Scope,
+			Skills:      pluginSkillNames(plugin),
+		})
+	}
+	return entries
+}
+
+func pluginSkillNames(plugin ccplugin.Plugin) []string {
+	if len(plugin.Skills) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(plugin.Skills))
+	for _, skill := range plugin.Skills {
+		names = append(names, skill.Name)
+	}
+	return names
+}
+
+func pluginDisplayID(plugin ccplugin.Plugin) string {
+	if plugin.ID != "" {
+		return plugin.ID
+	}
+	if plugin.Marketplace == "" {
+		return plugin.Name
+	}
+	return plugin.Name + "@" + plugin.Marketplace
+}
+
+func pluginDisplayDetail(plugin ccplugin.Plugin) string {
+	var parts []string
+	// The ledger's version field is opaque and sometimes literally "unknown" —
+	// rendering "vunknown" helps no one.
+	if plugin.Version != "" && plugin.Version != "unknown" {
+		parts = append(parts, "v"+plugin.Version)
+	}
+	if skills := pluginSkillNames(plugin); len(skills) > 0 {
+		parts = append(parts, "skills: "+strings.Join(skills, ", "))
+	}
+	return strings.Join(parts, "  ")
 }
 
 // trustGlyph maps the user-facing trust label to a single-character glyph for

--- a/cli/cmd/syllago/list_plugin_test.go
+++ b/cli/cmd/syllago/list_plugin_test.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/ccplugin"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/tidwall/gjson"
+)
+
+func setupListPluginRepo(t *testing.T, librarySkillName string) (string, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "skills"), 0755); err != nil {
+		t.Fatalf("mkdir repo marker: %v", err)
+	}
+
+	globalDir := t.TempDir()
+	skillDir := filepath.Join(globalDir, "skills", librarySkillName)
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill fixture: %v", err)
+	}
+	skillFrontmatter := "---\nname: " + librarySkillName + "\ndescription: Format code\n---\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillFrontmatter), 0644); err != nil {
+		t.Fatalf("write skill fixture: %v", err)
+	}
+	return root, globalDir
+}
+
+func setupListPluginTest(t *testing.T, plugins []ccplugin.Plugin) (*bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	return setupListPluginTestWithLibrarySkill(t, plugins, "library-format")
+}
+
+func setupListPluginTestWithLibrarySkill(t *testing.T, plugins []ccplugin.Plugin, librarySkillName string) (*bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+
+	root, globalDir := setupListPluginRepo(t, librarySkillName)
+	withFakeRepoRoot(t, root)
+	withGlobalLibrary(t, globalDir)
+	isolateListEnv(t)
+
+	stdout, stderr := output.SetForTest(t)
+	output.JSON = false
+
+	origLoad := loadCCPlugins
+	loadCCPlugins = func() ([]ccplugin.Plugin, error) {
+		return plugins, nil
+	}
+	t.Cleanup(func() { loadCCPlugins = origLoad })
+
+	listCmd.Flags().Set("source", "all")
+	listCmd.Flags().Set("type", "")
+	listCmd.Flags().Set("filter", "")
+	t.Cleanup(func() {
+		listCmd.Flags().Set("source", "all")
+		listCmd.Flags().Set("type", "")
+		listCmd.Flags().Set("filter", "")
+		output.JSON = false
+	})
+
+	return stdout, stderr
+}
+
+func captureProcessStderr(t *testing.T) func() string {
+	t.Helper()
+
+	oldStderr := os.Stderr
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = writePipe
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&buf, readPipe)
+		close(done)
+	}()
+
+	var once sync.Once
+	restore := func() string {
+		once.Do(func() {
+			os.Stderr = oldStderr
+			_ = writePipe.Close()
+			<-done
+			_ = readPipe.Close()
+		})
+		return buf.String()
+	}
+	t.Cleanup(func() { _ = restore() })
+	return restore
+}
+
+func testListPlugins() []ccplugin.Plugin {
+	return []ccplugin.Plugin{
+		{
+			Name:        "fmt-tools",
+			Marketplace: "acme-marketplace",
+			ID:          "fmt-tools@acme-marketplace",
+			Enabled:     true,
+			Version:     "1.2.0",
+			Skills: []ccplugin.Skill{
+				{Name: "format", Path: "/plugins/fmt-tools/skills/format"},
+				{Name: "lint", Path: "/plugins/fmt-tools/skills/lint"},
+			},
+		},
+		{
+			Name:        "notes",
+			Marketplace: "acme-marketplace",
+			ID:          "notes@acme-marketplace",
+			Enabled:     true,
+			Skills: []ccplugin.Skill{
+				{Name: "notes", Path: "/plugins/notes/skills/notes"},
+			},
+		},
+	}
+}
+
+func TestListPluginsSourceAllTextAndJSON(t *testing.T) {
+	stdout, _ := setupListPluginTest(t, testListPlugins())
+
+	if err := listCmd.RunE(listCmd, []string{}); err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Skills (1)") {
+		t.Fatalf("expected catalog group in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Claude Code plugins (2)") {
+		t.Fatalf("expected plugin section in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "fmt-tools@acme-marketplace") || !strings.Contains(out, "v1.2.0  skills: format, lint") {
+		t.Fatalf("expected fmt-tools plugin details in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "notes@acme-marketplace") || !strings.Contains(out, "skills: notes") {
+		t.Fatalf("expected notes plugin details in output, got:\n%s", out)
+	}
+
+	stdout, _ = setupListPluginTest(t, testListPlugins())
+	output.JSON = true
+
+	if err := listCmd.RunE(listCmd, []string{}); err != nil {
+		t.Fatalf("list --json failed: %v", err)
+	}
+
+	raw := stdout.Bytes()
+	if got := gjson.GetBytes(raw, "plugins.#").Int(); got != 2 {
+		t.Fatalf("plugins length = %d, want 2; raw: %s", got, stdout.String())
+	}
+	if got := gjson.GetBytes(raw, "plugins.0.name").String(); got != "fmt-tools" {
+		t.Errorf("plugins.0.name = %q, want fmt-tools", got)
+	}
+	if got := gjson.GetBytes(raw, "plugins.0.marketplace").String(); got != "acme-marketplace" {
+		t.Errorf("plugins.0.marketplace = %q, want acme-marketplace", got)
+	}
+	if got := gjson.GetBytes(raw, "plugins.0.version").String(); got != "1.2.0" {
+		t.Errorf("plugins.0.version = %q, want 1.2.0", got)
+	}
+	if got := gjson.GetBytes(raw, "plugins.0.skills.0").String(); got != "format" {
+		t.Errorf("plugins.0.skills.0 = %q, want format", got)
+	}
+	if got := gjson.GetBytes(raw, "plugins.0.skills.1").String(); got != "lint" {
+		t.Errorf("plugins.0.skills.1 = %q, want lint", got)
+	}
+}
+
+func TestListPluginsSourcePluginOnly(t *testing.T) {
+	stdout, _ := setupListPluginTest(t, testListPlugins())
+	listCmd.Flags().Set("source", "plugin")
+
+	if err := listCmd.RunE(listCmd, []string{}); err != nil {
+		t.Fatalf("list --source plugin failed: %v", err)
+	}
+
+	out := stdout.String()
+	if strings.Contains(out, "Skills (") {
+		t.Fatalf("catalog groups should be absent for --source plugin, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Claude Code plugins (2)") {
+		t.Fatalf("expected plugin section, got:\n%s", out)
+	}
+}
+
+func TestListPluginsSourceLibraryHidesPluginSection(t *testing.T) {
+	stdout, _ := setupListPluginTest(t, testListPlugins())
+	listCmd.Flags().Set("source", "library")
+
+	if err := listCmd.RunE(listCmd, []string{}); err != nil {
+		t.Fatalf("list --source library failed: %v", err)
+	}
+
+	if strings.Contains(stdout.String(), "Claude Code plugins") {
+		t.Fatalf("plugin section should be absent for --source library, got:\n%s", stdout.String())
+	}
+}
+
+func TestListPluginsTypeFilterHidesPluginSection(t *testing.T) {
+	stdout, _ := setupListPluginTest(t, testListPlugins())
+	listCmd.Flags().Set("type", "skills")
+
+	if err := listCmd.RunE(listCmd, []string{}); err != nil {
+		t.Fatalf("list --type skills failed: %v", err)
+	}
+
+	if strings.Contains(stdout.String(), "Claude Code plugins") {
+		t.Fatalf("plugin section should be absent for --type skills, got:\n%s", stdout.String())
+	}
+}
+
+func TestListPluginsDisabledNeverShown(t *testing.T) {
+	stdout, _ := setupListPluginTest(t, []ccplugin.Plugin{
+		{
+			Name:        "disabled",
+			Marketplace: "acme-marketplace",
+			ID:          "disabled@acme-marketplace",
+			Enabled:     false,
+			Skills:      []ccplugin.Skill{{Name: "disabled", Path: "/plugins/disabled/skills/disabled"}},
+		},
+	})
+
+	if err := listCmd.RunE(listCmd, []string{}); err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+
+	if strings.Contains(stdout.String(), "disabled@acme-marketplace") {
+		t.Fatalf("disabled plugin should not be shown, got:\n%s", stdout.String())
+	}
+}
+
+func TestListPluginsCollisionWarnsWithoutSwallowingLibrarySkill(t *testing.T) {
+	stdout, _ := setupListPluginTestWithLibrarySkill(t, []ccplugin.Plugin{
+		{
+			Name:        "fmt-tools",
+			Marketplace: "acme-marketplace",
+			ID:          "fmt-tools@acme-marketplace",
+			Enabled:     true,
+			Skills:      []ccplugin.Skill{{Name: "Format", Path: "/plugins/fmt-tools/skills/format"}},
+		},
+	}, "format")
+	restoreStderr := captureProcessStderr(t)
+
+	if err := listCmd.RunE(listCmd, []string{}); err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+
+	errOut := restoreStderr()
+	if !strings.Contains(errOut, "shadows a library skill") {
+		t.Fatalf("expected collision warning, got stderr:\n%s", errOut)
+	}
+	if !strings.Contains(stdout.String(), "format") {
+		t.Fatalf("library skill row should still appear, got:\n%s", stdout.String())
+	}
+}
+
+func TestListPluginsLoadErrorWarnsAndContinues(t *testing.T) {
+	stdout, stderr := setupListPluginTest(t, nil)
+
+	origLoad := loadCCPlugins
+	loadCCPlugins = func() ([]ccplugin.Plugin, error) {
+		return nil, errors.New("fixture boom")
+	}
+	t.Cleanup(func() { loadCCPlugins = origLoad })
+
+	if err := listCmd.RunE(listCmd, []string{}); err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+
+	if !strings.Contains(stderr.String(), "could not read Claude Code plugins") {
+		t.Fatalf("expected plugin read warning, got stderr:\n%s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Skills (1)") {
+		t.Fatalf("normal groups should still print, got:\n%s", stdout.String())
+	}
+}
+
+func TestListPluginsSourcePluginNoPlugins(t *testing.T) {
+	stdout, stderr := setupListPluginTest(t, nil)
+	listCmd.Flags().Set("source", "plugin")
+
+	if err := listCmd.RunE(listCmd, []string{}); err != nil {
+		t.Fatalf("list --source plugin failed: %v", err)
+	}
+
+	if stdout.String() != "" {
+		t.Fatalf("expected empty stdout, got:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "No plugins found.") {
+		t.Fatalf("expected No plugins found, got stderr:\n%s", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "No items found.") {
+		t.Fatalf("should not also print No items found, got stderr:\n%s", stderr.String())
+	}
+}

--- a/cli/cmd/syllago/list_test.go
+++ b/cli/cmd/syllago/list_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/ccplugin"
 	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/registry"
@@ -26,6 +27,9 @@ func isolateListEnv(t *testing.T) {
 	origCache := registry.CacheDirOverride
 	registry.CacheDirOverride = t.TempDir()
 	t.Cleanup(func() { registry.CacheDirOverride = origCache })
+	origLoadPlugins := loadCCPlugins
+	loadCCPlugins = func() ([]ccplugin.Plugin, error) { return nil, nil }
+	t.Cleanup(func() { loadCCPlugins = origLoadPlugins })
 }
 
 // setupListRepo creates a temp syllago repo with items across types and sources.

--- a/cli/commands.json
+++ b/cli/commands.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generatedAt": "2026-08-21T21:26:09Z",
+  "generatedAt": "2026-08-23T00:25:37Z",
   "syllagoVersion": "0.14.0",
   "commands": [
     {
@@ -1708,7 +1708,7 @@
           "type": "string",
           "default": "all",
           "required": false,
-          "description": "Filter by source: library, shared, registry, builtin, all"
+          "description": "Filter by source: library, shared, registry, builtin, plugin, all"
         },
         {
           "name": "--type",

--- a/cli/internal/telemetry/catalog.go
+++ b/cli/internal/telemetry/catalog.go
@@ -117,6 +117,13 @@ func EventCatalog() []EventDef {
 					Commands:    []string{"list", "registry_items"},
 				},
 				{
+					Name:        "plugin_count",
+					Type:        "int",
+					Description: "Number of enabled Claude Code plugins shown in list output",
+					Example:     2,
+					Commands:    []string{"list"},
+				},
+				{
 					Name:        "mode",
 					Type:        "string",
 					Description: "Operational mode (loadout 'try', add 'monolithic')",

--- a/cli/telemetry.json
+++ b/cli/telemetry.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generatedAt": "2026-08-21T21:26:09Z",
+  "generatedAt": "2026-08-23T00:25:38Z",
   "syllagoVersion": "0.14.0",
   "events": [
     {
@@ -133,6 +133,15 @@
           "commands": [
             "list",
             "registry_items"
+          ]
+        },
+        {
+          "name": "plugin_count",
+          "type": "int",
+          "description": "Number of enabled Claude Code plugins shown in list output",
+          "example": 2,
+          "commands": [
+            "list"
           ]
         },
         {


### PR DESCRIPTION
## Summary

Item 8b of #542: wires the merged `ccplugin` reader (#548) into `syllago list` — read-only plugin awareness per the item 8 decision.

- `--source` gains a `plugin` value; enabled plugins render in a separate "Claude Code plugins (N)" section (text) and a `plugins` array (JSON).
- Plugin rows never enter `catalog.Items`, so the precedence dedupe cannot displace same-named library skills.
- Skill-name collisions (plugin skill shadowing a library skill) warn on stderr through the existing `Catalog.Warnings` / `PrintWarnings` path.
- A failure to read plugin state degrades to a warning — `list` still works.
- Telemetry: new `plugin_count` property on the list event; `commands.json` and `telemetry.json` regenerated.

## Testing

- New `cli/cmd/syllago/list_plugin_test.go`: 8 cases covering source/type filtering, disabled plugins, collision warning without swallowing the library skill, load-error degradation, and empty-plugin output.
- Existing list tests isolated from the real home via the new `loadCCPlugins` seam.
- Full suite green locally (`make test`, 39 packages ok).

Part of #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
