### PR TITLE
feat(installstore): record install state on install/uninstall/remove (#542 item 2b-ii)

### DIFF
--- a/cli/cmd/syllago/add_cmd.go
+++ b/cli/cmd/syllago/add_cmd.go
@@ -318,8 +318,11 @@ func chainInstallAfterAdd(results []add.AddResult, toSlug, globalDir, projectRoo
 
 	for _, item := range globalCat.Items {
 		if addedSet[nameType{item.Name, item.Type}] {
-			if _, err := installer.Install(item, *prov, globalDir, installer.MethodSymlink, ""); err != nil {
+			placement, err := installer.Install(item, *prov, globalDir, installer.MethodSymlink, "")
+			if err != nil {
 				fmt.Fprintf(output.ErrWriter, "Warning: install %s to %s: %v\n", item.Name, toSlug, err)
+			} else {
+				recordInstallBookkeeping(item, toSlug, placement)
 			}
 		}
 	}

--- a/cli/cmd/syllago/install_cmd.go
+++ b/cli/cmd/syllago/install_cmd.go
@@ -382,6 +382,7 @@ func installToProvider(
 			}
 			continue
 		}
+		recordInstallBookkeeping(item, toSlug, placement)
 		desc := placement.String()
 
 		// Check for portability warnings by running the converter.

--- a/cli/cmd/syllago/installrecord.go
+++ b/cli/cmd/syllago/installrecord.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+)
+
+// recordInstallBookkeeping best-effort-records a successful install. Never
+// fails the install: any error is reported as a warning on stderr.
+func recordInstallBookkeeping(item catalog.ContentItem, provSlug string, pl installer.Placement) {
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		warnInstallRecord(err)
+		return
+	}
+	if err := installstore.RecordInstall(storePath, installRecordCoord(item), item.Path, installRecordPlacement(provSlug, pl), time.Now()); err != nil {
+		warnInstallRecord(err)
+	}
+}
+
+// recordUninstallBookkeeping mirrors recordInstallBookkeeping for uninstalls.
+func recordUninstallBookkeeping(item catalog.ContentItem, provSlug string, pl installer.Placement) {
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		warnInstallRecord(err)
+		return
+	}
+	if err := installstore.RecordUninstall(storePath, installRecordCoord(item), installRecordPlacement(provSlug, pl), time.Now()); err != nil {
+		warnInstallRecord(err)
+	}
+}
+
+// forgetInstallRecord drops the whole record after a library removal.
+func forgetInstallRecord(item catalog.ContentItem) {
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		warnInstallRecord(err)
+		return
+	}
+	if err := installstore.ForgetRecord(storePath, installRecordCoord(item)); err != nil {
+		warnInstallRecord(err)
+	}
+}
+
+func installRecordCoord(item catalog.ContentItem) installstore.Coord {
+	return installstore.Coord{
+		Registry: item.Registry,
+		Type:     string(item.Type),
+		Name:     item.Name,
+	}
+}
+
+func installRecordPlacement(provSlug string, pl installer.Placement) installstore.PlacementInput {
+	return installstore.PlacementInput{
+		Provider:  provSlug,
+		Mechanism: installstore.Mechanism(pl.Mechanism),
+		Path:      pl.Path,
+		Keys:      pl.Keys,
+	}
+}
+
+func warnInstallRecord(err error) {
+	fmt.Fprintf(output.ErrWriter, "warning: could not record install state: %v\n", err)
+}

--- a/cli/cmd/syllago/installrecord_test.go
+++ b/cli/cmd/syllago/installrecord_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+)
+
+func TestInstallCommandRecordsInstallState(t *testing.T) {
+	globalDir := setupGlobalLibrary(t)
+	withGlobalLibrary(t, globalDir)
+	configDir := withInstallRecordConfigDir(t)
+	withFakeRepoRoot(t, t.TempDir())
+	output.SetForTest(t)
+
+	installBase := t.TempDir()
+	addTestProviderOpts(t, "record-install-provider", "Record Install Provider", installBase, true)
+	resetInstallRecordInstallFlags(t)
+	installCmd.Flags().Set("to", "record-install-provider")
+
+	if err := installCmd.RunE(installCmd, []string{"my-skill"}); err != nil {
+		t.Fatalf("install command failed: %v", err)
+	}
+
+	store := mustLoadInstallRecordStore(t, configDir)
+	coord := installstore.Coord{Registry: "", Type: string(catalog.Skills), Name: "my-skill"}
+	rec := store.Find(coord)
+	if rec == nil {
+		t.Fatal("install record missing")
+	}
+	wantLibraryPath := filepath.Join(globalDir, "skills", "my-skill")
+	if rec.LibraryPath != wantLibraryPath {
+		t.Fatalf("LibraryPath = %s, want %s", rec.LibraryPath, wantLibraryPath)
+	}
+	if rec.ContentHash == "" {
+		t.Fatal("ContentHash is empty")
+	}
+	if len(rec.Placements) != 1 {
+		t.Fatalf("Placements length = %d, want 1", len(rec.Placements))
+	}
+	got := rec.Placements[0]
+	wantPath := filepath.Join(installBase, "skills", "my-skill")
+	if got.Provider != "record-install-provider" || got.Mechanism != installstore.MechanismSymlink || got.Path != wantPath || got.Key != "" {
+		t.Fatalf("placement = %#v, want provider record-install-provider symlink path %s", got, wantPath)
+	}
+}
+
+func TestUninstallCommandRemovesInstallStatePlacement(t *testing.T) {
+	globalDir := setupGlobalLibrary(t)
+	withGlobalLibrary(t, globalDir)
+	configDir := withInstallRecordConfigDir(t)
+	withFakeRepoRoot(t, t.TempDir())
+	output.SetForTest(t)
+
+	installBase := t.TempDir()
+	addTestProviderOpts(t, "record-uninstall-provider", "Record Uninstall Provider", installBase, true)
+	targetPath := filepath.Join(installBase, "skills", "my-skill")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll target dir: %v", err)
+	}
+	libraryPath := filepath.Join(globalDir, "skills", "my-skill")
+	if err := os.Symlink(libraryPath, targetPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	coord := installstore.Coord{Registry: "", Type: string(catalog.Skills), Name: "my-skill"}
+	storePath := filepath.Join(configDir, "installs.json")
+	if err := installstore.RecordInstall(storePath, coord, libraryPath, installstore.PlacementInput{
+		Provider:  "record-uninstall-provider",
+		Mechanism: installstore.MechanismSymlink,
+		Path:      targetPath,
+	}, time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("seed RecordInstall: %v", err)
+	}
+
+	resetInstallRecordUninstallFlags(t)
+	uninstallCmd.Flags().Set("from", "record-uninstall-provider")
+	uninstallCmd.Flags().Set("force", "true")
+
+	if err := uninstallCmd.RunE(uninstallCmd, []string{"my-skill"}); err != nil {
+		t.Fatalf("uninstall command failed: %v", err)
+	}
+
+	store := mustLoadInstallRecordStore(t, configDir)
+	if rec := store.Find(coord); rec != nil {
+		t.Fatalf("record after uninstall = %#v, want pruned record", rec)
+	}
+}
+
+func withInstallRecordConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := config.GlobalDirOverride
+	config.GlobalDirOverride = dir
+	t.Cleanup(func() { config.GlobalDirOverride = orig })
+	return dir
+}
+
+func resetInstallRecordInstallFlags(t *testing.T) {
+	t.Helper()
+	installCmd.Flags().Set("to", "")
+	installCmd.Flags().Set("to-all", "false")
+	installCmd.Flags().Set("type", "")
+	installCmd.Flags().Set("method", "symlink")
+	installCmd.Flags().Set("all", "false")
+	installCmd.Flags().Set("dry-run", "false")
+	installCmd.Flags().Set("base-dir", "")
+	installCmd.Flags().Set("no-input", "false")
+	installCmd.Flags().Set("hook-scanner", "")
+	installCmd.Flags().Set("force", "false")
+	installCmd.Flags().Set("on-clean", "")
+	installCmd.Flags().Set("on-modified", "")
+	t.Cleanup(func() {
+		installCmd.Flags().Set("to", "")
+		installCmd.Flags().Set("to-all", "false")
+		installCmd.Flags().Set("type", "")
+		installCmd.Flags().Set("method", "symlink")
+		installCmd.Flags().Set("all", "false")
+		installCmd.Flags().Set("dry-run", "false")
+		installCmd.Flags().Set("base-dir", "")
+		installCmd.Flags().Set("no-input", "false")
+		installCmd.Flags().Set("hook-scanner", "")
+		installCmd.Flags().Set("force", "false")
+		installCmd.Flags().Set("on-clean", "")
+		installCmd.Flags().Set("on-modified", "")
+	})
+}
+
+func resetInstallRecordUninstallFlags(t *testing.T) {
+	t.Helper()
+	uninstallCmd.Flags().Set("from", "")
+	uninstallCmd.Flags().Set("force", "false")
+	uninstallCmd.Flags().Set("dry-run", "false")
+	uninstallCmd.Flags().Set("no-input", "false")
+	uninstallCmd.Flags().Set("type", "")
+	t.Cleanup(func() {
+		uninstallCmd.Flags().Set("from", "")
+		uninstallCmd.Flags().Set("force", "false")
+		uninstallCmd.Flags().Set("dry-run", "false")
+		uninstallCmd.Flags().Set("no-input", "false")
+		uninstallCmd.Flags().Set("type", "")
+	})
+}
+
+func mustLoadInstallRecordStore(t *testing.T, configDir string) *installstore.Store {
+	t.Helper()
+	store, err := installstore.Load(filepath.Join(configDir, "installs.json"))
+	if err != nil {
+		t.Fatalf("Load install store: %v", err)
+	}
+	return store
+}

--- a/cli/cmd/syllago/remove_cmd.go
+++ b/cli/cmd/syllago/remove_cmd.go
@@ -155,9 +155,11 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		if installer.CheckStatus(item, prov, globalDir) != installer.StatusInstalled {
 			continue
 		}
-		if _, err := installer.Uninstall(item, prov, globalDir); err != nil {
+		placement, err := installer.Uninstall(item, prov, globalDir)
+		if err != nil {
 			fmt.Fprintf(output.ErrWriter, "  warning: failed to uninstall from %s: %s\n", prov.Name, err)
 		} else {
+			recordUninstallBookkeeping(item, prov.Slug, placement)
 			uninstalledFrom = append(uninstalledFrom, prov.Name)
 		}
 	}
@@ -182,6 +184,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	if err := catalog.RemoveLibraryItem(item.Path); err != nil {
 		return output.NewStructuredErrorDetail(output.ErrSystemIO, "removing from library failed", "Check filesystem permissions", err.Error())
 	}
+	forgetInstallRecord(item)
 
 	if output.JSON {
 		output.Print(removeResult{

--- a/cli/cmd/syllago/uninstall_cmd.go
+++ b/cli/cmd/syllago/uninstall_cmd.go
@@ -173,6 +173,7 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(output.ErrWriter, "  warning: failed to uninstall from %s: %s\n", prov.Name, err)
 			continue
 		}
+		recordUninstallBookkeeping(*item, prov.Slug, placement)
 		desc := placement.String()
 		removedFrom = append(removedFrom, prov.Name)
 		if !output.JSON && !output.Quiet {

--- a/cli/internal/installstore/record.go
+++ b/cli/internal/installstore/record.go
@@ -1,0 +1,146 @@
+package installstore
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+// PlacementInput describes one installer action to record. Keys carries the
+// JSON keys touched by a merge install (one stored Placement per key); an
+// empty Keys means a single placement with no key (symlink/copy).
+type PlacementInput struct {
+	Provider  string
+	Mechanism Mechanism
+	Path      string
+	Keys      []string
+}
+
+// RecordInstall loads the store at storePath, upserts the record for c, adds
+// one placement per key (or one keyless placement), and saves. contentHash
+// is computed from libraryPath via HashContent; a hash failure is returned
+// as an error without writing. now stamps InstalledAt/UpdatedAt.
+func RecordInstall(storePath string, c Coord, libraryPath string, p PlacementInput, now time.Time) error {
+	contentHash, err := HashContent(libraryPath)
+	if err != nil {
+		return fmt.Errorf("hashing install content: %w", err)
+	}
+
+	s, err := Load(storePath)
+	if err != nil {
+		return fmt.Errorf("loading install store: %w", err)
+	}
+
+	rec := Record{
+		Coord:       c,
+		ContentHash: contentHash,
+		LibraryPath: libraryPath,
+		UpdatedAt:   now,
+	}
+	if existing := s.Find(c); existing != nil {
+		rec.Placements = append([]Placement(nil), existing.Placements...)
+		rec.MOAT = cloneMOAT(existing.MOAT)
+	} else {
+		rec.InstalledAt = now
+	}
+	s.Upsert(rec)
+
+	keys := placementKeys(p)
+	for _, key := range keys {
+		placement := Placement{
+			Provider:    p.Provider,
+			Mechanism:   p.Mechanism,
+			Path:        p.Path,
+			Key:         key,
+			InstalledAt: now,
+		}
+		if err := s.AddPlacement(c, placement); err != nil {
+			return fmt.Errorf("adding install placement: %w", err)
+		}
+	}
+
+	if err := s.Save(); err != nil {
+		return fmt.Errorf("saving install store: %w", err)
+	}
+	return nil
+}
+
+// RecordUninstall loads the store at storePath, removes the matching
+// placement(s) for c, and prunes the record entirely when no placements
+// remain. Missing store file, missing record, or missing placement are all
+// no-ops returning nil (idempotent). Saves only when something changed.
+func RecordUninstall(storePath string, c Coord, p PlacementInput, now time.Time) error {
+	if _, err := os.Stat(storePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("stat install store: %w", err)
+	}
+
+	s, err := Load(storePath)
+	if err != nil {
+		return fmt.Errorf("loading install store: %w", err)
+	}
+
+	changed := false
+	for _, key := range placementKeys(p) {
+		if s.RemovePlacement(c, p.Provider, p.Mechanism, p.Path, key) {
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+
+	if rec := s.Find(c); rec != nil {
+		if len(rec.Placements) == 0 {
+			s.Remove(c)
+		} else {
+			rec.UpdatedAt = now
+		}
+	}
+	if err := s.Save(); err != nil {
+		return fmt.Errorf("saving install store: %w", err)
+	}
+	return nil
+}
+
+// ForgetRecord deletes the record for c regardless of remaining placements
+// (used when the item is removed from the library). Missing store or record
+// is a no-op returning nil. Saves only when something changed.
+func ForgetRecord(storePath string, c Coord) error {
+	if _, err := os.Stat(storePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("stat install store: %w", err)
+	}
+
+	s, err := Load(storePath)
+	if err != nil {
+		return fmt.Errorf("loading install store: %w", err)
+	}
+	if !s.Remove(c) {
+		return nil
+	}
+	if err := s.Save(); err != nil {
+		return fmt.Errorf("saving install store: %w", err)
+	}
+	return nil
+}
+
+func placementKeys(p PlacementInput) []string {
+	if len(p.Keys) == 0 {
+		return []string{""}
+	}
+	return p.Keys
+}
+
+func cloneMOAT(m *MOATProvenance) *MOATProvenance {
+	if m == nil {
+		return nil
+	}
+	clone := *m
+	return &clone
+}

--- a/cli/internal/installstore/record_test.go
+++ b/cli/internal/installstore/record_test.go
@@ -1,0 +1,312 @@
+package installstore
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeContentFixture(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	writeFile(t, path, []byte("# "+name+"\n"))
+	return path
+}
+
+func assertStoreFileMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("store file exists or stat failed: %v", err)
+	}
+}
+
+func TestRecordInstallCreatesStoreAndKeylessPlacement(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "state", "installs.json")
+	libraryPath := writeContentFixture(t, dir, "skill.md")
+	coord := testCoord("core", "skills", "writer")
+	now := fixedTime(1)
+
+	err := RecordInstall(storePath, coord, libraryPath, PlacementInput{
+		Provider:  "codex",
+		Mechanism: MechanismSymlink,
+		Path:      "/tmp/home/.codex/skills/writer",
+	}, now)
+	if err != nil {
+		t.Fatalf("RecordInstall: %v", err)
+	}
+
+	s := mustLoadStore(t, storePath)
+	rec := s.Find(coord)
+	if rec == nil {
+		t.Fatal("record missing")
+	}
+	if rec.Coord != coord {
+		t.Fatalf("Coord = %#v, want %#v", rec.Coord, coord)
+	}
+	if rec.LibraryPath != libraryPath {
+		t.Fatalf("LibraryPath = %s, want %s", rec.LibraryPath, libraryPath)
+	}
+	if rec.ContentHash == "" {
+		t.Fatal("ContentHash is empty")
+	}
+	if rec.InstalledAt != now || rec.UpdatedAt != now {
+		t.Fatalf("times = installed %v updated %v, want %v", rec.InstalledAt, rec.UpdatedAt, now)
+	}
+	if len(rec.Placements) != 1 {
+		t.Fatalf("Placements length = %d, want 1", len(rec.Placements))
+	}
+	gotPlacement := rec.Placements[0]
+	wantPlacement := Placement{
+		Provider:    "codex",
+		Mechanism:   MechanismSymlink,
+		Path:        "/tmp/home/.codex/skills/writer",
+		InstalledAt: now,
+	}
+	if gotPlacement != wantPlacement {
+		t.Fatalf("placement = %#v, want %#v", gotPlacement, wantPlacement)
+	}
+}
+
+func TestRecordInstallKeyedPlacementReplacesIdentity(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "installs.json")
+	libraryPath := writeContentFixture(t, dir, "hook.json")
+	coord := testCoord("core", "hooks", "audit")
+	first := fixedTime(2)
+	second := fixedTime(3)
+	input := PlacementInput{
+		Provider:  "claude-code",
+		Mechanism: MechanismHookMerge,
+		Path:      "/tmp/home/.claude/settings.json",
+		Keys:      []string{"hooks.PreToolUse"},
+	}
+
+	if err := RecordInstall(storePath, coord, libraryPath, input, first); err != nil {
+		t.Fatalf("RecordInstall first: %v", err)
+	}
+	if err := RecordInstall(storePath, coord, libraryPath, input, second); err != nil {
+		t.Fatalf("RecordInstall second: %v", err)
+	}
+
+	rec := mustLoadStore(t, storePath).Find(coord)
+	if rec == nil {
+		t.Fatal("record missing")
+	}
+	if len(rec.Placements) != 1 {
+		t.Fatalf("Placements length = %d, want 1", len(rec.Placements))
+	}
+	got := rec.Placements[0]
+	if got.Key != "hooks.PreToolUse" {
+		t.Fatalf("Key = %q, want hooks.PreToolUse", got.Key)
+	}
+	if got.InstalledAt != second {
+		t.Fatalf("InstalledAt = %v, want replacement time %v", got.InstalledAt, second)
+	}
+}
+
+func TestRecordInstallSecondProviderPreservesInstallTimeAndBumpsUpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "installs.json")
+	libraryPath := writeContentFixture(t, dir, "writer.md")
+	coord := testCoord("core", "skills", "writer")
+	first := fixedTime(4)
+	second := fixedTime(5)
+
+	if err := RecordInstall(storePath, coord, libraryPath, PlacementInput{
+		Provider:  "codex",
+		Mechanism: MechanismSymlink,
+		Path:      "/tmp/codex/writer",
+	}, first); err != nil {
+		t.Fatalf("RecordInstall first: %v", err)
+	}
+	if err := RecordInstall(storePath, coord, libraryPath, PlacementInput{
+		Provider:  "claude-code",
+		Mechanism: MechanismSymlink,
+		Path:      "/tmp/claude/writer",
+	}, second); err != nil {
+		t.Fatalf("RecordInstall second: %v", err)
+	}
+
+	rec := mustLoadStore(t, storePath).Find(coord)
+	if rec == nil {
+		t.Fatal("record missing")
+	}
+	if rec.InstalledAt != first {
+		t.Fatalf("InstalledAt = %v, want preserved %v", rec.InstalledAt, first)
+	}
+	if rec.UpdatedAt != second {
+		t.Fatalf("UpdatedAt = %v, want %v", rec.UpdatedAt, second)
+	}
+	if got := providersOf(rec.Placements); !reflect.DeepEqual(got, []string{"claude-code", "codex"}) {
+		t.Fatalf("providers = %#v, want claude-code/codex", got)
+	}
+}
+
+func TestRecordInstallHashFailureLeavesStoreUntouched(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(t.TempDir(), "installs.json")
+	err := RecordInstall(storePath, testCoord("core", "skills", "missing"), filepath.Join(t.TempDir(), "missing.md"), PlacementInput{
+		Provider:  "codex",
+		Mechanism: MechanismSymlink,
+		Path:      "/tmp/codex/missing",
+	}, fixedTime(6))
+	if err == nil {
+		t.Fatal("RecordInstall missing libraryPath returned nil error")
+	}
+	assertStoreFileMissing(t, storePath)
+}
+
+func TestRecordUninstallRemovesPlacementAndPrunesEmptyRecord(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "installs.json")
+	libraryPath := writeContentFixture(t, dir, "writer.md")
+	coord := testCoord("core", "skills", "writer")
+
+	codex := PlacementInput{Provider: "codex", Mechanism: MechanismSymlink, Path: "/tmp/codex/writer"}
+	claude := PlacementInput{Provider: "claude-code", Mechanism: MechanismSymlink, Path: "/tmp/claude/writer"}
+	if err := RecordInstall(storePath, coord, libraryPath, codex, fixedTime(7)); err != nil {
+		t.Fatalf("RecordInstall codex: %v", err)
+	}
+	if err := RecordInstall(storePath, coord, libraryPath, claude, fixedTime(8)); err != nil {
+		t.Fatalf("RecordInstall claude: %v", err)
+	}
+
+	if err := RecordUninstall(storePath, coord, codex, fixedTime(9)); err != nil {
+		t.Fatalf("RecordUninstall first: %v", err)
+	}
+	rec := mustLoadStore(t, storePath).Find(coord)
+	if rec == nil {
+		t.Fatal("record pruned too early")
+	}
+	if got := providersOf(rec.Placements); !reflect.DeepEqual(got, []string{"claude-code"}) {
+		t.Fatalf("providers after first uninstall = %#v, want claude-code", got)
+	}
+
+	if err := RecordUninstall(storePath, coord, claude, fixedTime(10)); err != nil {
+		t.Fatalf("RecordUninstall last: %v", err)
+	}
+	if rec := mustLoadStore(t, storePath).Find(coord); rec != nil {
+		t.Fatalf("record after last placement removal = %#v, want nil", rec)
+	}
+}
+
+func TestRecordUninstallNoOpsDoNotCreateOrRewriteStore(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	input := PlacementInput{Provider: "codex", Mechanism: MechanismSymlink, Path: "/tmp/codex/writer"}
+
+	missingStore := filepath.Join(dir, "missing", "installs.json")
+	if err := RecordUninstall(missingStore, testCoord("core", "skills", "writer"), input, fixedTime(11)); err != nil {
+		t.Fatalf("RecordUninstall missing store: %v", err)
+	}
+	assertStoreFileMissing(t, missingStore)
+
+	storePath := filepath.Join(dir, "installs.json")
+	s := mustLoadStore(t, storePath)
+	s.Upsert(testRecord(testCoord("core", "skills", "other"), fixedTime(12)))
+	mustSaveStore(t, s)
+	before := mustReadFile(t, storePath)
+
+	if err := RecordUninstall(storePath, testCoord("core", "skills", "writer"), input, fixedTime(13)); err != nil {
+		t.Fatalf("RecordUninstall missing record: %v", err)
+	}
+	if after := mustReadFile(t, storePath); !reflect.DeepEqual(after, before) {
+		t.Fatalf("missing-record no-op rewrote store\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+
+	if err := RecordUninstall(storePath, testCoord("core", "skills", "other"), input, fixedTime(14)); err != nil {
+		t.Fatalf("RecordUninstall missing placement: %v", err)
+	}
+	if after := mustReadFile(t, storePath); !reflect.DeepEqual(after, before) {
+		t.Fatalf("missing-placement no-op rewrote store\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestForgetRecordRemovesRecordAndNoOpsWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "installs.json")
+	libraryPath := writeContentFixture(t, dir, "writer.md")
+	coord := testCoord("core", "skills", "writer")
+	input := PlacementInput{Provider: "codex", Mechanism: MechanismSymlink, Path: "/tmp/codex/writer"}
+	if err := RecordInstall(storePath, coord, libraryPath, input, fixedTime(15)); err != nil {
+		t.Fatalf("RecordInstall: %v", err)
+	}
+
+	if err := ForgetRecord(storePath, coord); err != nil {
+		t.Fatalf("ForgetRecord present: %v", err)
+	}
+	if rec := mustLoadStore(t, storePath).Find(coord); rec != nil {
+		t.Fatalf("record after ForgetRecord = %#v, want nil", rec)
+	}
+	before := mustReadFile(t, storePath)
+	if err := ForgetRecord(storePath, coord); err != nil {
+		t.Fatalf("ForgetRecord missing: %v", err)
+	}
+	if after := mustReadFile(t, storePath); !reflect.DeepEqual(after, before) {
+		t.Fatalf("missing ForgetRecord rewrote store\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+
+	missingStore := filepath.Join(dir, "none", "installs.json")
+	if err := ForgetRecord(missingStore, coord); err != nil {
+		t.Fatalf("ForgetRecord missing store: %v", err)
+	}
+	assertStoreFileMissing(t, missingStore)
+}
+
+func TestRecordInstallPreservesMOAT(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "installs.json")
+	libraryPath := writeContentFixture(t, dir, "writer.md")
+	coord := testCoord("core", "skills", "writer")
+	moat := &MOATProvenance{
+		ManifestURI: "https://example.com/moat.json",
+		SourceURI:   "https://example.com/writer.tgz",
+		TrustTier:   "SIGNED",
+		AttestedAt:  fixedTime(16),
+	}
+
+	s := mustLoadStore(t, storePath)
+	rec := testRecord(coord, fixedTime(17))
+	rec.MOAT = moat
+	s.Upsert(rec)
+	mustSaveStore(t, s)
+
+	if err := RecordInstall(storePath, coord, libraryPath, PlacementInput{
+		Provider:  "codex",
+		Mechanism: MechanismSymlink,
+		Path:      "/tmp/codex/writer",
+	}, fixedTime(18)); err != nil {
+		t.Fatalf("RecordInstall: %v", err)
+	}
+	got := mustLoadStore(t, storePath).Find(coord)
+	if got == nil {
+		t.Fatal("record missing")
+	}
+	if !reflect.DeepEqual(got.MOAT, moat) {
+		t.Fatalf("MOAT = %#v, want %#v", got.MOAT, moat)
+	}
+}
+
+func providersOf(placements []Placement) []string {
+	out := make([]string, 0, len(placements))
+	for _, placement := range placements {
+		out = append(out, placement.Provider)
+	}
+	return out
+}

--- a/cli/internal/installstore/store.go
+++ b/cli/internal/installstore/store.go
@@ -28,6 +28,7 @@ type Mechanism string
 
 const (
 	MechanismSymlink    Mechanism = "symlink"
+	MechanismCopy       Mechanism = "copy"
 	MechanismHookMerge  Mechanism = "hook_merge"
 	MechanismMCPMerge   Mechanism = "mcp_merge"
 	MechanismRuleAppend Mechanism = "rule_append"

--- a/cli/internal/tui/actions.go
+++ b/cli/internal/tui/actions.go
@@ -288,15 +288,18 @@ func (a App) doRemoveCmd(msg removeResultMsg) tea.Cmd {
 		var uninstalledFrom []string
 
 		for _, prov := range targetProviders {
-			if _, err := installer.Uninstall(item, prov, repoRoot); err != nil {
+			placement, err := installer.Uninstall(item, prov, repoRoot)
+			if err != nil {
 				continue // best-effort uninstall
 			}
+			recordTUIUninstallBookkeeping(item, prov.Slug, placement)
 			uninstalledFrom = append(uninstalledFrom, prov.Name)
 		}
 
 		if err := catalog.RemoveLibraryItem(item.Path); err != nil {
 			return removeDoneMsg{itemName: item.Name, err: fmt.Errorf("removing from library: %w", err)}
 		}
+		forgetTUIInstallRecord(item)
 
 		return removeDoneMsg{itemName: item.Name, uninstalledFrom: uninstalledFrom}
 	}
@@ -308,6 +311,7 @@ func (a App) doSimpleRemoveCmd(item catalog.ContentItem) tea.Cmd {
 		if err := catalog.RemoveLibraryItem(item.Path); err != nil {
 			return removeDoneMsg{itemName: item.Name, err: fmt.Errorf("removing: %w", err)}
 		}
+		forgetTUIInstallRecord(item)
 		return removeDoneMsg{itemName: item.Name}
 	}
 }
@@ -333,9 +337,11 @@ func (a App) doUninstallCmd(msg confirmResultMsg) tea.Cmd {
 		var uninstalledFrom []string
 		var lastErr error
 		for _, prov := range targetProviders {
-			if _, err := installer.Uninstall(item, prov, repoRoot); err != nil {
+			placement, err := installer.Uninstall(item, prov, repoRoot)
+			if err != nil {
 				lastErr = err
 			} else {
+				recordTUIUninstallBookkeeping(item, prov.Slug, placement)
 				uninstalledFrom = append(uninstalledFrom, prov.Name)
 			}
 		}
@@ -907,6 +913,7 @@ func (a App) doInstallCmd(msg installResultMsg) tea.Cmd {
 				err:          err,
 			}
 		}
+		recordTUIInstallBookkeeping(item, prov.Slug, placement)
 		return installDoneMsg{
 			itemName:     item.DisplayName,
 			providerName: prov.Name,
@@ -1147,12 +1154,13 @@ func (a App) doInstallAllCmd(msg installAllResultMsg) tea.Cmd {
 		var firstErr error
 		count := 0
 		for _, prov := range providers {
-			_, err := installer.Install(item, prov, projectRoot, installer.MethodSymlink, "")
+			placement, err := installer.Install(item, prov, projectRoot, installer.MethodSymlink, "")
 			if err != nil {
 				if firstErr == nil {
 					firstErr = err
 				}
 			} else {
+				recordTUIInstallBookkeeping(item, prov.Slug, placement)
 				count++
 			}
 		}

--- a/cli/internal/tui/installrecord.go
+++ b/cli/internal/tui/installrecord.go
@@ -1,0 +1,56 @@
+package tui
+
+import (
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+)
+
+func recordTUIInstallBookkeeping(item catalog.ContentItem, provSlug string, pl installer.Placement) {
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		return
+	}
+	// The TUI has no stable stderr surface mid-render; install-state
+	// bookkeeping is best-effort and must not disturb the Elm loop.
+	_ = installstore.RecordInstall(storePath, tuiInstallRecordCoord(item), item.Path, tuiInstallRecordPlacement(provSlug, pl), time.Now())
+}
+
+func recordTUIUninstallBookkeeping(item catalog.ContentItem, provSlug string, pl installer.Placement) {
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		return
+	}
+	// The TUI has no stable stderr surface mid-render; install-state
+	// bookkeeping is best-effort and must not disturb the Elm loop.
+	_ = installstore.RecordUninstall(storePath, tuiInstallRecordCoord(item), tuiInstallRecordPlacement(provSlug, pl), time.Now())
+}
+
+func forgetTUIInstallRecord(item catalog.ContentItem) {
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		return
+	}
+	// The TUI has no stable stderr surface mid-render; install-state
+	// bookkeeping is best-effort and must not disturb the Elm loop.
+	_ = installstore.ForgetRecord(storePath, tuiInstallRecordCoord(item))
+}
+
+func tuiInstallRecordCoord(item catalog.ContentItem) installstore.Coord {
+	return installstore.Coord{
+		Registry: item.Registry,
+		Type:     string(item.Type),
+		Name:     item.Name,
+	}
+}
+
+func tuiInstallRecordPlacement(provSlug string, pl installer.Placement) installstore.PlacementInput {
+	return installstore.PlacementInput{
+		Provider:  provSlug,
+		Mechanism: installstore.Mechanism(pl.Mechanism),
+		Path:      pl.Path,
+		Keys:      pl.Keys,
+	}
+}


### PR DESCRIPTION
## Summary
- Wires the `installstore` record store (from #547) into every CLI and TUI install/uninstall/remove path, so each successful operation now records or removes coordinate-keyed install state in `installs.json`.
- New `RecordInstall`/`RecordUninstall`/`ForgetRecord` helpers in `internal/installstore`: content-hash-first (hash failure returns error without writing), per-key placement fan-out for hook/MCP merges, MOAT provenance and original InstalledAt preserved on upsert, records pruned when the last placement is removed, and all no-ops are idempotent without rewriting the store file.
- Recording is strictly best-effort: CLI paths warn on stderr (`warning: could not record install state`), TUI paths drop errors silently to protect the Elm loop. No install/uninstall ever fails due to bookkeeping.
- Adds `MechanismCopy` to the mechanism enum.

Part of #542 (item 2: install-state record store — wiring chunk). MOAT install paths land in the next chunk; backfill of pre-existing installs comes after that.

## Test plan
- New `record_test.go`: keyless + keyed placements, identity replacement, InstalledAt preservation across providers, hash-failure atomicity, prune-on-last-placement, no-op idempotency (no store rewrite), MOAT preservation.
- New `installrecord_test.go`: cobra RunE integration tests for install and uninstall recording via `config.GlobalDirOverride`.
- Full suite green locally: `go build ./...` + `go test -count=1 ./...` (40 packages ok), gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
