### PR TITLE
refactor(installer): structured Placement result (#542 item 2b-i)

### DIFF
--- a/cli/cmd/syllago/init.go
+++ b/cli/cmd/syllago/init.go
@@ -262,13 +262,14 @@ func installBuiltins(cmd *cobra.Command, repoRoot string, detected []provider.Pr
 				continue
 			}
 
-			desc, err := installer.Install(item, prov, repoRoot, installer.MethodSymlink, "")
+			placement, err := installer.Install(item, prov, repoRoot, installer.MethodSymlink, "")
 			if err != nil {
 				if !output.JSON {
 					fmt.Fprintf(os.Stderr, "  warning: could not install %s to %s: %s\n", item.Name, prov.Name, err)
 				}
 				continue
 			}
+			desc := placement.String()
 
 			installed = append(installed, initInstalledItem{
 				Name:     item.Name,

--- a/cli/cmd/syllago/install_cmd.go
+++ b/cli/cmd/syllago/install_cmd.go
@@ -374,7 +374,7 @@ func installToProvider(
 			continue
 		}
 
-		desc, err := installer.InstallWithResolver(item, prov, globalDir, method, resolver)
+		placement, err := installer.InstallWithResolver(item, prov, globalDir, method, resolver)
 		if err != nil {
 			result.Skipped = append(result.Skipped, skippedItem{Name: item.Name, Reason: err.Error()})
 			if !output.JSON {
@@ -382,6 +382,7 @@ func installToProvider(
 			}
 			continue
 		}
+		desc := placement.String()
 
 		// Check for portability warnings by running the converter.
 		var warnings []string

--- a/cli/cmd/syllago/uninstall_cmd.go
+++ b/cli/cmd/syllago/uninstall_cmd.go
@@ -168,11 +168,12 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 	// Perform uninstall
 	var removedFrom []string
 	for _, prov := range targets {
-		desc, err := installer.Uninstall(*item, prov, globalDir)
+		placement, err := installer.Uninstall(*item, prov, globalDir)
 		if err != nil {
 			fmt.Fprintf(output.ErrWriter, "  warning: failed to uninstall from %s: %s\n", prov.Name, err)
 			continue
 		}
+		desc := placement.String()
 		removedFrom = append(removedFrom, prov.Name)
 		if !output.JSON && !output.Quiet {
 			if desc != "" {

--- a/cli/internal/installer/hooks.go
+++ b/cli/internal/installer/hooks.go
@@ -39,16 +39,16 @@ func hookSettingsPathImpl(prov provider.Provider) (string, error) {
 	return HookConfigPath(prov, home)
 }
 
-func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot string) (string, error) {
+func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot string) (Placement, error) {
 	// item.Path is already absolute (set by scanner).
 	h, err := readSingleManifestHook(item.Path)
 	if err != nil {
-		return "", fmt.Errorf("parsing hook file: %w", err)
+		return Placement{}, fmt.Errorf("parsing hook file: %w", err)
 	}
 
 	// M3: validate the event name (rejects garbage and prevents key injection).
 	if !converter.IsValidHookEvent(h.Event) {
-		return "", fmt.Errorf("unknown hook event %q: must be a known canonical or provider event name", h.Event)
+		return Placement{}, fmt.Errorf("unknown hook event %q: must be a known canonical or provider event name", h.Event)
 	}
 
 	// ADR-0020: install through the provider's HookAdapter. No adapter (amp,
@@ -56,17 +56,17 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 	// config the provider never reads.
 	adapter := converter.AdapterFor(prov.Slug)
 	if adapter == nil {
-		return "", fmt.Errorf("hook install not supported for %s (no encoder)", prov.Name)
+		return Placement{}, fmt.Errorf("hook install not supported for %s (no encoder)", prov.Name)
 	}
 
 	model, err := hookStorageModelFor(prov.Slug)
 	if err != nil {
-		return "", err
+		return Placement{}, err
 	}
 
 	canonHook, err := manifestHookToCanonical(h)
 	if err != nil {
-		return "", fmt.Errorf("building canonical hook: %w", err)
+		return Placement{}, fmt.Errorf("building canonical hook: %w", err)
 	}
 	canonEvent := canonicalizeEvent(h.Event, prov.Slug)
 	canonHook.Event = canonEvent
@@ -75,7 +75,7 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 	// capabilities are ADR-0020's source of truth (they see windsurf's
 	// split-event support, which ProviderSupportsHookEvent misses).
 	if !adapterSupportsEvent(adapter, canonEvent) {
-		return "", fmt.Errorf("hook %q: %s does not support hook event %q", item.Name, prov.Name, h.Event)
+		return Placement{}, fmt.Errorf("hook %q: %s does not support hook event %q", item.Name, prov.Name, h.Event)
 	}
 
 	// SECURITY (M2): run the pluggable scanner chain against the source hook
@@ -97,14 +97,14 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 		fmt.Fprintf(output.ErrWriter, "  scanner error: %s\n", e)
 	}
 	if !scannerForceBypass && converter.HighestSeverity(scanResult.Findings) == "high" {
-		return "", fmt.Errorf("hook %q has high-severity security findings; re-run with --force to install anyway", item.Name)
+		return Placement{}, fmt.Errorf("hook %q has high-severity security findings; re-run with --force to install anyway", item.Name)
 	}
 
 	// SECURITY: copy referenced scripts to a stable location and rewrite the
 	// command path (operates on the hook before encode).
 	resolvedCmd, err := resolveHookCommandScript(canonHook.Handler.Command, item, repoRoot)
 	if err != nil {
-		return "", err
+		return Placement{}, err
 	}
 	canonHook.Handler.Command = resolvedCmd
 
@@ -113,7 +113,7 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 	// file is touched.
 	groupHash, err := roundTripIdentity(adapter, canonHook)
 	if err != nil {
-		return "", fmt.Errorf("hook %q: %w", item.Name, err)
+		return Placement{}, fmt.Errorf("hook %q: %w", item.Name, err)
 	}
 
 	nativeEvent := nativeEventFor(canonEvent, prov.Slug)
@@ -121,25 +121,25 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 	// Dedup against installed.json (name + event).
 	inst, err := LoadInstalled(repoRoot)
 	if err != nil {
-		return "", fmt.Errorf("loading installed.json: %w", err)
+		return Placement{}, fmt.Errorf("loading installed.json: %w", err)
 	}
 	if inst.FindHook(item.Name, nativeEvent) >= 0 {
-		return "", fmt.Errorf("hook %s already installed for %s event", item.Name, nativeEvent)
+		return Placement{}, fmt.Errorf("hook %s already installed for %s event", item.Name, nativeEvent)
 	}
 
 	settingsPath, err := hookSettingsPath(prov)
 	if err != nil {
-		return "", err
+		return Placement{}, err
 	}
 
 	snapshotDir, err := snapshot.CreateForHook(repoRoot, "hook-install:"+item.Name, []string{settingsPath})
 	if err != nil {
-		return "", fmt.Errorf("creating snapshot: %w", err)
+		return Placement{}, fmt.Errorf("creating snapshot: %w", err)
 	}
 
 	existing, err := decodeExistingHooks(model, adapter, settingsPath)
 	if err != nil {
-		return "", err
+		return Placement{}, err
 	}
 	all := make([]converter.CanonicalHook, 0, len(existing)+1)
 	all = append(all, existing...)
@@ -147,14 +147,14 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 
 	encoded, err := adapter.Encode(&converter.CanonicalHooks{Spec: converter.SpecVersion, Hooks: all})
 	if err != nil {
-		return "", fmt.Errorf("encoding hooks: %w", err)
+		return Placement{}, fmt.Errorf("encoding hooks: %w", err)
 	}
 	if err := writeHookFile(model, settingsPath, encoded.Content); err != nil {
 		// Auto-rollback using the snapshot we just created.
 		if manifest, _, loadErr := snapshot.Load(repoRoot); loadErr == nil {
 			_ = snapshot.Restore(snapshotDir, manifest)
 		}
-		return "", fmt.Errorf("writing %s: %w", settingsPath, err)
+		return Placement{}, fmt.Errorf("writing %s: %w", settingsPath, err)
 	}
 
 	inst.Hooks = append(inst.Hooks, InstalledHook{
@@ -167,25 +167,31 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 		InstalledAt: time.Now(),
 	})
 	if err := SaveInstalled(repoRoot, inst); err != nil {
-		return "", fmt.Errorf("saving installed.json: %w", err)
+		return Placement{}, fmt.Errorf("saving installed.json: %w", err)
 	}
 
-	return fmt.Sprintf("hooks.%s in %s", nativeEvent, settingsPath), nil
+	desc := fmt.Sprintf("hooks.%s in %s", nativeEvent, settingsPath)
+	return Placement{
+		Mechanism: MechanismHookMerge,
+		Path:      settingsPath,
+		Keys:      []string{"hooks." + nativeEvent},
+		desc:      desc,
+	}, nil
 }
 
-func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot string) (string, error) {
+func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot string) (Placement, error) {
 	h, err := readSingleManifestHook(item.Path)
 	if err != nil {
-		return "", fmt.Errorf("parsing hook file: %w", err)
+		return Placement{}, fmt.Errorf("parsing hook file: %w", err)
 	}
 
 	adapter := converter.AdapterFor(prov.Slug)
 	if adapter == nil {
-		return "", fmt.Errorf("hook uninstall not supported for %s (no encoder)", prov.Name)
+		return Placement{}, fmt.Errorf("hook uninstall not supported for %s (no encoder)", prov.Name)
 	}
 	model, err := hookStorageModelFor(prov.Slug)
 	if err != nil {
-		return "", err
+		return Placement{}, err
 	}
 
 	canonEvent := canonicalizeEvent(h.Event, prov.Slug)
@@ -193,16 +199,16 @@ func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot st
 
 	settingsPath, err := hookSettingsPath(prov)
 	if err != nil {
-		return "", err
+		return Placement{}, err
 	}
 
 	inst, err := LoadInstalled(repoRoot)
 	if err != nil {
-		return "", fmt.Errorf("loading installed.json: %w", err)
+		return Placement{}, fmt.Errorf("loading installed.json: %w", err)
 	}
 	instIdx := inst.FindHook(item.Name, nativeEvent)
 	if instIdx < 0 {
-		return "", fmt.Errorf("hook %s not tracked for %s event (not installed by syllago)", item.Name, nativeEvent)
+		return Placement{}, fmt.Errorf("hook %s not tracked for %s event (not installed by syllago)", item.Name, nativeEvent)
 	}
 	storedHash := inst.Hooks[instIdx].GroupHash
 
@@ -210,7 +216,7 @@ func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot st
 	// identity matches the stored hash, drop it, and re-encode.
 	existing, err := decodeExistingHooks(model, adapter, settingsPath)
 	if err != nil {
-		return "", err
+		return Placement{}, err
 	}
 	found := -1
 	for i, eh := range existing {
@@ -220,12 +226,12 @@ func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot st
 		}
 	}
 	if found == -1 {
-		return "", fmt.Errorf("hook %s not found in %s (modified since installation; use 'syllago restore' to revert)", item.Name, settingsPath)
+		return Placement{}, fmt.Errorf("hook %s not found in %s (modified since installation; use 'syllago restore' to revert)", item.Name, settingsPath)
 	}
 
 	snapshotDir, err := snapshot.CreateForHook(repoRoot, "hook-uninstall:"+item.Name, []string{settingsPath})
 	if err != nil {
-		return "", fmt.Errorf("creating snapshot: %w", err)
+		return Placement{}, fmt.Errorf("creating snapshot: %w", err)
 	}
 
 	remaining := make([]converter.CanonicalHook, 0, len(existing)-1)
@@ -237,27 +243,33 @@ func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot st
 			if manifest, _, loadErr := snapshot.Load(repoRoot); loadErr == nil {
 				_ = snapshot.Restore(snapshotDir, manifest)
 			}
-			return "", fmt.Errorf("removing %s: %w", settingsPath, err)
+			return Placement{}, fmt.Errorf("removing %s: %w", settingsPath, err)
 		}
 	} else {
 		encoded, err := adapter.Encode(&converter.CanonicalHooks{Spec: converter.SpecVersion, Hooks: remaining})
 		if err != nil {
-			return "", fmt.Errorf("encoding hooks: %w", err)
+			return Placement{}, fmt.Errorf("encoding hooks: %w", err)
 		}
 		if err := writeHookFile(model, settingsPath, encoded.Content); err != nil {
 			if manifest, _, loadErr := snapshot.Load(repoRoot); loadErr == nil {
 				_ = snapshot.Restore(snapshotDir, manifest)
 			}
-			return "", fmt.Errorf("writing %s: %w", settingsPath, err)
+			return Placement{}, fmt.Errorf("writing %s: %w", settingsPath, err)
 		}
 	}
 
 	inst.RemoveHook(instIdx)
 	if err := SaveInstalled(repoRoot, inst); err != nil {
-		return "", fmt.Errorf("saving installed.json: %w", err)
+		return Placement{}, fmt.Errorf("saving installed.json: %w", err)
 	}
 
-	return fmt.Sprintf("hooks.%s from %s", nativeEvent, settingsPath), nil
+	desc := fmt.Sprintf("hooks.%s from %s", nativeEvent, settingsPath)
+	return Placement{
+		Mechanism: MechanismHookMerge,
+		Path:      settingsPath,
+		Keys:      []string{"hooks." + nativeEvent},
+		desc:      desc,
+	}, nil
 }
 
 func checkHookStatus(item catalog.ContentItem, prov provider.Provider, repoRoot string) Status {

--- a/cli/internal/installer/hooks_crush_test.go
+++ b/cli/internal/installer/hooks_crush_test.go
@@ -55,10 +55,11 @@ func TestInstallHook_E2E_Crush(t *testing.T) {
 	os.WriteFile(configPath, []byte(`{"mcp":{"existing":{"command":"keep-me"}}}`), 0644)
 	overrideHookSettingsPath(t, configPath)
 
-	result, err := installHook(item, provider.Crush, projectRoot)
+	placement, err := installHook(item, provider.Crush, projectRoot)
 	if err != nil {
 		t.Fatalf("installHook: %v", err)
 	}
+	result := placement.String()
 	if !strings.Contains(result, "hooks.PreToolUse") {
 		t.Errorf("result should mention the native event, got %q", result)
 	}

--- a/cli/internal/installer/hooks_e2e_test.go
+++ b/cli/internal/installer/hooks_e2e_test.go
@@ -46,10 +46,11 @@ func TestInstallHook_E2E_InlineCommand(t *testing.T) {
 	}
 
 	// Install
-	result, err := installHook(item, prov, projectRoot)
+	placement, err := installHook(item, prov, projectRoot)
 	if err != nil {
 		t.Fatalf("installHook: %v", err)
 	}
+	result := placement.String()
 	if !strings.Contains(result, "hooks.PostToolUse") {
 		t.Errorf("result should mention event, got %q", result)
 	}
@@ -247,10 +248,11 @@ func TestInstallHook_TranslatesCanonicalEvent(t *testing.T) {
 		ConfigDir: filepath.Base(configDir),
 	}
 
-	result, err := installHook(item, prov, projectRoot)
+	placement, err := installHook(item, prov, projectRoot)
 	if err != nil {
 		t.Fatalf("installHook: %v", err)
 	}
+	result := placement.String()
 
 	// Result message must reference the translated native key.
 	if !strings.Contains(result, "hooks.PreToolUse") {

--- a/cli/internal/installer/installer.go
+++ b/cli/internal/installer/installer.go
@@ -53,6 +53,26 @@ const (
 	MethodAppend InstallMethod = "append"
 )
 
+const (
+	MechanismSymlink   = "symlink"
+	MechanismCopy      = "copy"
+	MechanismHookMerge = "hook_merge"
+	MechanismMCPMerge  = "mcp_merge"
+)
+
+// Placement describes where an install (or uninstall) acted: the mechanism
+// used, the filesystem destination, and — for JSON merges — the keys touched.
+// String() renders the same human-readable description these functions used
+// to return, so display call sites keep their exact output.
+type Placement struct {
+	Mechanism string   // "symlink", "copy", "hook_merge", or "mcp_merge"
+	Path      string   // destination path (symlink/copy) or settings file (merges)
+	Keys      []string // full JSON keys for merges (e.g. "hooks.PreToolUse", "mcpServers.github"); nil otherwise
+	desc      string   // exact legacy display string
+}
+
+func (p Placement) String() string { return p.desc }
+
 // Status represents the install status of an item for a provider.
 type Status int
 
@@ -194,8 +214,8 @@ func CheckStatusWithResolver(item catalog.ContentItem, prov provider.Provider, r
 // For JSON merge types (MCP, hooks), it merges into the provider's config file.
 // For filesystem types, it creates a symlink or copy depending on the method.
 // baseDir overrides the home directory as the install root. If empty, uses home dir.
-// Returns a description of what was installed on success.
-func Install(item catalog.ContentItem, prov provider.Provider, repoRoot string, method InstallMethod, baseDir string) (string, error) {
+// Returns placement metadata; Placement.String renders the legacy description.
+func Install(item catalog.ContentItem, prov provider.Provider, repoRoot string, method InstallMethod, baseDir string) (Placement, error) {
 	// Dispatch to JSON merge handlers for types that need it
 	if IsJSONMerge(prov, item.Type) {
 		switch item.Type {
@@ -204,7 +224,7 @@ func Install(item catalog.ContentItem, prov provider.Provider, repoRoot string, 
 		case catalog.Hooks:
 			return installHook(item, prov, repoRoot)
 		}
-		return "", fmt.Errorf("%s does not support %s via JSON merge", prov.Name, item.Type.Label())
+		return Placement{}, fmt.Errorf("%s does not support %s via JSON merge", prov.Name, item.Type.Label())
 	}
 
 	// Resolve target path using baseDir or home dir
@@ -225,43 +245,45 @@ func Install(item catalog.ContentItem, prov provider.Provider, repoRoot string, 
 		if item.Provider != "" && item.Provider != prov.Slug {
 			targetPath, err := resolveTarget()
 			if err != nil {
-				return "", err
+				return Placement{}, err
 			}
-			return installWithRenderTo(item, prov, conv, filepath.Dir(targetPath))
+			installedPath, err := installWithRenderTo(item, prov, conv, filepath.Dir(targetPath))
+			return Placement{Mechanism: MechanismCopy, Path: installedPath, desc: installedPath}, err
 		}
 		// Same provider + has .source/ → use original for lossless install
 		if converter.HasSourceFile(item) && item.Provider == prov.Slug {
 			targetPath, err := resolveTarget()
 			if err != nil {
-				return "", err
+				return Placement{}, err
 			}
-			return installFromSourceTo(item, prov, filepath.Dir(targetPath))
+			installedPath, err := installFromSourceTo(item, prov, filepath.Dir(targetPath))
+			return Placement{Mechanism: MechanismCopy, Path: installedPath, desc: installedPath}, err
 		}
 	}
 
 	targetPath, err := resolveTarget()
 	if err != nil {
-		return "", err
+		return Placement{}, err
 	}
 
 	sourcePath := SourcePathFor(item)
 
 	switch method {
 	case MethodCopy:
-		return targetPath, CopyContent(sourcePath, targetPath)
+		return Placement{Mechanism: MechanismCopy, Path: targetPath, desc: targetPath}, CopyContent(sourcePath, targetPath)
 	default:
 		if IsWindowsMount(targetPath) {
 			fmt.Fprintf(os.Stderr, "note: %s is on a Windows mount, using copy instead of symlink\n", targetPath)
-			return targetPath, CopyContent(sourcePath, targetPath)
+			return Placement{Mechanism: MechanismCopy, Path: targetPath, desc: targetPath}, CopyContent(sourcePath, targetPath)
 		}
-		return targetPath, CreateSymlink(sourcePath, targetPath)
+		return Placement{Mechanism: MechanismSymlink, Path: targetPath, desc: targetPath}, CreateSymlink(sourcePath, targetPath)
 	}
 }
 
 // InstallWithResolver places the given item under the provider's install directory,
 // using the resolver for path resolution instead of a flat baseDir string.
 // This respects the full priority chain: per-type path > CLI --base-dir > config baseDir > default.
-func InstallWithResolver(item catalog.ContentItem, prov provider.Provider, repoRoot string, method InstallMethod, resolver *config.PathResolver) (string, error) {
+func InstallWithResolver(item catalog.ContentItem, prov provider.Provider, repoRoot string, method InstallMethod, resolver *config.PathResolver) (Placement, error) {
 	// Dispatch to JSON merge handlers for types that need it
 	if IsJSONMerge(prov, item.Type) {
 		switch item.Type {
@@ -270,23 +292,23 @@ func InstallWithResolver(item catalog.ContentItem, prov provider.Provider, repoR
 		case catalog.Hooks:
 			return installHook(item, prov, repoRoot)
 		}
-		return "", fmt.Errorf("%s does not support %s via JSON merge", prov.Name, item.Type.Label())
+		return Placement{}, fmt.Errorf("%s does not support %s via JSON merge", prov.Name, item.Type.Label())
 	}
 
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("getting home directory: %w", err)
+		return Placement{}, fmt.Errorf("getting home directory: %w", err)
 	}
 
 	installDir := resolver.InstallDir(prov, item.Type, home)
 	if installDir == "" {
-		return "", fmt.Errorf("%s does not support %s", prov.Name, item.Type.Label())
+		return Placement{}, fmt.Errorf("%s does not support %s", prov.Name, item.Type.Label())
 	}
 	if installDir == provider.JSONMergeSentinel {
-		return "", fmt.Errorf("%s uses JSON merge for %s (not filesystem install)", prov.Name, item.Type.Label())
+		return Placement{}, fmt.Errorf("%s uses JSON merge for %s (not filesystem install)", prov.Name, item.Type.Label())
 	}
 	if installDir == provider.ProjectScopeSentinel {
-		return "", fmt.Errorf("%s %s is project-scoped (use export with --to from within a project directory)", prov.Name, item.Type.Label())
+		return Placement{}, fmt.Errorf("%s %s is project-scoped (use export with --to from within a project directory)", prov.Name, item.Type.Label())
 	}
 
 	// Compute target path from resolved install dir (same logic as CheckStatusWithResolver).
@@ -302,10 +324,12 @@ func InstallWithResolver(item catalog.ContentItem, prov provider.Provider, repoR
 	// Check for cross-provider rendering via converter
 	if conv := converter.For(item.Type); conv != nil {
 		if item.Provider != "" && item.Provider != prov.Slug {
-			return installWithRenderTo(item, prov, conv, filepath.Dir(targetPath))
+			installedPath, err := installWithRenderTo(item, prov, conv, filepath.Dir(targetPath))
+			return Placement{Mechanism: MechanismCopy, Path: installedPath, desc: installedPath}, err
 		}
 		if converter.HasSourceFile(item) && item.Provider == prov.Slug {
-			return installFromSourceTo(item, prov, filepath.Dir(targetPath))
+			installedPath, err := installFromSourceTo(item, prov, filepath.Dir(targetPath))
+			return Placement{Mechanism: MechanismCopy, Path: installedPath, desc: installedPath}, err
 		}
 	}
 
@@ -313,21 +337,21 @@ func InstallWithResolver(item catalog.ContentItem, prov provider.Provider, repoR
 
 	switch method {
 	case MethodCopy:
-		return targetPath, CopyContent(sourcePath, targetPath)
+		return Placement{Mechanism: MechanismCopy, Path: targetPath, desc: targetPath}, CopyContent(sourcePath, targetPath)
 	default:
 		if IsWindowsMount(targetPath) {
 			fmt.Fprintf(os.Stderr, "note: %s is on a Windows mount, using copy instead of symlink\n", targetPath)
-			return targetPath, CopyContent(sourcePath, targetPath)
+			return Placement{Mechanism: MechanismCopy, Path: targetPath, desc: targetPath}, CopyContent(sourcePath, targetPath)
 		}
-		return targetPath, CreateSymlink(sourcePath, targetPath)
+		return Placement{Mechanism: MechanismSymlink, Path: targetPath, desc: targetPath}, CreateSymlink(sourcePath, targetPath)
 	}
 }
 
 // Uninstall removes the given item from the provider's install directory.
 // For JSON merge types, it removes the entry from the provider's config file.
 // For filesystem types, it removes the symlink.
-// Returns a description of what was removed on success.
-func Uninstall(item catalog.ContentItem, prov provider.Provider, repoRoot string) (string, error) {
+// Returns placement metadata; Placement.String renders the legacy description.
+func Uninstall(item catalog.ContentItem, prov provider.Provider, repoRoot string) (Placement, error) {
 	// Dispatch to JSON merge handlers for types that need it
 	if IsJSONMerge(prov, item.Type) {
 		switch item.Type {
@@ -336,34 +360,34 @@ func Uninstall(item catalog.ContentItem, prov provider.Provider, repoRoot string
 		case catalog.Hooks:
 			return uninstallHook(item, prov, repoRoot)
 		}
-		return "", fmt.Errorf("%s does not support %s via JSON merge", prov.Name, item.Type.Label())
+		return Placement{}, fmt.Errorf("%s does not support %s via JSON merge", prov.Name, item.Type.Label())
 	}
 
 	targetPath, err := resolveTarget(item, prov)
 	if err != nil {
-		return "", err
+		return Placement{}, err
 	}
 
 	info, err := os.Lstat(targetPath)
 	if err != nil {
-		return "", fmt.Errorf("not installed: %s", targetPath)
+		return Placement{}, fmt.Errorf("not installed: %s", targetPath)
 	}
 
 	// Remove symlinks only when they still point at this library item.
 	if info.Mode()&os.ModeSymlink != 0 {
 		actualTarget, err := resolveSymlinkTarget(targetPath)
 		if err != nil {
-			return "", fmt.Errorf("reading symlink %s: %w", targetPath, err)
+			return Placement{}, fmt.Errorf("reading symlink %s: %w", targetPath, err)
 		}
 		if !symlinkTargetBelongsToItem(actualTarget, item) {
-			return "", fmt.Errorf("refusing to remove %s: symlink points to %s, not to %s", targetPath, actualTarget, item.Path)
+			return Placement{}, fmt.Errorf("refusing to remove %s: symlink points to %s, not to %s", targetPath, actualTarget, item.Path)
 		}
-		return targetPath, os.Remove(targetPath)
+		return Placement{Mechanism: MechanismSymlink, Path: targetPath, desc: targetPath}, os.Remove(targetPath)
 	}
 
 	// Remove regular files (copies)
 	if info.Mode().IsRegular() {
-		return targetPath, os.Remove(targetPath)
+		return Placement{Mechanism: MechanismCopy, Path: targetPath, desc: targetPath}, os.Remove(targetPath)
 	}
 
 	// Remove directories (copy-installed content)
@@ -372,18 +396,18 @@ func Uninstall(item catalog.ContentItem, prov provider.Provider, repoRoot string
 		// path traversal attacks from removing arbitrary directories.
 		home, homeErr := os.UserHomeDir()
 		if homeErr != nil {
-			return "", fmt.Errorf("getting home directory: %w", homeErr)
+			return Placement{}, fmt.Errorf("getting home directory: %w", homeErr)
 		}
 		var resolver *config.PathResolver
 		installDir := resolver.InstallDir(prov, item.Type, home)
 		rel, relErr := filepath.Rel(installDir, targetPath)
 		if relErr != nil || strings.HasPrefix(rel, "..") {
-			return "", fmt.Errorf("refusing to remove %s: outside install directory %s", targetPath, installDir)
+			return Placement{}, fmt.Errorf("refusing to remove %s: outside install directory %s", targetPath, installDir)
 		}
-		return targetPath, os.RemoveAll(targetPath)
+		return Placement{Mechanism: MechanismCopy, Path: targetPath, desc: targetPath}, os.RemoveAll(targetPath)
 	}
 
-	return "", fmt.Errorf("unexpected file type at %s, remove manually", targetPath)
+	return Placement{}, fmt.Errorf("unexpected file type at %s, remove manually", targetPath)
 }
 
 func symlinkTargetBelongsToItem(target string, item catalog.ContentItem) bool {

--- a/cli/internal/installer/installer_resolver_test.go
+++ b/cli/internal/installer/installer_resolver_test.go
@@ -270,10 +270,11 @@ func TestInstallWithResolver_PerTypePath(t *testing.T) {
 	resolver := config.NewResolver(cfg, "")
 
 	// Install with per-type path override
-	desc, err := InstallWithResolver(item, prov, repoRoot, MethodSymlink, resolver)
+	placement, err := InstallWithResolver(item, prov, repoRoot, MethodSymlink, resolver)
 	if err != nil {
 		t.Fatalf("InstallWithResolver: %v", err)
 	}
+	desc := placement.String()
 
 	// Should install to the custom per-type path, not the provider default
 	expectedTarget := filepath.Join(customDir, "my-rule")
@@ -318,10 +319,11 @@ func TestInstallWithResolver_BaseDir(t *testing.T) {
 	}
 	resolver := config.NewResolver(cfg, "")
 
-	desc, err := InstallWithResolver(item, prov, repoRoot, MethodSymlink, resolver)
+	placement, err := InstallWithResolver(item, prov, repoRoot, MethodSymlink, resolver)
 	if err != nil {
 		t.Fatalf("InstallWithResolver: %v", err)
 	}
+	desc := placement.String()
 
 	// BaseDir goes through prov.InstallDir, so target is customBase/.provider/rules/my-rule
 	expectedTarget := filepath.Join(customBase, ".provider", "rules", "my-rule")
@@ -358,10 +360,11 @@ func TestInstallWithResolver_CLIOverridesConfig(t *testing.T) {
 	}
 	resolver := config.NewResolver(cfg, cliBase)
 
-	desc, err := InstallWithResolver(item, prov, repoRoot, MethodSymlink, resolver)
+	placement, err := InstallWithResolver(item, prov, repoRoot, MethodSymlink, resolver)
 	if err != nil {
 		t.Fatalf("InstallWithResolver: %v", err)
 	}
+	desc := placement.String()
 
 	// CLI base should win over config base
 	expectedTarget := filepath.Join(cliBase, ".provider", "rules", "my-rule")
@@ -399,10 +402,11 @@ func TestInstallWithResolver_PerTypeOverridesCLI(t *testing.T) {
 	}
 	resolver := config.NewResolver(cfg, cliBase)
 
-	desc, err := InstallWithResolver(item, prov, repoRoot, MethodSymlink, resolver)
+	placement, err := InstallWithResolver(item, prov, repoRoot, MethodSymlink, resolver)
 	if err != nil {
 		t.Fatalf("InstallWithResolver: %v", err)
 	}
+	desc := placement.String()
 
 	// Per-type path should win over CLI base
 	expectedTarget := filepath.Join(customDir, "my-rule")
@@ -482,10 +486,11 @@ func TestInstallWithResolver_CopyMethod(t *testing.T) {
 	}
 	resolver := config.NewResolver(cfg, "")
 
-	desc, err := InstallWithResolver(item, prov, repoRoot, MethodCopy, resolver)
+	placement, err := InstallWithResolver(item, prov, repoRoot, MethodCopy, resolver)
 	if err != nil {
 		t.Fatalf("InstallWithResolver with copy: %v", err)
 	}
+	desc := placement.String()
 
 	expectedTarget := filepath.Join(customDir, "my-rule")
 	if desc != expectedTarget {

--- a/cli/internal/installer/installer_test.go
+++ b/cli/internal/installer/installer_test.go
@@ -254,10 +254,11 @@ func TestInstall_SymlinkMethod(t *testing.T) {
 		Path: sourcePath,
 	}
 
-	desc, err := Install(item, prov, repoRoot, MethodSymlink, "")
+	placement, err := Install(item, prov, repoRoot, MethodSymlink, "")
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
+	desc := placement.String()
 
 	expectedTarget := filepath.Join(tmp, ".testprovider", "rules", "install-rule")
 	if desc != expectedTarget {
@@ -292,10 +293,11 @@ func TestInstall_CopyMethod(t *testing.T) {
 		Path: sourcePath,
 	}
 
-	desc, err := Install(item, prov, repoRoot, MethodCopy, "")
+	placement, err := Install(item, prov, repoRoot, MethodCopy, "")
 	if err != nil {
 		t.Fatalf("Install copy: %v", err)
 	}
+	desc := placement.String()
 
 	expectedTarget := filepath.Join(tmp, ".testprovider", "rules", "copy-rule")
 	if desc != expectedTarget {
@@ -330,10 +332,11 @@ func TestInstall_WithBaseDir(t *testing.T) {
 		Path: sourcePath,
 	}
 
-	desc, err := Install(item, prov, repoRoot, MethodSymlink, baseDir)
+	placement, err := Install(item, prov, repoRoot, MethodSymlink, baseDir)
 	if err != nil {
 		t.Fatalf("Install with baseDir: %v", err)
 	}
+	desc := placement.String()
 
 	expectedTarget := filepath.Join(baseDir, ".testprovider", "rules", "base-rule")
 	if desc != expectedTarget {
@@ -374,10 +377,11 @@ func TestInstall_AgentsUsesAGENTMD(t *testing.T) {
 		Path: sourcePath,
 	}
 
-	desc, err := Install(item, prov, repoRoot, MethodSymlink, "")
+	placement, err := Install(item, prov, repoRoot, MethodSymlink, "")
 	if err != nil {
 		t.Fatalf("Install agent: %v", err)
 	}
+	desc := placement.String()
 
 	expectedTarget := filepath.Join(tmp, ".testprovider", "agents", "my-agent.md")
 	if desc != expectedTarget {
@@ -415,10 +419,11 @@ func TestUninstall_RemovesSymlink(t *testing.T) {
 	os.MkdirAll(filepath.Dir(targetPath), 0755)
 	os.Symlink(sourcePath, targetPath)
 
-	desc, err := Uninstall(item, prov, repoRoot)
+	placement, err := Uninstall(item, prov, repoRoot)
 	if err != nil {
 		t.Fatalf("Uninstall: %v", err)
 	}
+	desc := placement.String()
 	if desc != targetPath {
 		t.Errorf("expected desc %s, got %s", targetPath, desc)
 	}
@@ -492,10 +497,11 @@ func TestUninstall_RemovesAgentSymlinkToSourceFile(t *testing.T) {
 	os.MkdirAll(filepath.Dir(targetPath), 0755)
 	os.Symlink(agentFile, targetPath)
 
-	desc, err := Uninstall(item, prov, repoRoot)
+	placement, err := Uninstall(item, prov, repoRoot)
 	if err != nil {
 		t.Fatalf("Uninstall agent: %v", err)
 	}
+	desc := placement.String()
 	if desc != targetPath {
 		t.Errorf("expected desc %s, got %s", targetPath, desc)
 	}
@@ -523,10 +529,11 @@ func TestUninstall_RemovesRegularFile(t *testing.T) {
 	os.MkdirAll(filepath.Dir(targetPath), 0755)
 	os.WriteFile(targetPath, []byte("# Copied"), 0644)
 
-	desc, err := Uninstall(item, prov, repoRoot)
+	placement, err := Uninstall(item, prov, repoRoot)
 	if err != nil {
 		t.Fatalf("Uninstall: %v", err)
 	}
+	desc := placement.String()
 	if desc != targetPath {
 		t.Errorf("expected desc %s, got %s", targetPath, desc)
 	}
@@ -554,10 +561,11 @@ func TestUninstall_RemovesDirectory(t *testing.T) {
 	os.MkdirAll(targetPath, 0755)
 	os.WriteFile(filepath.Join(targetPath, "file.md"), []byte("# Content"), 0644)
 
-	desc, err := Uninstall(item, prov, repoRoot)
+	placement, err := Uninstall(item, prov, repoRoot)
 	if err != nil {
 		t.Fatalf("Uninstall dir: %v", err)
 	}
+	desc := placement.String()
 	if desc != targetPath {
 		t.Errorf("expected desc %s, got %s", targetPath, desc)
 	}
@@ -864,10 +872,11 @@ func TestInstall_CrossProviderRendering(t *testing.T) {
 		},
 	}
 
-	desc, err := Install(item, cursorProv, repoRoot, MethodSymlink, "")
+	placement, err := Install(item, cursorProv, repoRoot, MethodSymlink, "")
 	if err != nil {
 		t.Fatalf("Install cross-provider: %v", err)
 	}
+	desc := placement.String()
 
 	// Verify the file was written
 	data, err := os.ReadFile(desc)
@@ -914,10 +923,11 @@ func TestInstall_SameProviderWithSource(t *testing.T) {
 		},
 	}
 
-	desc, err := Install(item, cursorProv, repoRoot, MethodSymlink, "")
+	placement, err := Install(item, cursorProv, repoRoot, MethodSymlink, "")
 	if err != nil {
 		t.Fatalf("Install with source: %v", err)
 	}
+	desc := placement.String()
 
 	// Should have installed the original source file
 	data, err := os.ReadFile(desc)
@@ -972,10 +982,11 @@ func TestInstallWithResolver_SameProviderWithSource(t *testing.T) {
 	}
 	resolver := config.NewResolver(cfg, "")
 
-	desc, err := InstallWithResolver(item, cursorProv, repoRoot, MethodSymlink, resolver)
+	placement, err := InstallWithResolver(item, cursorProv, repoRoot, MethodSymlink, resolver)
 	if err != nil {
 		t.Fatalf("InstallWithResolver: %v", err)
 	}
+	desc := placement.String()
 
 	data, err := os.ReadFile(desc)
 	if err != nil {
@@ -1029,10 +1040,11 @@ func TestInstallWithResolver_CrossProviderRendering(t *testing.T) {
 	}
 	resolver := config.NewResolver(cfg, "")
 
-	desc, err := InstallWithResolver(item, cursorProv, repoRoot, MethodSymlink, resolver)
+	placement, err := InstallWithResolver(item, cursorProv, repoRoot, MethodSymlink, resolver)
 	if err != nil {
 		t.Fatalf("InstallWithResolver cross-provider: %v", err)
 	}
+	desc := placement.String()
 
 	data, err := os.ReadFile(desc)
 	if err != nil {
@@ -1139,10 +1151,11 @@ func TestInstallWithResolver_AgentsType(t *testing.T) {
 	}
 	resolver := config.NewResolver(cfg, "")
 
-	desc, err := InstallWithResolver(item, prov, repoRoot, MethodSymlink, resolver)
+	placement, err := InstallWithResolver(item, prov, repoRoot, MethodSymlink, resolver)
 	if err != nil {
 		t.Fatalf("InstallWithResolver agents: %v", err)
 	}
+	desc := placement.String()
 
 	expected := filepath.Join(customDir, "my-agent.md")
 	if desc != expected {
@@ -1176,10 +1189,11 @@ func TestInstall_MergeTypeMCPDispatch(t *testing.T) {
 		Path: itemDir,
 	}
 
-	desc, err := Install(item, prov, tmpDir, MethodSymlink, "")
+	placement, err := Install(item, prov, tmpDir, MethodSymlink, "")
 	if err != nil {
 		t.Fatalf("Install MCP: %v", err)
 	}
+	desc := placement.String()
 	if desc == "" {
 		t.Error("expected non-empty description")
 	}

--- a/cli/internal/installer/mcp.go
+++ b/cli/internal/installer/mcp.go
@@ -296,11 +296,11 @@ func ExtractServerEntries(rawData []byte, itemName string, jsonKey string) (map[
 	return entries, nil
 }
 
-func installMCP(item catalog.ContentItem, prov provider.Provider, repoRoot string) (string, error) {
+func installMCP(item catalog.ContentItem, prov provider.Provider, repoRoot string) (Placement, error) {
 	// Read the MCP config from the content item
 	rawData, err := os.ReadFile(filepath.Join(item.Path, "config.json"))
 	if err != nil {
-		return "", fmt.Errorf("reading config.json: %w", err)
+		return Placement{}, fmt.Errorf("reading config.json: %w", err)
 	}
 
 	jsonKey := MCPConfigKey(prov)
@@ -308,14 +308,14 @@ func installMCP(item catalog.ContentItem, prov provider.Provider, repoRoot strin
 	// Extract server entries — handles both nested and flat config.json formats
 	entries, err := ExtractServerEntries(rawData, item.Name, jsonKey)
 	if err != nil {
-		return "", err
+		return Placement{}, err
 	}
 
 	// If item has a ServerKey, filter to just that one server.
 	if item.ServerKey != "" {
 		configData, ok := entries[item.ServerKey]
 		if !ok {
-			return "", fmt.Errorf("server %q not found in config.json", item.ServerKey)
+			return Placement{}, fmt.Errorf("server %q not found in config.json", item.ServerKey)
 		}
 		entries = map[string]json.RawMessage{item.ServerKey: configData}
 	}
@@ -323,29 +323,30 @@ func installMCP(item catalog.ContentItem, prov provider.Provider, repoRoot strin
 	// Read target config file
 	cfgPath, err := mcpConfigPath(prov, repoRoot)
 	if err != nil {
-		return "", err
+		return Placement{}, err
 	}
 
 	if err := backupFile(cfgPath); err != nil {
-		return "", fmt.Errorf("backing up %s: %w", cfgPath, err)
+		return Placement{}, fmt.Errorf("backing up %s: %w", cfgPath, err)
 	}
 
 	fileData, err := readMCPConfig(cfgPath, prov)
 	if err != nil {
-		return "", fmt.Errorf("reading %s: %w", cfgPath, err)
+		return Placement{}, fmt.Errorf("reading %s: %w", cfgPath, err)
 	}
 
 	// Load installed.json to check for syllago-managed entries
 	inst, err := LoadInstalled(repoRoot)
 	if err != nil {
-		return "", fmt.Errorf("loading installed.json: %w", err)
+		return Placement{}, fmt.Errorf("loading installed.json: %w", err)
 	}
 
 	// Merge each server entry into the target config
 	var serverNames []string
+	var keys []string
 	for name, configData := range entries {
 		if !catalog.IsValidItemName(name) {
-			return "", fmt.Errorf("invalid MCP server name %q: names may only contain letters, numbers, hyphens, and underscores", name)
+			return Placement{}, fmt.Errorf("invalid MCP server name %q: names may only contain letters, numbers, hyphens, and underscores", name)
 		}
 		key := jsonKey + "." + name
 
@@ -369,19 +370,20 @@ func installMCP(item catalog.ContentItem, prov provider.Provider, repoRoot strin
 				}
 			}
 			if !syllagoManaged {
-				return "", fmt.Errorf("MCP server %q already exists in %s and was not installed by syllago; use --force to overwrite", name, cfgPath)
+				return Placement{}, fmt.Errorf("MCP server %q already exists in %s and was not installed by syllago; use --force to overwrite", name, cfgPath)
 			}
 		}
 
 		fileData, err = sjson.SetRawBytes(fileData, key, configData)
 		if err != nil {
-			return "", fmt.Errorf("setting %s: %w", key, err)
+			return Placement{}, fmt.Errorf("setting %s: %w", key, err)
 		}
 		serverNames = append(serverNames, name)
+		keys = append(keys, key)
 	}
 
 	if err := writeJSONFile(cfgPath, fileData); err != nil {
-		return "", fmt.Errorf("writing %s: %w", cfgPath, err)
+		return Placement{}, fmt.Errorf("writing %s: %w", cfgPath, err)
 	}
 
 	// Record in installed.json (inst already loaded above for collision check)
@@ -404,21 +406,27 @@ func installMCP(item catalog.ContentItem, prov provider.Provider, repoRoot strin
 	}
 
 	if err := SaveInstalled(repoRoot, inst); err != nil {
-		return "", fmt.Errorf("saving installed.json: %w", err)
+		return Placement{}, fmt.Errorf("saving installed.json: %w", err)
 	}
 
-	return fmt.Sprintf("%s in %s", jsonKey, cfgPath), nil
+	desc := fmt.Sprintf("%s in %s", jsonKey, cfgPath)
+	return Placement{
+		Mechanism: MechanismMCPMerge,
+		Path:      cfgPath,
+		Keys:      keys,
+		desc:      desc,
+	}, nil
 }
 
-func uninstallMCP(item catalog.ContentItem, prov provider.Provider, repoRoot string) (string, error) {
+func uninstallMCP(item catalog.ContentItem, prov provider.Provider, repoRoot string) (Placement, error) {
 	cfgPath, err := mcpConfigPath(prov, repoRoot)
 	if err != nil {
-		return "", err
+		return Placement{}, err
 	}
 
 	fileData, err := readMCPConfig(cfgPath, prov)
 	if err != nil {
-		return "", fmt.Errorf("reading %s: %w", cfgPath, err)
+		return Placement{}, fmt.Errorf("reading %s: %w", cfgPath, err)
 	}
 
 	jsonKey := MCPConfigKey(prov)
@@ -426,7 +434,7 @@ func uninstallMCP(item catalog.ContentItem, prov provider.Provider, repoRoot str
 	// Check installed.json for ownership
 	inst, err := LoadInstalled(repoRoot)
 	if err != nil {
-		return "", fmt.Errorf("loading installed.json: %w", err)
+		return Placement{}, fmt.Errorf("loading installed.json: %w", err)
 	}
 
 	// Try per-server lookup first (new format), then legacy bulk lookup.
@@ -438,11 +446,11 @@ func uninstallMCP(item catalog.ContentItem, prov provider.Provider, repoRoot str
 		instIdx = inst.FindMCP(item.Name)
 	}
 	if instIdx < 0 {
-		return "", fmt.Errorf("%s was not installed by syllago", item.Name)
+		return Placement{}, fmt.Errorf("%s was not installed by syllago", item.Name)
 	}
 
 	if err := backupFile(cfgPath); err != nil {
-		return "", fmt.Errorf("backing up %s: %w", cfgPath, err)
+		return Placement{}, fmt.Errorf("backing up %s: %w", cfgPath, err)
 	}
 
 	// Determine which server keys to remove.
@@ -459,27 +467,35 @@ func uninstallMCP(item catalog.ContentItem, prov provider.Provider, repoRoot str
 		keysToRemove = []string{item.Name}
 	}
 
+	var keys []string
 	for _, name := range keysToRemove {
 		key := jsonKey + "." + name
+		keys = append(keys, key)
 		if gjson.GetBytes(fileData, key).Exists() {
 			fileData, err = sjson.DeleteBytes(fileData, key)
 			if err != nil {
-				return "", fmt.Errorf("deleting %s: %w", key, err)
+				return Placement{}, fmt.Errorf("deleting %s: %w", key, err)
 			}
 		}
 	}
 
 	if err := writeJSONFile(cfgPath, fileData); err != nil {
-		return "", fmt.Errorf("writing %s: %w", cfgPath, err)
+		return Placement{}, fmt.Errorf("writing %s: %w", cfgPath, err)
 	}
 
 	// Remove from installed.json
 	inst.RemoveMCP(instIdx)
 	if err := SaveInstalled(repoRoot, inst); err != nil {
-		return "", fmt.Errorf("saving installed.json: %w", err)
+		return Placement{}, fmt.Errorf("saving installed.json: %w", err)
 	}
 
-	return fmt.Sprintf("%s from %s", jsonKey, cfgPath), nil
+	desc := fmt.Sprintf("%s from %s", jsonKey, cfgPath)
+	return Placement{
+		Mechanism: MechanismMCPMerge,
+		Path:      cfgPath,
+		Keys:      keys,
+		desc:      desc,
+	}, nil
 }
 
 func checkMCPStatus(item catalog.ContentItem, prov provider.Provider, repoRoot string) Status {

--- a/cli/internal/installer/moat_provider_install.go
+++ b/cli/internal/installer/moat_provider_install.go
@@ -32,8 +32,8 @@ import (
 // consulted — content verification is the caller's responsibility.
 //
 // Returns the provider-side install path (e.g. ~/.claude/skills/foo) on
-// success. The signature mirrors Install() so callers using a baseDir
-// override (--base-dir flag, project install root) get the same semantics.
+// success. The baseDir override (--base-dir flag, project install root)
+// follows the same semantics as Install().
 func InstallCachedMOATToProvider(
 	cacheDir string,
 	entry *moat.ContentEntry,
@@ -68,5 +68,6 @@ func InstallCachedMOATToProvider(
 		Path:        cacheDir,
 	}
 
-	return Install(item, prov, repoRoot, method, baseDir)
+	placement, err := Install(item, prov, repoRoot, method, baseDir)
+	return placement.String(), err
 }

--- a/cli/internal/installer/placement_test.go
+++ b/cli/internal/installer/placement_test.go
@@ -1,0 +1,254 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+)
+
+func TestPlacement_InstallFilesystemMethods(t *testing.T) {
+	tmp := t.TempDir()
+	repoRoot := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", tmp)
+
+	prov := testProvider("test")
+
+	t.Run("symlink", func(t *testing.T) {
+		sourcePath := filepath.Join(repoRoot, "rules", "test", "placement-symlink")
+		if err := os.MkdirAll(sourcePath, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(sourcePath, "rule.md"), []byte("# Symlink"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		item := catalog.ContentItem{Name: "placement-symlink", Type: catalog.Rules, Path: sourcePath}
+
+		placement, err := Install(item, prov, repoRoot, MethodSymlink, "")
+		if err != nil {
+			t.Fatalf("Install symlink: %v", err)
+		}
+
+		expectedTarget := filepath.Join(tmp, ".testprovider", "rules", "placement-symlink")
+		if placement.Mechanism != MechanismSymlink {
+			t.Errorf("Mechanism = %q, want %q", placement.Mechanism, MechanismSymlink)
+		}
+		if placement.Path != expectedTarget {
+			t.Errorf("Path = %q, want %q", placement.Path, expectedTarget)
+		}
+		if placement.String() != expectedTarget {
+			t.Errorf("String() = %q, want %q", placement.String(), expectedTarget)
+		}
+	})
+
+	t.Run("copy", func(t *testing.T) {
+		sourcePath := filepath.Join(repoRoot, "rules", "test", "placement-copy")
+		if err := os.MkdirAll(sourcePath, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(sourcePath, "rule.md"), []byte("# Copy"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		item := catalog.ContentItem{Name: "placement-copy", Type: catalog.Rules, Path: sourcePath}
+
+		placement, err := Install(item, prov, repoRoot, MethodCopy, "")
+		if err != nil {
+			t.Fatalf("Install copy: %v", err)
+		}
+
+		expectedTarget := filepath.Join(tmp, ".testprovider", "rules", "placement-copy")
+		if placement.Mechanism != MechanismCopy {
+			t.Errorf("Mechanism = %q, want %q", placement.Mechanism, MechanismCopy)
+		}
+		if placement.Path != expectedTarget {
+			t.Errorf("Path = %q, want %q", placement.Path, expectedTarget)
+		}
+		if placement.String() != expectedTarget {
+			t.Errorf("String() = %q, want %q", placement.String(), expectedTarget)
+		}
+	})
+}
+
+func TestPlacement_UninstallSymlink(t *testing.T) {
+	tmp := t.TempDir()
+	repoRoot := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", tmp)
+
+	prov := testProvider("test")
+	sourcePath := filepath.Join(repoRoot, "rules", "test", "placement-remove")
+	if err := os.MkdirAll(sourcePath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	item := catalog.ContentItem{Name: "placement-remove", Type: catalog.Rules, Path: sourcePath}
+
+	targetPath := filepath.Join(tmp, ".testprovider", "rules", "placement-remove")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(sourcePath, targetPath); err != nil {
+		t.Fatal(err)
+	}
+
+	placement, err := Uninstall(item, prov, repoRoot)
+	if err != nil {
+		t.Fatalf("Uninstall symlink: %v", err)
+	}
+	if placement.Mechanism != MechanismSymlink {
+		t.Errorf("Mechanism = %q, want %q", placement.Mechanism, MechanismSymlink)
+	}
+	if placement.Path != targetPath {
+		t.Errorf("Path = %q, want %q", placement.Path, targetPath)
+	}
+	if placement.String() != targetPath {
+		t.Errorf("String() = %q, want %q", placement.String(), targetPath)
+	}
+}
+
+func TestPlacement_HookMergeInstallAndUninstall(t *testing.T) {
+	projectRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	hookDir := filepath.Join(projectRoot, "hooks", "placement-hook")
+	if err := os.MkdirAll(hookDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"event":"PreToolUse","matcher":"Bash","handler":{"type":"command","command":"echo check"}}]}`
+	if err := os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	item := catalog.ContentItem{Name: "placement-hook", Type: catalog.Hooks, Path: hookDir}
+
+	settingsPath := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(settingsPath, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	overrideHookSettingsPath(t, settingsPath)
+
+	placement, err := installHook(item, provider.ClaudeCode, projectRoot)
+	if err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+	if placement.Mechanism != MechanismHookMerge {
+		t.Errorf("install Mechanism = %q, want %q", placement.Mechanism, MechanismHookMerge)
+	}
+	if placement.Path != settingsPath {
+		t.Errorf("install Path = %q, want %q", placement.Path, settingsPath)
+	}
+	assertStringSet(t, placement.Keys, []string{"hooks.PreToolUse"})
+	expectedInstall := "hooks.PreToolUse in " + settingsPath
+	if placement.String() != expectedInstall {
+		t.Errorf("install String() = %q, want %q", placement.String(), expectedInstall)
+	}
+
+	placement, err = uninstallHook(item, provider.ClaudeCode, projectRoot)
+	if err != nil {
+		t.Fatalf("uninstallHook: %v", err)
+	}
+	if placement.Mechanism != MechanismHookMerge {
+		t.Errorf("uninstall Mechanism = %q, want %q", placement.Mechanism, MechanismHookMerge)
+	}
+	if placement.Path != settingsPath {
+		t.Errorf("uninstall Path = %q, want %q", placement.Path, settingsPath)
+	}
+	assertStringSet(t, placement.Keys, []string{"hooks.PreToolUse"})
+	expectedUninstall := "hooks.PreToolUse from " + settingsPath
+	if placement.String() != expectedUninstall {
+		t.Errorf("uninstall String() = %q, want %q", placement.String(), expectedUninstall)
+	}
+}
+
+func TestPlacement_MCPMergeInstallAndUninstall(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	itemDir := filepath.Join(tmpDir, "placement-mcp")
+	if err := os.MkdirAll(itemDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configJSON := `{
+		"mcpServers": {
+			"server-a": {"command": "node", "args": ["a.js"]},
+			"server-b": {"url": "https://b.example.com"}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(itemDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	item := catalog.ContentItem{Name: "placement-mcp", Type: catalog.MCP, Path: itemDir}
+
+	cfgPath := filepath.Join(tmpDir, ".claude.json")
+	if err := os.WriteFile(cfgPath, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalFunc := mcpConfigPath
+	mcpConfigPath = func(p provider.Provider, repoRoot string) (string, error) {
+		return cfgPath, nil
+	}
+	t.Cleanup(func() { mcpConfigPath = originalFunc })
+
+	prov := provider.Provider{Slug: "claude-code", Name: "Claude Code"}
+
+	placement, err := installMCP(item, prov, tmpDir)
+	if err != nil {
+		t.Fatalf("installMCP: %v", err)
+	}
+	if placement.Mechanism != MechanismMCPMerge {
+		t.Errorf("install Mechanism = %q, want %q", placement.Mechanism, MechanismMCPMerge)
+	}
+	if placement.Path != cfgPath {
+		t.Errorf("install Path = %q, want %q", placement.Path, cfgPath)
+	}
+	assertStringSet(t, placement.Keys, []string{"mcpServers.server-a", "mcpServers.server-b"})
+	expectedInstall := "mcpServers in " + cfgPath
+	if placement.String() != expectedInstall {
+		t.Errorf("install String() = %q, want %q", placement.String(), expectedInstall)
+	}
+
+	placement, err = uninstallMCP(item, prov, tmpDir)
+	if err != nil {
+		t.Fatalf("uninstallMCP: %v", err)
+	}
+	if placement.Mechanism != MechanismMCPMerge {
+		t.Errorf("uninstall Mechanism = %q, want %q", placement.Mechanism, MechanismMCPMerge)
+	}
+	if placement.Path != cfgPath {
+		t.Errorf("uninstall Path = %q, want %q", placement.Path, cfgPath)
+	}
+	assertStringSet(t, placement.Keys, []string{"mcpServers.server-a", "mcpServers.server-b"})
+	expectedUninstall := "mcpServers from " + cfgPath
+	if placement.String() != expectedUninstall {
+		t.Errorf("uninstall String() = %q, want %q", placement.String(), expectedUninstall)
+	}
+}
+
+func assertStringSet(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("keys length = %d, want %d; got %v", len(got), len(want), got)
+	}
+	seen := make(map[string]int, len(got))
+	for _, key := range got {
+		seen[key]++
+	}
+	for _, key := range want {
+		if seen[key] == 0 {
+			t.Fatalf("missing key %q in %v", key, got)
+		}
+		seen[key]--
+	}
+	for key, count := range seen {
+		if count != 0 {
+			t.Fatalf("unexpected key %q in %v", key, got)
+		}
+	}
+}

--- a/cli/internal/tui/actions.go
+++ b/cli/internal/tui/actions.go
@@ -899,7 +899,7 @@ func (a App) doInstallCmd(msg installResultMsg) tea.Cmd {
 	}
 
 	return func() tea.Msg {
-		desc, err := installer.Install(item, prov, projectRoot, method, baseDir)
+		placement, err := installer.Install(item, prov, projectRoot, method, baseDir)
 		if err != nil {
 			return installDoneMsg{
 				itemName:     item.DisplayName,
@@ -910,7 +910,7 @@ func (a App) doInstallCmd(msg installResultMsg) tea.Cmd {
 		return installDoneMsg{
 			itemName:     item.DisplayName,
 			providerName: prov.Name,
-			targetPath:   desc,
+			targetPath:   placement.String(),
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Item 2b (first half) of #542. The unified install-record store (#547) needs the mechanism, destination path, and JSON keys of every placement — data the installer flattened into a human-readable string. This refactor makes `installer.Install`, `InstallWithResolver`, and `Uninstall` return a structured `Placement{Mechanism, Path, Keys}` whose `String()` renders the exact legacy description.

- Every user-visible string is byte-identical; TUI golden files are unchanged.
- Mechanism constants (`symlink`/`copy`/`hook_merge`/`mcp_merge`) deliberately match `installstore.Mechanism` values so the follow-up wiring chunk (2b-ii) maps placements directly.
- Hook merges report the settings file plus the `hooks.<event>` key; MCP merges report the config file plus one key per merged/removed server.
- Display call sites updated mechanically; call sites that discarded the string still discard the struct.

Pure refactor — no behavior change, no records written yet.

## Testing

- New `cli/internal/installer/placement_test.go` pins Placement fields and exact legacy strings for all four mechanisms, install and uninstall.
- Existing installer tests updated to assert via `.String()`, keeping the legacy-string contract pinned.
- Full suite green locally (`make test`, 39 packages ok); TUI goldens untouched.

Part of #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
