### PR TITLE
feat(doctor): backfill install records for untracked provider links (#542 item 2d)

### DIFF
--- a/cli/cmd/syllago/doctor_cmd.go
+++ b/cli/cmd/syllago/doctor_cmd.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/doctor"
 	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
 	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
 	"github.com/spf13/cobra"
 )
@@ -28,7 +31,7 @@ pass, 1 if there are warnings, 2 if there are errors.`,
 }
 
 func init() {
-	doctorCmd.Flags().Bool("fix", false, "Repair broken provider links: re-link to library content or prune dead links")
+	doctorCmd.Flags().Bool("fix", false, "Repair broken provider links and backfill missing install records")
 	doctorCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 	rootCmd.AddCommand(doctorCmd)
 }
@@ -80,10 +83,12 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 }
 
 func runDoctorFix(force bool) error {
-	broken, err := doctor.BrokenProviderLinks()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return output.NewStructuredErrorDetail(output.ErrSystemHomedir, "cannot determine home directory", "Ensure $HOME is set in your environment", err.Error())
 	}
+	links := installer.ScanProviderLinks(provider.AllProviders, home, doctor.SyllagoOwnedRoots(home))
+	broken := doctorFixBrokenLinks(links)
 
 	libraryItems, err := doctorFixLibraryItems()
 	if err != nil {
@@ -91,7 +96,11 @@ func runDoctorFix(force bool) error {
 	}
 
 	actions := installer.PlanLinkFixes(broken, libraryItems)
-	if len(actions) == 0 {
+	storePath, plan := doctorFixBackfillPlan(links, libraryItems)
+	if len(actions) == 0 && len(plan.Entries) == 0 {
+		if len(plan.Legacy) > 0 {
+			fmt.Fprintf(output.Writer, "skipping %d legacy direct link(s) (not library-backed)\n", len(plan.Legacy))
+		}
 		fmt.Fprintln(output.Writer, "Nothing to fix.")
 		return nil
 	}
@@ -103,6 +112,12 @@ func runDoctorFix(force bool) error {
 		case installer.FixPrune:
 			fmt.Fprintf(output.Writer, "prune:  %s (target gone: %s)\n", action.Link.Path, action.Link.Target)
 		}
+	}
+	for _, entry := range plan.Entries {
+		fmt.Fprintf(output.Writer, "record: %s %s/%s\n", entry.Placement.Provider, entry.Coord.Type, entry.Coord.Name)
+	}
+	if len(plan.Legacy) > 0 {
+		fmt.Fprintf(output.Writer, "skipping %d legacy direct link(s) (not library-backed)\n", len(plan.Legacy))
 	}
 
 	if !force {
@@ -121,19 +136,45 @@ func runDoctorFix(force bool) error {
 		}
 	}
 
-	errs := installer.ApplyLinkFixes(actions)
-	if len(errs) > 0 {
-		for _, err := range errs {
-			fmt.Fprintln(output.ErrWriter, err)
+	linkErrs := installer.ApplyLinkFixes(actions)
+	for _, err := range linkErrs {
+		fmt.Fprintln(output.ErrWriter, err)
+	}
+
+	recorded := 0
+	if storePath != "" {
+		for _, entry := range plan.Entries {
+			if err := installstore.RecordInstall(storePath, entry.Coord, entry.LibraryPath, entry.Placement, time.Now()); err != nil {
+				fmt.Fprintln(output.ErrWriter, err)
+				continue
+			}
+			recorded++
 		}
+	}
+
+	if len(linkErrs) > 0 {
 		osExit(1)
 		return nil
 	}
 
 	relinked, pruned := countLinkFixKinds(actions)
-	fmt.Fprintf(output.Writer, "Fixed: %d relinked, %d pruned\n", relinked, pruned)
-	telemetry.Enrich("action_count", len(actions))
+	fmt.Fprintf(output.Writer, "Fixed: %d relinked, %d pruned, %d recorded\n", relinked, pruned, recorded)
+	telemetry.Enrich("action_count", len(actions)+len(plan.Entries))
 	return nil
+}
+
+func doctorFixBackfillPlan(links []installer.ScannedLink, libraryItems []catalog.ContentItem) (string, doctor.BackfillPlan) {
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		fmt.Fprintf(output.ErrWriter, "warning: could not plan install-record backfill: %v\n", err)
+		return "", doctor.BackfillPlan{}
+	}
+	store, err := installstore.Load(storePath)
+	if err != nil {
+		fmt.Fprintf(output.ErrWriter, "warning: could not plan install-record backfill: %v\n", err)
+		return "", doctor.BackfillPlan{}
+	}
+	return storePath, doctor.PlanRecordBackfill(links, store, catalog.GlobalContentDir(), libraryItems)
 }
 
 func doctorFixLibraryItems() ([]catalog.ContentItem, error) {
@@ -167,6 +208,16 @@ func countLinkFixKinds(actions []installer.FixAction) (relinked, pruned int) {
 		}
 	}
 	return relinked, pruned
+}
+
+func doctorFixBrokenLinks(links []installer.ScannedLink) []installer.ScannedLink {
+	var broken []installer.ScannedLink
+	for _, link := range links {
+		if link.Class == installer.LinkBroken {
+			broken = append(broken, link)
+		}
+	}
+	return broken
 }
 
 const (

--- a/cli/cmd/syllago/doctor_cmd_test.go
+++ b/cli/cmd/syllago/doctor_cmd_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
 )
@@ -534,6 +535,70 @@ func TestRunDoctorFix_NothingBroken(t *testing.T) {
 
 	if !strings.Contains(stdout.String(), "Nothing to fix.") {
 		t.Fatalf("output missing nothing-to-fix message:\n%s", stdout.String())
+	}
+}
+
+func TestRunDoctorFixForce_BackfillsInstallRecords(t *testing.T) {
+	resetDoctorFlags(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	contentDir := filepath.Join(home, ".syllago", "content")
+	configDir := withInstallRecordConfigDir(t)
+	withFakeRepoRoot(t, home)
+
+	skillDir := filepath.Join(contentDir, "skills", "registry-skill")
+	writeDoctorCmdFile(t, filepath.Join(skillDir, "SKILL.md"), "# Registry Skill\n")
+	writeDoctorCmdFile(t, filepath.Join(skillDir, ".syllago.yaml"), "format_version: 1\nid: registry-skill\nname: Registry Skill\nsource_type: registry\nsource_registry: acme/tools\n")
+
+	installDir := filepath.Join(home, ".claude", "skills")
+	linkPath := filepath.Join(installDir, "registry-skill")
+	symlinkDoctorCmd(t, skillDir, linkPath)
+
+	withDoctorCmdGlobals(t, home, contentDir, []provider.Provider{
+		doctorCmdProvider("claude-code", map[catalog.ContentType]string{catalog.Skills: installDir}),
+	})
+
+	stdout, _ := output.SetForTest(t)
+	captureOsExit(t)
+	mustSetDoctorFlag(t, "fix", "true")
+	mustSetDoctorFlag(t, "force", "true")
+
+	if err := doctorCmd.RunE(doctorCmd, nil); err != nil {
+		t.Fatalf("RunE first: %v", err)
+	}
+
+	firstOutput := stdout.String()
+	if !strings.Contains(firstOutput, "record: claude-code skills/registry-skill") {
+		t.Fatalf("output missing record plan:\n%s", firstOutput)
+	}
+	if !strings.Contains(firstOutput, "Fixed: 0 relinked, 0 pruned, 1 recorded") {
+		t.Fatalf("output missing recorded summary:\n%s", firstOutput)
+	}
+
+	store := mustLoadInstallRecordStore(t, configDir)
+	coord := installstore.Coord{Registry: "acme/tools", Type: string(catalog.Skills), Name: "registry-skill"}
+	rec := store.Find(coord)
+	if rec == nil {
+		t.Fatal("install record missing")
+	}
+	if rec.LibraryPath != skillDir {
+		t.Fatalf("LibraryPath = %s, want %s", rec.LibraryPath, skillDir)
+	}
+	if len(rec.Placements) != 1 {
+		t.Fatalf("Placements length = %d, want 1", len(rec.Placements))
+	}
+	placement := rec.Placements[0]
+	if placement.Provider != "claude-code" || placement.Mechanism != installstore.MechanismSymlink || placement.Path != linkPath {
+		t.Fatalf("placement = %#v, want claude-code symlink %s", placement, linkPath)
+	}
+
+	stdout.Reset()
+	if err := doctorCmd.RunE(doctorCmd, nil); err != nil {
+		t.Fatalf("RunE second: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Nothing to fix.") {
+		t.Fatalf("second output missing nothing-to-fix message:\n%s", stdout.String())
 	}
 }
 

--- a/cli/cmd/syllago/installrecord.go
+++ b/cli/cmd/syllago/installrecord.go
@@ -61,8 +61,12 @@ func forgetInstallRecord(item catalog.ContentItem) {
 }
 
 func installRecordCoord(item catalog.ContentItem) installstore.Coord {
+	registry := item.Registry
+	if registry == "" && item.Meta != nil && item.Meta.SourceType == "registry" && item.Meta.SourceRegistry != "" {
+		registry = item.Meta.SourceRegistry
+	}
 	return installstore.Coord{
-		Registry: item.Registry,
+		Registry: registry,
 		Type:     string(item.Type),
 		Name:     item.Name,
 	}

--- a/cli/cmd/syllago/installrecord_test.go
+++ b/cli/cmd/syllago/installrecord_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/metadata"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 )
 
@@ -90,6 +91,56 @@ func TestUninstallCommandRemovesInstallStatePlacement(t *testing.T) {
 	store := mustLoadInstallRecordStore(t, configDir)
 	if rec := store.Find(coord); rec != nil {
 		t.Fatalf("record after uninstall = %#v, want pruned record", rec)
+	}
+}
+
+func TestInstallRecordCoordRegistryFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		item         catalog.ContentItem
+		wantRegistry string
+	}{
+		{
+			name: "metadata registry used when item registry empty",
+			item: catalog.ContentItem{
+				Name: "writer",
+				Type: catalog.Skills,
+				Meta: &metadata.Meta{SourceType: "registry", SourceRegistry: "acme/tools"},
+			},
+			wantRegistry: "acme/tools",
+		},
+		{
+			name: "non registry source type leaves registry empty",
+			item: catalog.ContentItem{
+				Name: "writer",
+				Type: catalog.Skills,
+				Meta: &metadata.Meta{SourceType: "provider", SourceRegistry: "acme/tools"},
+			},
+		},
+		{
+			name: "explicit item registry wins",
+			item: catalog.ContentItem{
+				Name:     "writer",
+				Type:     catalog.Skills,
+				Registry: "explicit",
+				Meta:     &metadata.Meta{SourceType: "registry", SourceRegistry: "acme/tools"},
+			},
+			wantRegistry: "explicit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := installRecordCoord(tt.item)
+			if got.Registry != tt.wantRegistry {
+				t.Fatalf("Registry = %q, want %q", got.Registry, tt.wantRegistry)
+			}
+			if got.Type != string(tt.item.Type) || got.Name != tt.item.Name {
+				t.Fatalf("Coord = %#v, want type/name from item", got)
+			}
+		})
 	}
 }
 

--- a/cli/commands.json
+++ b/cli/commands.json
@@ -1110,7 +1110,7 @@
           "type": "bool",
           "default": null,
           "required": false,
-          "description": "Repair broken provider links: re-link to library content or prune dead links"
+          "description": "Repair broken provider links and backfill missing install records"
         },
         {
           "name": "--force",

--- a/cli/internal/doctor/doctor.go
+++ b/cli/internal/doctor/doctor.go
@@ -49,6 +49,7 @@ func Run(projectRoot string) Result {
 	checks = append(checks, CheckConfigWith(projectRoot))
 	checks = append(checks, CheckProviders())
 	checks = append(checks, CheckProviderLinks())
+	checks = append(checks, CheckInstallRecords())
 	if projectRoot != "" {
 		checks = append(checks, CheckSymlinks(projectRoot))
 		checks = append(checks, CheckContentDrift(projectRoot))
@@ -176,17 +177,6 @@ func SyllagoOwnedRoots(home string) []string {
 		roots = append(roots, cacheDir)
 	}
 	return roots
-}
-
-// BrokenProviderLinks scans provider install directories and returns only
-// broken syllago-owned symlinks.
-func BrokenProviderLinks() ([]installer.ScannedLink, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
-	}
-	links := installer.ScanProviderLinks(provider.AllProviders, home, SyllagoOwnedRoots(home))
-	return brokenProviderLinks(links), nil
 }
 
 func checkProviderLinksAt(home string, providers []provider.Provider, roots []string) CheckResult {

--- a/cli/internal/doctor/recordsync.go
+++ b/cli/internal/doctor/recordsync.go
@@ -1,0 +1,202 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+)
+
+// BackfillEntry is one healthy library-backed provider link with no
+// matching install record.
+type BackfillEntry struct {
+	Coord       installstore.Coord
+	LibraryPath string
+	Placement   installstore.PlacementInput
+}
+
+// BackfillPlan classifies healthy syllago-owned provider links against the
+// install-record store.
+type BackfillPlan struct {
+	Entries   []BackfillEntry         // untracked library-backed links to record
+	Legacy    []installer.ScannedLink // healthy links targeting outside the library root (registry checkout / MOAT cache)
+	Unmatched []installer.ScannedLink // links inside the library root with no matching catalog item
+	Tracked   int                     // healthy links already recorded
+}
+
+// PlanRecordBackfill classifies healthy syllago-owned provider links against
+// the install-record store.
+func PlanRecordBackfill(links []installer.ScannedLink, store *installstore.Store, libraryRoot string, items []catalog.ContentItem) BackfillPlan {
+	var plan BackfillPlan
+	for _, link := range links {
+		if link.Class == installer.LinkBroken {
+			continue
+		}
+		if !recordSyncPathWithinRoot(link.Target, libraryRoot) {
+			plan.Legacy = append(plan.Legacy, link)
+			continue
+		}
+
+		item, ok := recordSyncItemForLink(link, items)
+		if !ok {
+			plan.Unmatched = append(plan.Unmatched, link)
+			continue
+		}
+
+		coord := installstore.Coord{
+			Registry: recordSyncRegistryFor(item),
+			Type:     string(item.Type),
+			Name:     item.Name,
+		}
+		if recordSyncPlacementTracked(store.Find(coord), link) {
+			plan.Tracked++
+			continue
+		}
+
+		plan.Entries = append(plan.Entries, BackfillEntry{
+			Coord:       coord,
+			LibraryPath: item.Path,
+			Placement: installstore.PlacementInput{
+				Provider:  link.Provider,
+				Mechanism: installstore.MechanismSymlink,
+				Path:      link.Path,
+			},
+		})
+	}
+	return plan
+}
+
+// CheckInstallRecords reconciles healthy provider links against the
+// install-record store: reality-based complement to record-based checks.
+func CheckInstallRecords() CheckResult {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return installRecordsGatherWarn(err)
+	}
+	links := installer.ScanProviderLinks(provider.AllProviders, home, SyllagoOwnedRoots(home))
+
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		return installRecordsGatherWarn(err)
+	}
+	store, err := installstore.Load(storePath)
+	if err != nil {
+		return installRecordsGatherWarn(err)
+	}
+
+	items, err := recordSyncLibraryItems()
+	if err != nil {
+		return installRecordsGatherWarn(err)
+	}
+	return checkInstallRecordsAt(links, store, catalog.GlobalContentDir(), items)
+}
+
+func checkInstallRecordsAt(links []installer.ScannedLink, store *installstore.Store, libraryRoot string, items []catalog.ContentItem) CheckResult {
+	plan := PlanRecordBackfill(links, store, libraryRoot, items)
+	if len(plan.Entries) == 0 && len(plan.Legacy) == 0 && len(plan.Unmatched) == 0 {
+		if plan.Tracked == 0 {
+			return CheckResult{Name: "install-records", Status: CheckOK, Message: "Install records: no provider links to track"}
+		}
+		return CheckResult{Name: "install-records", Status: CheckOK, Message: fmt.Sprintf("Install records: %d link(s) tracked", plan.Tracked)}
+	}
+
+	details := make([]string, 0, len(plan.Entries)+len(plan.Legacy)+len(plan.Unmatched)+1)
+	for _, entry := range plan.Entries {
+		details = append(details, fmt.Sprintf("untracked: %s %s/%s", entry.Placement.Provider, entry.Coord.Type, entry.Coord.Name))
+	}
+	for _, link := range plan.Legacy {
+		details = append(details, fmt.Sprintf("legacy: %s -> %s", link.Path, link.Target))
+	}
+	for _, link := range plan.Unmatched {
+		details = append(details, fmt.Sprintf("unknown: %s -> %s", link.Path, link.Target))
+	}
+	if len(plan.Entries) > 0 {
+		details = append(details, "Run 'syllago doctor --fix' to backfill install records")
+	}
+
+	message := fmt.Sprintf("Install records: %d untracked link(s)", len(plan.Entries))
+	if len(plan.Entries) == 0 {
+		message = fmt.Sprintf("Install records: %d link(s) not reconciled", len(plan.Legacy)+len(plan.Unmatched))
+	}
+	return CheckResult{Name: "install-records", Status: CheckWarn, Message: message, Details: details}
+}
+
+func installRecordsGatherWarn(err error) CheckResult {
+	return CheckResult{
+		Name:    "install-records",
+		Status:  CheckWarn,
+		Message: "Install records: could not reconcile",
+		Details: []string{err.Error()},
+	}
+}
+
+func recordSyncLibraryItems() ([]catalog.ContentItem, error) {
+	emptyProjectRoot, err := os.MkdirTemp("", "syllago-doctor-records-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(emptyProjectRoot) }()
+
+	cat, err := catalog.ScanWithGlobalAndRegistries(emptyProjectRoot, emptyProjectRoot, nil)
+	if err != nil {
+		return nil, fmt.Errorf("scanning library: %w", err)
+	}
+
+	var items []catalog.ContentItem
+	for _, item := range cat.Items {
+		if item.Source == "global" {
+			items = append(items, item)
+		}
+	}
+	return items, nil
+}
+
+func recordSyncItemForLink(link installer.ScannedLink, items []catalog.ContentItem) (catalog.ContentItem, bool) {
+	for _, item := range items {
+		if item.Type != link.ContentType {
+			continue
+		}
+		if link.Target == item.Path || link.Target == installer.SourcePathFor(item) || recordSyncPathWithinRoot(link.Target, item.Path) {
+			return item, true
+		}
+	}
+	return catalog.ContentItem{}, false
+}
+
+func recordSyncPlacementTracked(rec *installstore.Record, link installer.ScannedLink) bool {
+	if rec == nil {
+		return false
+	}
+	for _, placement := range rec.Placements {
+		if placement.Provider == link.Provider &&
+			placement.Mechanism == installstore.MechanismSymlink &&
+			placement.Path == link.Path {
+			return true
+		}
+	}
+	return false
+}
+
+func recordSyncRegistryFor(item catalog.ContentItem) string {
+	registry := item.Registry
+	if registry == "" && item.Meta != nil && item.Meta.SourceType == "registry" && item.Meta.SourceRegistry != "" {
+		registry = item.Meta.SourceRegistry
+	}
+	return registry
+}
+
+func recordSyncPathWithinRoot(path, root string) bool {
+	if path == "" || root == "" {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
+}

--- a/cli/internal/doctor/recordsync_test.go
+++ b/cli/internal/doctor/recordsync_test.go
@@ -1,0 +1,287 @@
+package doctor
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/metadata"
+)
+
+func TestPlanRecordBackfill(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	libraryRoot := filepath.Join(tmp, "content")
+	skillPath := filepath.Join(libraryRoot, "skills", "dir-skill")
+	agentPath := filepath.Join(libraryRoot, "agents", "helper")
+	registrySkillPath := filepath.Join(libraryRoot, "skills", "registry-skill")
+	nestedSkillPath := filepath.Join(libraryRoot, "skills", "nested-skill")
+
+	skill := catalog.ContentItem{Name: "dir-skill", Type: catalog.Skills, Path: skillPath}
+	agent := catalog.ContentItem{Name: "helper", Type: catalog.Agents, Path: agentPath}
+	registrySkill := catalog.ContentItem{
+		Name: "registry-skill",
+		Type: catalog.Skills,
+		Path: registrySkillPath,
+		Meta: &metadata.Meta{SourceType: "registry", SourceRegistry: "acme/tools"},
+	}
+	nestedSkill := catalog.ContentItem{Name: "nested-skill", Type: catalog.Skills, Path: nestedSkillPath}
+	items := []catalog.ContentItem{skill, agent, registrySkill, nestedSkill}
+
+	skillLink := doctorBackfillLink("claude-code", catalog.Skills, filepath.Join(tmp, "provider", "skills", "dir-skill"), skillPath, installer.LinkHealthy)
+	agentLink := doctorBackfillLink("claude-code", catalog.Agents, filepath.Join(tmp, "provider", "agents", "helper.md"), filepath.Join(agentPath, "AGENT.md"), installer.LinkHealthy)
+	registryLink := doctorBackfillLink("codex", catalog.Skills, filepath.Join(tmp, "codex", "skills", "registry-skill"), registrySkillPath, installer.LinkHealthy)
+	nestedLink := doctorBackfillLink("zed", catalog.Skills, filepath.Join(tmp, "zed", "skills", "nested-skill"), filepath.Join(nestedSkillPath, "docs", "README.md"), installer.LinkHealthy)
+	legacyLink := doctorBackfillLink("claude-code", catalog.Skills, filepath.Join(tmp, "provider", "skills", "legacy"), filepath.Join(tmp, "registries", "core", "skills", "legacy"), installer.LinkHealthy)
+	unmatchedLink := doctorBackfillLink("claude-code", catalog.Skills, filepath.Join(tmp, "provider", "skills", "unknown"), filepath.Join(libraryRoot, "skills", "unknown"), installer.LinkHealthy)
+	brokenLink := doctorBackfillLink("claude-code", catalog.Skills, filepath.Join(tmp, "provider", "skills", "broken"), filepath.Join(libraryRoot, "skills", "broken"), installer.LinkBroken)
+
+	skillCoord := installstore.Coord{Type: string(catalog.Skills), Name: "dir-skill"}
+	agentCoord := installstore.Coord{Type: string(catalog.Agents), Name: "helper"}
+	registryCoord := installstore.Coord{Registry: "acme/tools", Type: string(catalog.Skills), Name: "registry-skill"}
+	nestedCoord := installstore.Coord{Type: string(catalog.Skills), Name: "nested-skill"}
+
+	tests := []struct {
+		name          string
+		links         []installer.ScannedLink
+		store         *installstore.Store
+		wantEntries   []BackfillEntry
+		wantLegacy    []installer.ScannedLink
+		wantUnmatched []installer.ScannedLink
+		wantTracked   int
+	}{
+		{
+			name:  "fresh store records every healthy library link",
+			links: []installer.ScannedLink{skillLink, agentLink, registryLink},
+			store: &installstore.Store{Version: installstore.CurrentVersion},
+			wantEntries: []BackfillEntry{
+				doctorBackfillEntry(skillCoord, skillPath, skillLink),
+				doctorBackfillEntry(agentCoord, agentPath, agentLink),
+				doctorBackfillEntry(registryCoord, registrySkillPath, registryLink),
+			},
+		},
+		{
+			name:  "already recorded placement is tracked",
+			links: []installer.ScannedLink{skillLink},
+			store: doctorBackfillStore(skillCoord, installstore.Placement{
+				Provider:    skillLink.Provider,
+				Mechanism:   installstore.MechanismSymlink,
+				Path:        skillLink.Path,
+				InstalledAt: doctorBackfillTime(),
+			}),
+			wantTracked: 1,
+		},
+		{
+			name:  "same coord different placement still needs entry",
+			links: []installer.ScannedLink{skillLink},
+			store: doctorBackfillStore(skillCoord, installstore.Placement{
+				Provider:    "codex",
+				Mechanism:   installstore.MechanismSymlink,
+				Path:        filepath.Join(tmp, "elsewhere", "dir-skill"),
+				InstalledAt: doctorBackfillTime(),
+			}),
+			wantEntries: []BackfillEntry{doctorBackfillEntry(skillCoord, skillPath, skillLink)},
+		},
+		{
+			name:        "legacy direct link is skipped",
+			links:       []installer.ScannedLink{legacyLink},
+			store:       &installstore.Store{Version: installstore.CurrentVersion},
+			wantLegacy:  []installer.ScannedLink{legacyLink},
+			wantTracked: 0,
+		},
+		{
+			name:          "library link without item is unmatched",
+			links:         []installer.ScannedLink{unmatchedLink},
+			store:         &installstore.Store{Version: installstore.CurrentVersion},
+			wantUnmatched: []installer.ScannedLink{unmatchedLink},
+		},
+		{
+			name:  "nested target under item path matches",
+			links: []installer.ScannedLink{nestedLink},
+			store: &installstore.Store{Version: installstore.CurrentVersion},
+			wantEntries: []BackfillEntry{
+				doctorBackfillEntry(nestedCoord, nestedSkillPath, nestedLink),
+			},
+		},
+		{
+			name:  "broken links are ignored",
+			links: []installer.ScannedLink{brokenLink},
+			store: &installstore.Store{Version: installstore.CurrentVersion},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := PlanRecordBackfill(tt.links, tt.store, libraryRoot, items)
+			if !reflect.DeepEqual(plan.Entries, tt.wantEntries) {
+				t.Fatalf("Entries = %#v, want %#v", plan.Entries, tt.wantEntries)
+			}
+			if !reflect.DeepEqual(plan.Legacy, tt.wantLegacy) {
+				t.Fatalf("Legacy = %#v, want %#v", plan.Legacy, tt.wantLegacy)
+			}
+			if !reflect.DeepEqual(plan.Unmatched, tt.wantUnmatched) {
+				t.Fatalf("Unmatched = %#v, want %#v", plan.Unmatched, tt.wantUnmatched)
+			}
+			if plan.Tracked != tt.wantTracked {
+				t.Fatalf("Tracked = %d, want %d", plan.Tracked, tt.wantTracked)
+			}
+		})
+	}
+}
+
+func TestCheckInstallRecordsAt(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	libraryRoot := filepath.Join(tmp, "content")
+	skillPath := filepath.Join(libraryRoot, "skills", "dir-skill")
+	skill := catalog.ContentItem{Name: "dir-skill", Type: catalog.Skills, Path: skillPath}
+	skillCoord := installstore.Coord{Type: string(catalog.Skills), Name: "dir-skill"}
+	skillLink := doctorBackfillLink("claude-code", catalog.Skills, filepath.Join(tmp, "provider", "skills", "dir-skill"), skillPath, installer.LinkHealthy)
+	legacyLink := doctorBackfillLink("claude-code", catalog.Skills, filepath.Join(tmp, "provider", "skills", "legacy"), filepath.Join(tmp, "registries", "core", "skills", "legacy"), installer.LinkHealthy)
+	unmatchedLink := doctorBackfillLink("codex", catalog.Skills, filepath.Join(tmp, "codex", "skills", "unknown"), filepath.Join(libraryRoot, "skills", "unknown"), installer.LinkHealthy)
+	brokenLink := doctorBackfillLink("claude-code", catalog.Skills, filepath.Join(tmp, "provider", "skills", "broken"), filepath.Join(libraryRoot, "skills", "broken"), installer.LinkBroken)
+
+	tests := []struct {
+		name             string
+		links            []installer.ScannedLink
+		store            *installstore.Store
+		wantStatus       CheckStatus
+		wantMessage      string
+		wantDetails      []string
+		wantHintPresent  bool
+		wantHintExcluded bool
+	}{
+		{
+			name:        "no links",
+			store:       &installstore.Store{Version: installstore.CurrentVersion},
+			wantStatus:  CheckOK,
+			wantMessage: "Install records: no provider links to track",
+		},
+		{
+			name:        "broken links do not count",
+			links:       []installer.ScannedLink{brokenLink},
+			store:       &installstore.Store{Version: installstore.CurrentVersion},
+			wantStatus:  CheckOK,
+			wantMessage: "Install records: no provider links to track",
+		},
+		{
+			name:  "tracked link is clean",
+			links: []installer.ScannedLink{skillLink},
+			store: doctorBackfillStore(skillCoord, installstore.Placement{
+				Provider:    skillLink.Provider,
+				Mechanism:   installstore.MechanismSymlink,
+				Path:        skillLink.Path,
+				InstalledAt: doctorBackfillTime(),
+			}),
+			wantStatus:  CheckOK,
+			wantMessage: "Install records: 1 link(s) tracked",
+		},
+		{
+			name:        "untracked library link warns with fix hint",
+			links:       []installer.ScannedLink{skillLink},
+			store:       &installstore.Store{Version: installstore.CurrentVersion},
+			wantStatus:  CheckWarn,
+			wantMessage: "Install records: 1 untracked link(s)",
+			wantDetails: []string{
+				"untracked: claude-code skills/dir-skill",
+				"Run 'syllago doctor --fix' to backfill install records",
+			},
+			wantHintPresent: true,
+		},
+		{
+			name:        "legacy and unknown without entries warn without fix hint",
+			links:       []installer.ScannedLink{legacyLink, unmatchedLink},
+			store:       &installstore.Store{Version: installstore.CurrentVersion},
+			wantStatus:  CheckWarn,
+			wantMessage: "Install records: 2 link(s) not reconciled",
+			wantDetails: []string{
+				"legacy: " + legacyLink.Path + " -> " + legacyLink.Target,
+				"unknown: " + unmatchedLink.Path + " -> " + unmatchedLink.Target,
+			},
+			wantHintExcluded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkInstallRecordsAt(tt.links, tt.store, libraryRoot, []catalog.ContentItem{skill})
+			if result.Name != "install-records" {
+				t.Fatalf("Name = %q, want install-records", result.Name)
+			}
+			if result.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s: %#v", result.Status, tt.wantStatus, result)
+			}
+			if result.Message != tt.wantMessage {
+				t.Fatalf("Message = %q, want %q", result.Message, tt.wantMessage)
+			}
+			if tt.wantDetails != nil && !reflect.DeepEqual(result.Details, tt.wantDetails) {
+				t.Fatalf("Details = %#v, want %#v", result.Details, tt.wantDetails)
+			}
+			hasHint := doctorDetailsContain(result.Details, "Run 'syllago doctor --fix' to backfill install records")
+			if tt.wantHintPresent && !hasHint {
+				t.Fatalf("Details = %#v, want doctor --fix hint", result.Details)
+			}
+			if tt.wantHintExcluded && hasHint {
+				t.Fatalf("Details = %#v, did not want doctor --fix hint", result.Details)
+			}
+		})
+	}
+}
+
+func doctorBackfillLink(provider string, ct catalog.ContentType, path, target string, class installer.LinkClass) installer.ScannedLink {
+	return installer.ScannedLink{
+		Provider:    provider,
+		ContentType: ct,
+		Path:        path,
+		Target:      target,
+		Class:       class,
+	}
+}
+
+func doctorBackfillEntry(coord installstore.Coord, libraryPath string, link installer.ScannedLink) BackfillEntry {
+	return BackfillEntry{
+		Coord:       coord,
+		LibraryPath: libraryPath,
+		Placement: installstore.PlacementInput{
+			Provider:  link.Provider,
+			Mechanism: installstore.MechanismSymlink,
+			Path:      link.Path,
+		},
+	}
+}
+
+func doctorBackfillStore(coord installstore.Coord, placement installstore.Placement) *installstore.Store {
+	return &installstore.Store{
+		Version: installstore.CurrentVersion,
+		Records: []installstore.Record{
+			{
+				Coord:       coord,
+				ContentHash: "sha256:test",
+				LibraryPath: "/tmp/library",
+				InstalledAt: doctorBackfillTime(),
+				UpdatedAt:   doctorBackfillTime(),
+				Placements:  []installstore.Placement{placement},
+			},
+		},
+	}
+}
+
+func doctorBackfillTime() time.Time {
+	return time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC)
+}
+
+func doctorDetailsContain(details []string, needle string) bool {
+	for _, detail := range details {
+		if strings.Contains(detail, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/tui/installrecord.go
+++ b/cli/internal/tui/installrecord.go
@@ -49,8 +49,12 @@ func forgetTUIInstallRecord(item catalog.ContentItem) {
 }
 
 func tuiInstallRecordCoord(item catalog.ContentItem) installstore.Coord {
+	registry := item.Registry
+	if registry == "" && item.Meta != nil && item.Meta.SourceType == "registry" && item.Meta.SourceRegistry != "" {
+		registry = item.Meta.SourceRegistry
+	}
 	return installstore.Coord{
-		Registry: item.Registry,
+		Registry: registry,
 		Type:     string(item.Type),
 		Name:     item.Name,
 	}

--- a/cli/internal/tui/installrecord_test.go
+++ b/cli/internal/tui/installrecord_test.go
@@ -1,0 +1,58 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/metadata"
+)
+
+func TestTUIInstallRecordCoordRegistryFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		item         catalog.ContentItem
+		wantRegistry string
+	}{
+		{
+			name: "metadata registry used when item registry empty",
+			item: catalog.ContentItem{
+				Name: "writer",
+				Type: catalog.Skills,
+				Meta: &metadata.Meta{SourceType: "registry", SourceRegistry: "acme/tools"},
+			},
+			wantRegistry: "acme/tools",
+		},
+		{
+			name: "non registry source type leaves registry empty",
+			item: catalog.ContentItem{
+				Name: "writer",
+				Type: catalog.Skills,
+				Meta: &metadata.Meta{SourceType: "provider", SourceRegistry: "acme/tools"},
+			},
+		},
+		{
+			name: "explicit item registry wins",
+			item: catalog.ContentItem{
+				Name:     "writer",
+				Type:     catalog.Skills,
+				Registry: "explicit",
+				Meta:     &metadata.Meta{SourceType: "registry", SourceRegistry: "acme/tools"},
+			},
+			wantRegistry: "explicit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tuiInstallRecordCoord(tt.item)
+			if got.Registry != tt.wantRegistry {
+				t.Fatalf("Registry = %q, want %q", got.Registry, tt.wantRegistry)
+			}
+			if got.Type != string(tt.item.Type) || got.Name != tt.item.Name {
+				t.Fatalf("Coord = %#v, want type/name from item", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Part of #542 (item 2d, record backfill). Follows #547/#551/#553/#554 which built the install-record store and wired install/uninstall paths.
- Fixes a coordinate drift: global-library items sourced from registries carry attribution only in `.syllago.yaml` metadata (`source_registry`), so CLI/TUI install recording wrote `Registry: ""` while MOAT-route installs wrote the registry name. `installRecordCoord` (both surfaces) now falls back to `Meta.SourceRegistry` for registry-sourced items.
- New `install-records` doctor check reconciles healthy syllago-owned provider links against the store: reports untracked library-backed links (with a `doctor --fix` hint), legacy direct links (targets outside the library root), and unknown links (no catalog match — never invents coordinates).
- `doctor --fix` now also backfills: prints `record: <provider> <type>/<name>` plan lines alongside relink/prune, applies via `installstore.RecordInstall`, reports `Fixed: N relinked, N pruned, N recorded`, and skips legacy links with an explicit count. Store/scan failures degrade to warnings — link repair still runs.
- Removed the now-orphaned `doctor.BrokenProviderLinks`; `--fix` filters the single shared provider-link scan instead of scanning twice.

## Testing
- New planner/check unit tests (`recordsync_test.go`), an end-to-end `doctor --fix --force` backfill test asserting the persisted record and idempotence on a second run, and coord-fallback table tests for both CLI and TUI helpers.
- Full suite: `go test -count=1 ./...` — 40 packages ok, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
