### PR TITLE
feat(regdiff): registry diff engine for git and MOAT registries (#542 item 6b)

### DIFF
--- a/cli/internal/moat/producer.go
+++ b/cli/internal/moat/producer.go
@@ -348,6 +348,32 @@ func manifestCachePathsFor(absCacheDir, name string) (string, string, error) {
 		nil
 }
 
+// ManifestCachePath returns the on-disk path of the cached manifest for a
+// registry: <cacheDir>/moat/registries/<name>/manifest.json. Same
+// validation and traversal guard as WriteManifestCache.
+func ManifestCachePath(cacheDir, name string) (string, error) {
+	if cacheDir == "" {
+		return "", fmt.Errorf("ManifestCachePath: cacheDir is empty")
+	}
+	if name == "" {
+		return "", fmt.Errorf("ManifestCachePath: registry name is empty")
+	}
+	if !catalog.IsValidRegistryName(name) {
+		return "", fmt.Errorf("ManifestCachePath: registry name %q is not valid", name)
+	}
+
+	absCache, err := filepath.Abs(cacheDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve cacheDir: %w", err)
+	}
+
+	manifestPath, _, err := manifestCachePathsFor(absCache, name)
+	if err != nil {
+		return "", err
+	}
+	return manifestPath, nil
+}
+
 // WriteManifestCache persists a verified manifest+bundle pair into the
 // per-registry cache layout that EnrichFromMOATManifests reads. Without
 // this call, a successful Sync leaves no observable trust state — the

--- a/cli/internal/moat/producer_write_test.go
+++ b/cli/internal/moat/producer_write_test.go
@@ -57,6 +57,36 @@ func TestWriteManifestCache_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestManifestCachePath(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	name := "example-reg"
+
+	got, err := ManifestCachePath(cacheDir, name)
+	if err != nil {
+		t.Fatalf("ManifestCachePath: %v", err)
+	}
+	absCache, err := filepath.Abs(cacheDir)
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	want := filepath.Join(absCache, manifestCacheDirName, manifestCacheSubDir, name, manifestFileName)
+	if got != want {
+		t.Fatalf("ManifestCachePath() = %q; want %q", got, want)
+	}
+}
+
+func TestManifestCachePath_InvalidName(t *testing.T) {
+	t.Parallel()
+	_, err := ManifestCachePath(t.TempDir(), "../evil")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not valid") {
+		t.Fatalf("error %q does not contain not valid", err.Error())
+	}
+}
+
 func TestWriteManifestCache_OverwriteAtomic(t *testing.T) {
 	t.Parallel()
 	cacheDir := t.TempDir()

--- a/cli/internal/regdiff/git.go
+++ b/cli/internal/regdiff/git.go
@@ -1,0 +1,227 @@
+package regdiff
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type gitPathStatus struct {
+	path   string
+	status byte
+}
+
+type itemKey struct {
+	Type string
+	Name string
+}
+
+type itemAccum struct {
+	key      itemKey
+	dir      string
+	paths    []string
+	statuses []byte
+}
+
+// GitDiff computes the item-level change set between two commits of a git
+// registry checkout at repoDir. items describes the CURRENT checkout's
+// items; knownTypeDirs lists top-level content-type directory names
+// (e.g. "skills", "rules") used to attribute paths of items that no
+// longer exist in the current checkout.
+func GitDiff(registry, repoDir, oldHead, newHead string, items []ItemRef, knownTypeDirs []string) (Diff, error) {
+	diff := Diff{
+		Registry: registry,
+		OldRef:   oldHead,
+		NewRef:   newHead,
+		UpToDate: oldHead == newHead && oldHead != "",
+	}
+	if oldHead == "" || oldHead == newHead {
+		return diff, nil
+	}
+
+	out, err := runGit(repoDir, "diff", "--name-status", "--no-renames", oldHead, newHead)
+	if err != nil {
+		return diff, fmt.Errorf("git diff %s..%s: %w", oldHead, newHead, err)
+	}
+
+	knownTypes := make(map[string]bool, len(knownTypeDirs))
+	for _, dir := range knownTypeDirs {
+		knownTypes[dir] = true
+	}
+
+	current := make(map[itemKey]*itemAccum)
+	fallback := make(map[itemKey]*itemAccum)
+	var otherPaths []string
+
+	for _, ps := range parseNameStatus(out) {
+		if item, ok := longestItemMatch(ps.path, items); ok {
+			key := itemKey{Type: item.Type, Name: item.Name}
+			acc := current[key]
+			if acc == nil {
+				acc = &itemAccum{key: key, dir: item.Dir}
+				current[key] = acc
+			}
+			acc.paths = append(acc.paths, ps.path)
+			acc.statuses = append(acc.statuses, ps.status)
+			continue
+		}
+
+		if key, dir, ok := fallbackItem(ps.path, knownTypes); ok {
+			acc := fallback[key]
+			if acc == nil {
+				acc = &itemAccum{key: key, dir: dir}
+				fallback[key] = acc
+			}
+			acc.paths = append(acc.paths, ps.path)
+			acc.statuses = append(acc.statuses, ps.status)
+			continue
+		}
+
+		otherPaths = append(otherPaths, ps.path)
+	}
+
+	for _, acc := range current {
+		kind := KindModified
+		if allStatus(acc.statuses, 'A') {
+			exists, err := gitDirExists(repoDir, oldHead, acc.dir)
+			if err != nil {
+				return diff, err
+			}
+			if !exists {
+				kind = KindAdded
+			}
+		}
+		diff.Changes = append(diff.Changes, itemChangeFromAccum(acc, kind))
+	}
+
+	for _, acc := range fallback {
+		kind := KindModified
+		if allStatus(acc.statuses, 'D') {
+			exists, err := gitDirExists(repoDir, newHead, acc.dir)
+			if err != nil {
+				return diff, err
+			}
+			if !exists {
+				kind = KindRemoved
+			}
+		}
+		diff.Changes = append(diff.Changes, itemChangeFromAccum(acc, kind))
+	}
+
+	sort.Slice(diff.Changes, func(i, j int) bool {
+		if diff.Changes[i].Type != diff.Changes[j].Type {
+			return diff.Changes[i].Type < diff.Changes[j].Type
+		}
+		return diff.Changes[i].Name < diff.Changes[j].Name
+	})
+	sort.Strings(otherPaths)
+	diff.OtherPaths = otherPaths
+
+	return diff, nil
+}
+
+func parseNameStatus(out []byte) []gitPathStatus {
+	var parsed []gitPathStatus
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if line == "" {
+			continue
+		}
+		statusText, pathText, ok := strings.Cut(line, "\t")
+		if !ok || statusText == "" || pathText == "" {
+			continue
+		}
+		status := statusText[0]
+		if status != 'A' && status != 'M' && status != 'D' {
+			status = 'M'
+		}
+		parsed = append(parsed, gitPathStatus{path: pathText, status: status})
+	}
+	return parsed
+}
+
+func longestItemMatch(changedPath string, items []ItemRef) (ItemRef, bool) {
+	var matched ItemRef
+	longest := -1
+	for _, item := range items {
+		dir := cleanRelDir(item.Dir)
+		if dir == "" {
+			continue
+		}
+		if changedPath == dir || strings.HasPrefix(changedPath, dir+"/") {
+			if len(dir) > longest {
+				matched = item
+				matched.Dir = dir
+				longest = len(dir)
+			}
+		}
+	}
+	return matched, longest >= 0
+}
+
+func fallbackItem(changedPath string, knownTypes map[string]bool) (itemKey, string, bool) {
+	segments := strings.Split(changedPath, "/")
+	if len(segments) < 2 || !knownTypes[segments[0]] {
+		return itemKey{}, "", false
+	}
+	key := itemKey{Type: segments[0], Name: segments[1]}
+	return key, segments[0] + "/" + segments[1], true
+}
+
+func itemChangeFromAccum(acc *itemAccum, kind Kind) ItemChange {
+	paths := append([]string(nil), acc.paths...)
+	sort.Strings(paths)
+	return ItemChange{
+		Type:  acc.key.Type,
+		Name:  acc.key.Name,
+		Kind:  kind,
+		Paths: paths,
+	}
+}
+
+func allStatus(statuses []byte, want byte) bool {
+	if len(statuses) == 0 {
+		return false
+	}
+	for _, status := range statuses {
+		if status != want {
+			return false
+		}
+	}
+	return true
+}
+
+func gitDirExists(repoDir, ref, dir string) (bool, error) {
+	out, err := runGit(repoDir, "ls-tree", "-d", ref, "--", dir)
+	if err != nil {
+		return false, fmt.Errorf("git ls-tree %s -- %s: %w", ref, dir, err)
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+func runGit(repoDir string, args ...string) ([]byte, error) {
+	allArgs := append([]string{"-C", repoDir}, args...)
+	cmd := exec.Command("git", allArgs...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return nil, fmt.Errorf("%w: %s", err, msg)
+		}
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}
+
+func cleanRelDir(dir string) string {
+	dir = strings.TrimSpace(dir)
+	dir = strings.TrimPrefix(dir, "./")
+	return strings.Trim(dir, "/")
+}

--- a/cli/internal/regdiff/git_test.go
+++ b/cli/internal/regdiff/git_test.go
@@ -1,0 +1,176 @@
+package regdiff
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestGitDiff_FullDiff(t *testing.T) {
+	t.Parallel()
+	repoDir, commit1, commit2 := buildGitScenario(t)
+
+	items := []ItemRef{
+		{Type: "skills", Name: "alpha", Dir: "skills/alpha"},
+		{Type: "skills", Name: "delta", Dir: "skills/delta"},
+		{Type: "rules", Name: "gamma", Dir: "rules/gamma"},
+	}
+	got, err := GitDiff("example", repoDir, commit1, commit2, items, []string{"skills", "rules"})
+	if err != nil {
+		t.Fatalf("GitDiff: %v", err)
+	}
+
+	want := Diff{
+		Registry: "example",
+		OldRef:   commit1,
+		NewRef:   commit2,
+		Changes: []ItemChange{
+			{Type: "skills", Name: "alpha", Kind: KindModified, Paths: []string{"skills/alpha/SKILL.md"}},
+			{Type: "skills", Name: "beta", Kind: KindRemoved, Paths: []string{"skills/beta/SKILL.md"}},
+			{Type: "skills", Name: "delta", Kind: KindAdded, Paths: []string{"skills/delta/SKILL.md"}},
+		},
+		OtherPaths: []string{"README.md"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GitDiff() mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestGitDiff_UpToDate(t *testing.T) {
+	t.Parallel()
+
+	got, err := GitDiff("example", filepath.Join(t.TempDir(), "missing"), "abc123", "abc123", nil, nil)
+	if err != nil {
+		t.Fatalf("GitDiff: %v", err)
+	}
+	want := Diff{
+		Registry: "example",
+		OldRef:   "abc123",
+		NewRef:   "abc123",
+		UpToDate: true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GitDiff() mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestGitDiff_FirstSyncNoBaseline(t *testing.T) {
+	t.Parallel()
+
+	got, err := GitDiff("example", filepath.Join(t.TempDir(), "missing"), "", "new-head", nil, nil)
+	if err != nil {
+		t.Fatalf("GitDiff: %v", err)
+	}
+	want := Diff{
+		Registry: "example",
+		OldRef:   "",
+		NewRef:   "new-head",
+		UpToDate: false,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GitDiff() mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestGitDiff_BadSHA(t *testing.T) {
+	t.Parallel()
+	repoDir, commit1, _ := buildGitScenario(t)
+
+	_, err := GitDiff("example", repoDir, commit1, "not-a-sha", nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "git diff") {
+		t.Fatalf("error %q does not mention git diff", err.Error())
+	}
+}
+
+func TestGitDiff_RenameUsesDeleteAndAdd(t *testing.T) {
+	t.Parallel()
+	repoDir, _, commit2 := buildGitScenario(t)
+
+	if err := os.Rename(filepath.Join(repoDir, "skills", "delta"), filepath.Join(repoDir, "skills", "epsilon")); err != nil {
+		t.Fatalf("rename delta to epsilon: %v", err)
+	}
+	commitAll(t, repoDir, "rename delta")
+	commit3 := gitIn(t, repoDir, "rev-parse", "HEAD")
+
+	items := []ItemRef{
+		{Type: "skills", Name: "alpha", Dir: "skills/alpha"},
+		{Type: "skills", Name: "epsilon", Dir: "skills/epsilon"},
+		{Type: "rules", Name: "gamma", Dir: "rules/gamma"},
+	}
+	got, err := GitDiff("example", repoDir, commit2, commit3, items, []string{"skills", "rules"})
+	if err != nil {
+		t.Fatalf("GitDiff: %v", err)
+	}
+
+	wantChanges := []ItemChange{
+		{Type: "skills", Name: "delta", Kind: KindRemoved, Paths: []string{"skills/delta/SKILL.md"}},
+		{Type: "skills", Name: "epsilon", Kind: KindAdded, Paths: []string{"skills/epsilon/SKILL.md"}},
+	}
+	if !reflect.DeepEqual(got.Changes, wantChanges) {
+		t.Fatalf("Changes mismatch:\n got: %#v\nwant: %#v", got.Changes, wantChanges)
+	}
+	if len(got.OtherPaths) != 0 {
+		t.Fatalf("OtherPaths = %#v; want empty", got.OtherPaths)
+	}
+}
+
+func buildGitScenario(t *testing.T) (repoDir, commit1, commit2 string) {
+	t.Helper()
+	repoDir = t.TempDir()
+	gitIn(t, repoDir, "init")
+	gitIn(t, repoDir, "config", "user.email", "test@example.com")
+	gitIn(t, repoDir, "config", "user.name", "Test User")
+
+	writeRepoFile(t, repoDir, "skills/alpha/SKILL.md", "alpha v1\n")
+	writeRepoFile(t, repoDir, "skills/beta/SKILL.md", "beta v1\n")
+	writeRepoFile(t, repoDir, "rules/gamma/rule.md", "gamma v1\n")
+	writeRepoFile(t, repoDir, "README.md", "# registry\n")
+	commitAll(t, repoDir, "initial")
+	commit1 = gitIn(t, repoDir, "rev-parse", "HEAD")
+
+	writeRepoFile(t, repoDir, "skills/alpha/SKILL.md", "alpha v2\n")
+	if err := os.RemoveAll(filepath.Join(repoDir, "skills", "beta")); err != nil {
+		t.Fatalf("remove beta: %v", err)
+	}
+	writeRepoFile(t, repoDir, "skills/delta/SKILL.md", "delta v1\n")
+	writeRepoFile(t, repoDir, "README.md", "# registry\n\nupdated\n")
+	commitAll(t, repoDir, "second")
+	commit2 = gitIn(t, repoDir, "rev-parse", "HEAD")
+
+	return repoDir, commit1, commit2
+}
+
+func writeRepoFile(t *testing.T, repoDir, rel, contents string) {
+	t.Helper()
+	path := filepath.Join(repoDir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func commitAll(t *testing.T, repoDir, message string) {
+	t.Helper()
+	gitIn(t, repoDir, "add", "-A")
+	gitIn(t, repoDir, "commit", "-m", message)
+}
+
+func gitIn(t *testing.T, repoDir string, args ...string) string {
+	t.Helper()
+	allArgs := append([]string{"-C", repoDir}, args...)
+	cmd := exec.Command("git", allArgs...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", allArgs, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/cli/internal/regdiff/moat.go
+++ b/cli/internal/regdiff/moat.go
@@ -1,0 +1,86 @@
+package regdiff
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/moat"
+)
+
+// MOATDiff computes the item-level change set between two MOAT manifests.
+// old may be nil (no cached baseline - first sync): returns a Diff with
+// UpToDate false and nil Changes.
+func MOATDiff(registry string, old, new *moat.Manifest) Diff {
+	diff := Diff{Registry: registry}
+	if old != nil {
+		diff.OldRef = old.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	if new != nil {
+		diff.NewRef = new.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	if old == nil {
+		return diff
+	}
+
+	oldItems := manifestItems(old)
+	newItems := manifestItems(new)
+
+	for key, newEntry := range newItems {
+		oldEntry, ok := oldItems[key]
+		switch {
+		case !ok:
+			diff.Changes = append(diff.Changes, ItemChange{Type: key.Type, Name: key.Name, Kind: KindAdded})
+		case oldEntry.ContentHash != newEntry.ContentHash:
+			diff.Changes = append(diff.Changes, ItemChange{Type: key.Type, Name: key.Name, Kind: KindModified})
+		}
+	}
+	for key := range oldItems {
+		if _, ok := newItems[key]; !ok {
+			diff.Changes = append(diff.Changes, ItemChange{Type: key.Type, Name: key.Name, Kind: KindRemoved})
+		}
+	}
+
+	sort.Slice(diff.Changes, func(i, j int) bool {
+		if diff.Changes[i].Type != diff.Changes[j].Type {
+			return diff.Changes[i].Type < diff.Changes[j].Type
+		}
+		return diff.Changes[i].Name < diff.Changes[j].Name
+	})
+	diff.UpToDate = len(diff.Changes) == 0
+	return diff
+}
+
+// LoadCachedManifest reads the previously synced manifest for a registry
+// from the MOAT manifest cache. A missing cache file returns (nil, nil) -
+// no baseline yet. Corrupt JSON returns an error.
+func LoadCachedManifest(cacheDir, name string) (*moat.Manifest, error) {
+	path, err := moat.ManifestCachePath(cacheDir, name)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read cached manifest: %w", err)
+	}
+	m, err := moat.ParseManifest(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse cached manifest: %w", err)
+	}
+	return m, nil
+}
+
+func manifestItems(m *moat.Manifest) map[itemKey]moat.ContentEntry {
+	items := make(map[itemKey]moat.ContentEntry)
+	if m == nil {
+		return items
+	}
+	for _, entry := range m.Content {
+		items[itemKey{Type: entry.Type, Name: entry.Name}] = entry
+	}
+	return items
+}

--- a/cli/internal/regdiff/moat_test.go
+++ b/cli/internal/regdiff/moat_test.go
@@ -1,0 +1,182 @@
+package regdiff
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/moat"
+)
+
+func TestMOATDiff_ChangeKinds(t *testing.T) {
+	t.Parallel()
+	oldManifest := testManifest(t, "2026-04-09T00:00:00Z", []moat.ContentEntry{
+		{Type: "skill", Name: "alpha", ContentHash: testHash("1")},
+		{Type: "skill", Name: "beta", ContentHash: testHash("2")},
+		{Type: "rules", Name: "gamma", ContentHash: testHash("3")},
+		{Type: "agent", Name: "same", ContentHash: testHash("4")},
+	})
+	newManifest := testManifest(t, "2026-04-10T00:00:00Z", []moat.ContentEntry{
+		{Type: "skill", Name: "alpha", ContentHash: testHash("9")},
+		{Type: "skill", Name: "beta", ContentHash: testHash("2")},
+		{Type: "agent", Name: "same", ContentHash: testHash("4")},
+		{Type: "command", Name: "delta", ContentHash: testHash("5")},
+	})
+
+	got := MOATDiff("example", oldManifest, newManifest)
+	want := Diff{
+		Registry: "example",
+		OldRef:   "2026-04-09T00:00:00Z",
+		NewRef:   "2026-04-10T00:00:00Z",
+		Changes: []ItemChange{
+			{Type: "command", Name: "delta", Kind: KindAdded},
+			{Type: "rules", Name: "gamma", Kind: KindRemoved},
+			{Type: "skill", Name: "alpha", Kind: KindModified},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MOATDiff() mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+	for _, change := range got.Changes {
+		if change.Paths != nil {
+			t.Fatalf("change %s/%s Paths = %#v; want nil", change.Type, change.Name, change.Paths)
+		}
+	}
+}
+
+func TestMOATDiff_FirstSyncNoBaseline(t *testing.T) {
+	t.Parallel()
+	newManifest := testManifest(t, "2026-04-10T00:00:00Z", []moat.ContentEntry{
+		{Type: "skill", Name: "alpha", ContentHash: testHash("1")},
+	})
+
+	got := MOATDiff("example", nil, newManifest)
+	want := Diff{
+		Registry: "example",
+		OldRef:   "",
+		NewRef:   "2026-04-10T00:00:00Z",
+		UpToDate: false,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MOATDiff() mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestMOATDiff_NoDifferences(t *testing.T) {
+	t.Parallel()
+	oldManifest := testManifest(t, "2026-04-09T00:00:00Z", []moat.ContentEntry{
+		{Type: "skill", Name: "alpha", ContentHash: testHash("1")},
+	})
+	newManifest := testManifest(t, "2026-04-10T00:00:00Z", []moat.ContentEntry{
+		{Type: "skill", Name: "alpha", ContentHash: testHash("1")},
+	})
+
+	got := MOATDiff("example", oldManifest, newManifest)
+	if !got.UpToDate {
+		t.Fatalf("UpToDate = false; want true")
+	}
+	if len(got.Changes) != 0 {
+		t.Fatalf("Changes = %#v; want none", got.Changes)
+	}
+}
+
+func TestLoadCachedManifest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing", func(t *testing.T) {
+		t.Parallel()
+		got, err := LoadCachedManifest(t.TempDir(), "example")
+		if err != nil {
+			t.Fatalf("LoadCachedManifest: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("LoadCachedManifest() = %#v; want nil", got)
+		}
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		cacheDir := t.TempDir()
+		path, err := moat.ManifestCachePath(cacheDir, "example")
+		if err != nil {
+			t.Fatalf("ManifestCachePath: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir cache: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(minimalManifestJSON), 0o644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+
+		got, err := LoadCachedManifest(cacheDir, "example")
+		if err != nil {
+			t.Fatalf("LoadCachedManifest: %v", err)
+		}
+		if got == nil {
+			t.Fatal("LoadCachedManifest() = nil; want manifest")
+		}
+		if got.Name != "Example Registry" {
+			t.Fatalf("Name = %q; want Example Registry", got.Name)
+		}
+	})
+
+	t.Run("corrupt", func(t *testing.T) {
+		t.Parallel()
+		cacheDir := t.TempDir()
+		path, err := moat.ManifestCachePath(cacheDir, "example")
+		if err != nil {
+			t.Fatalf("ManifestCachePath: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir cache: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("{"), 0o644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+
+		_, err = LoadCachedManifest(cacheDir, "example")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func testManifest(t *testing.T, updatedAt string, content []moat.ContentEntry) *moat.Manifest {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, updatedAt)
+	if err != nil {
+		t.Fatalf("parse time: %v", err)
+	}
+	return &moat.Manifest{
+		UpdatedAt: ts,
+		Content:   content,
+	}
+}
+
+func testHash(digit string) string {
+	return "sha256:" + stringsRepeat(digit, 64)
+}
+
+func stringsRepeat(s string, count int) string {
+	out := ""
+	for i := 0; i < count; i++ {
+		out += s
+	}
+	return out
+}
+
+const minimalManifestJSON = `{
+  "schema_version": 1,
+  "manifest_uri": "https://example.com/moat-manifest.json",
+  "name": "Example Registry",
+  "operator": "Example Operator",
+  "updated_at": "2026-04-09T00:00:00Z",
+  "registry_signing_profile": {
+    "issuer": "https://token.actions.githubusercontent.com",
+    "subject": "repo:owner/repo:ref:refs/heads/main"
+  },
+  "content": [],
+  "revocations": []
+}`

--- a/cli/internal/regdiff/regdiff.go
+++ b/cli/internal/regdiff/regdiff.go
@@ -1,0 +1,36 @@
+package regdiff
+
+// Kind classifies how an item changed between two registry states.
+type Kind string
+
+const (
+	KindAdded    Kind = "added"
+	KindModified Kind = "modified"
+	KindRemoved  Kind = "removed"
+)
+
+// ItemChange is one content item's change between two registry states.
+type ItemChange struct {
+	Type  string // content type dir/slug, e.g. "skills", or MOAT type "skill"
+	Name  string // item name
+	Kind  Kind
+	Paths []string // changed file paths relative to repo root (git registries); nil for MOAT
+}
+
+// Diff is the full change set for one registry between two refs.
+type Diff struct {
+	Registry   string       // registry name
+	OldRef     string       // old git SHA or old manifest UpdatedAt (RFC3339); "" when no baseline
+	NewRef     string       // new git SHA or new manifest UpdatedAt (RFC3339)
+	UpToDate   bool         // true when OldRef == NewRef (nothing to diff)
+	Changes    []ItemChange // sorted by (Type, Name)
+	OtherPaths []string     // changed paths not attributable to any item (git only), sorted
+}
+
+// ItemRef locates one item inside a git registry checkout. Callers build
+// this from their catalog scan of the CURRENT (new) checkout.
+type ItemRef struct {
+	Type string // content type, e.g. "skills"
+	Name string
+	Dir  string // item directory relative to repo root, e.g. "skills/my-skill"
+}


### PR DESCRIPTION
## Summary
- New `cli/internal/regdiff` package: the diff engine behind upcoming registry change reporting (#542 item 6).
- `GitDiff(registry, repoDir, oldHead, newHead, items, knownTypeDirs)` runs `git diff --name-status --no-renames` between the SHAs recorded by the 6a sync bookkeeping, attributes changed paths to items by longest item-dir prefix, classifies added/modified via `git ls-tree` existence at the old head, recovers removed items through a `<typeDir>/<name>` convention fallback, and reports unattributable paths in `OtherPaths`.
- `MOATDiff(registry, old, new)` diffs two MOAT manifests keyed by (type, name): set difference for added/removed, `ContentHash` inequality for modified.
- `LoadCachedManifest(cacheDir, name)` reads the previously synced manifest as the baseline (missing cache = first sync, no diff), using a new exported `moat.ManifestCachePath` that shares the existing validation + traversal guard with `WriteManifestCache`.
- Engine only: no CLI or TUI wiring (that is the next chunk, `registry status`).

## Testing
- New `regdiff` tests: real git fixture repos (add/modify/delete/rename scenarios), up-to-date and no-baseline paths, bad-SHA error; pure-struct MOAT diff tests plus `LoadCachedManifest` missing/corrupt cases.
- `moat.ManifestCachePath` path and invalid-name tests.
- Full `go test ./...` suite green locally (40 packages), `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)