### PR TITLE
feat(registry): add registry status command (#542 item 6c-ii)

### DIFF
--- a/cli/cmd/syllago/registry_cmd.go
+++ b/cli/cmd/syllago/registry_cmd.go
@@ -949,6 +949,6 @@ func init() {
 	registryCreateCmd.Flags().String("description", "", "Short description of the registry (used with --new)")
 	registryCreateCmd.Flags().Bool("no-git", false, "Skip git init and initial commit (used with --new)")
 
-	registryCmd.AddCommand(registryAddCmd, registryRemoveCmd, registryListCmd, registrySyncCmd, registryItemsCmd, registryCreateCmd)
+	registryCmd.AddCommand(registryAddCmd, registryRemoveCmd, registryListCmd, registrySyncCmd, registryStatusCmd, registryItemsCmd, registryCreateCmd)
 	rootCmd.AddCommand(registryCmd)
 }

--- a/cli/cmd/syllago/registry_diff.go
+++ b/cli/cmd/syllago/registry_diff.go
@@ -25,6 +25,13 @@ func printRegistryDiff(w io.Writer, d *regdiff.Diff) {
 	}
 
 	fmt.Fprintln(w, "Changes since last sync:")
+	printRegistryDiffLines(w, d)
+}
+
+func printRegistryDiffLines(w io.Writer, d *regdiff.Diff) {
+	if d == nil {
+		return
+	}
 	limit := len(d.Changes)
 	if limit > registryDiffChangeLimit {
 		limit = registryDiffChangeLimit

--- a/cli/cmd/syllago/registry_diff_test.go
+++ b/cli/cmd/syllago/registry_diff_test.go
@@ -74,6 +74,28 @@ func TestPrintRegistryDiff_MixedChanges(t *testing.T) {
 	}
 }
 
+func TestPrintRegistryDiffLines_RendersBodyWithoutHeaderOrGuards(t *testing.T) {
+	output.SetForTest(t)
+	d := &regdiff.Diff{
+		Changes: []regdiff.ItemChange{
+			{Type: "skills", Name: "new-thing.md", Kind: regdiff.KindAdded},
+			{Type: "rules", Name: "updated-rule", Kind: regdiff.KindModified},
+			{Type: "agents", Name: "old-agent", Kind: regdiff.KindRemoved},
+		},
+		OtherPaths: []string{"README.md"},
+	}
+
+	var buf bytes.Buffer
+	printRegistryDiffLines(&buf, d)
+	want := "  + skills/new-thing\n" +
+		"  ~ rules/updated-rule\n" +
+		"  - agents/old-agent\n" +
+		"  (plus 1 other changed files)\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("printRegistryDiffLines() = %q; want %q", got, want)
+	}
+}
+
 func TestPrintRegistryDiff_TrimsKnownExtensionsForDisplay(t *testing.T) {
 	output.SetForTest(t)
 	d := &regdiff.Diff{

--- a/cli/cmd/syllago/registry_status.go
+++ b/cli/cmd/syllago/registry_status.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/regdiff"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
+	"github.com/OpenScribbler/syllago/cli/internal/registryops"
+	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+type registryStatusJSON struct {
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+	State    string `json:"state"`
+	Added    int    `json:"added"`
+	Modified int    `json:"modified"`
+	Removed  int    `json:"removed"`
+	Error    string `json:"error,omitempty"`
+}
+
+var registryStatusCmd = &cobra.Command{
+	Use:   "status [name]",
+	Short: "Show upstream registry changes without syncing",
+	Long: `Fetches registry metadata and reports what "registry sync" would pull
+without moving git checkouts or persisting MOAT trust/cache state.`,
+	Example: `  # Check all registries
+  syllago registry status
+
+  # Check a specific registry
+  syllago registry status my-rules`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runRegistryStatus(cmd.Context(), args)
+	},
+}
+
+func runRegistryStatus(ctx context.Context, args []string) error {
+	lockfileRoot, err := findProjectRoot()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return err
+	}
+
+	var regs []config.Registry
+	explicit := len(args) == 1
+	if explicit {
+		reg := findRegistryByName(cfg, args[0])
+		if reg == nil {
+			telemetry.Enrich("registry_count", 0)
+			return output.NewStructuredError(output.ErrRegistryNotFound, fmt.Sprintf("registry %q not found in config", args[0]), "Run 'syllago registry list' to see configured registries")
+		}
+		regs = append(regs, *reg)
+	} else {
+		regs = append(regs, cfg.Registries...)
+	}
+
+	telemetry.Enrich("registry_count", len(regs))
+	if len(regs) == 0 {
+		if output.JSON {
+			output.Print([]registryStatusJSON{})
+		} else {
+			fmt.Fprintln(output.Writer, "No registries configured.")
+		}
+		return nil
+	}
+
+	cacheDir, _ := config.GlobalDirPath()
+	rows := make([]registryStatusJSON, 0, len(regs))
+	for i := range regs {
+		reg := &regs[i]
+		row, err := registryStatusOne(ctx, reg, lockfileRoot, cacheDir)
+		if err != nil {
+			if explicit {
+				return err
+			}
+			row = registryStatusJSON{
+				Name:  reg.Name,
+				Kind:  registryStatusKind(reg),
+				State: "error",
+				Error: err.Error(),
+			}
+			if !output.JSON {
+				fmt.Fprintf(output.ErrWriter, "warning: %s: %s\n", reg.Name, err)
+				continue
+			}
+		}
+		rows = append(rows, row)
+	}
+
+	if output.JSON {
+		output.Print(rows)
+	}
+	return nil
+}
+
+func registryStatusOne(ctx context.Context, reg *config.Registry, lockfileRoot, cacheDir string) (registryStatusJSON, error) {
+	if reg.IsMOAT() {
+		return registryStatusMOAT(ctx, reg, lockfileRoot, cacheDir)
+	}
+	return registryStatusGit(reg)
+}
+
+func registryStatusMOAT(ctx context.Context, reg *config.Registry, lockfileRoot, cacheDir string) (registryStatusJSON, error) {
+	row := registryStatusJSON{Name: reg.Name, Kind: "moat"}
+	outcome, err := registryops.StatusOne(ctx, reg.Name, registryops.SyncOpts{
+		LockfileRoot: lockfileRoot,
+		CacheDir:     cacheDir,
+		Now:          time.Now(),
+	})
+	if err != nil {
+		return row, classifyMOATStatusError(reg.Name, err)
+	}
+
+	switch {
+	case outcome.UpToDate:
+		row.State = "up_to_date"
+		registryStatusPrintLine("%s (moat): up to date\n", reg.Name)
+	case outcome.ProfileChanged:
+		row.State = "profile_changed"
+		registryStatusPrintLine("%s (moat): signing profile changed upstream — run 'syllago registry sync %s'\n", reg.Name, reg.Name)
+	case outcome.NotSynced:
+		row.State = "not_synced"
+		registryStatusPrintLine("%s (moat): not synced yet — run 'syllago registry sync %s'\n", reg.Name, reg.Name)
+	case outcome.Diff == nil:
+		row.State = "error"
+		row.Error = "could not compare"
+		registryStatusPrintLine("%s (moat): could not compare — run 'syllago registry sync %s'\n", reg.Name, reg.Name)
+	case registryStatusHasChanges(outcome.Diff):
+		registryStatusSetChangeCounts(&row, outcome.Diff)
+		registryStatusPrintDiff(reg.Name, "moat", outcome.Diff)
+	default:
+		row.State = "up_to_date"
+		registryStatusPrintLine("%s (moat): up to date\n", reg.Name)
+	}
+
+	return row, nil
+}
+
+func registryStatusGit(reg *config.Registry) (registryStatusJSON, error) {
+	row := registryStatusJSON{Name: reg.Name, Kind: "git"}
+	outcome, err := registry.Status(reg.Name)
+	if err != nil {
+		return row, output.NewStructuredErrorDetail(output.ErrRegistrySyncFailed, fmt.Sprintf("status failed for %q", reg.Name), "Check network connectivity and git credentials", err.Error())
+	}
+	if outcome.Head == outcome.RemoteHead {
+		row.State = "up_to_date"
+		registryStatusPrintLine("%s (git): up to date\n", reg.Name)
+		return row, nil
+	}
+
+	cloneDir, err := registry.CloneDir(reg.Name)
+	if err != nil {
+		row.State = "error"
+		row.Error = err.Error()
+		registryStatusPrintLine("%s (git): could not compare — run 'syllago registry sync %s'\n", reg.Name, reg.Name)
+		return row, nil
+	}
+	items := gitItemRefs(reg.Name, cloneDir)
+	types := catalog.AllContentTypes()
+	knownTypeDirs := make([]string, 0, len(types))
+	for _, ct := range types {
+		knownTypeDirs = append(knownTypeDirs, string(ct))
+	}
+	d, err := regdiff.GitDiff(reg.Name, cloneDir, outcome.Head, outcome.RemoteHead, items, knownTypeDirs)
+	if err != nil {
+		row.State = "error"
+		row.Error = err.Error()
+		registryStatusPrintLine("%s (git): could not compare — run 'syllago registry sync %s'\n", reg.Name, reg.Name)
+		return row, nil
+	}
+	refineRegistryStatusGitKinds(cloneDir, outcome.Head, outcome.RemoteHead, &d)
+	if registryStatusHasChanges(&d) {
+		registryStatusSetChangeCounts(&row, &d)
+		registryStatusPrintDiff(reg.Name, "git", &d)
+		return row, nil
+	}
+
+	row.State = "up_to_date"
+	registryStatusPrintLine("%s (git): up to date\n", reg.Name)
+	return row, nil
+}
+
+func registryStatusPrintLine(format string, args ...any) {
+	if output.JSON {
+		return
+	}
+	fmt.Fprintf(output.Writer, format, args...)
+}
+
+func registryStatusPrintDiff(name, kind string, d *regdiff.Diff) {
+	if output.JSON {
+		return
+	}
+	fmt.Fprintf(output.Writer, "%s (%s): %d upstream change(s)\n", name, kind, len(d.Changes))
+	printRegistryDiffLines(output.Writer, d)
+}
+
+func registryStatusSetChangeCounts(row *registryStatusJSON, d *regdiff.Diff) {
+	row.State = "changes"
+	for _, change := range d.Changes {
+		switch change.Kind {
+		case regdiff.KindAdded:
+			row.Added++
+		case regdiff.KindRemoved:
+			row.Removed++
+		default:
+			row.Modified++
+		}
+	}
+}
+
+func registryStatusHasChanges(d *regdiff.Diff) bool {
+	return d != nil && (len(d.Changes) > 0 || len(d.OtherPaths) > 0)
+}
+
+// refineRegistryStatusGitKinds corrects added/removed classification for the
+// status flow. GitDiff's kind logic assumes the working tree sits at newRef
+// (true after sync's pull): items scanned from the checkout decide which
+// accumulator a path lands in, and only one side runs each existence check.
+// During status the checkout is still at oldRef, so upstream adds and removes
+// would both surface as Modified; re-checking path existence at both refs
+// restores the right kinds without moving the checkout.
+func refineRegistryStatusGitKinds(repoDir, oldRef, newRef string, d *regdiff.Diff) {
+	if d == nil {
+		return
+	}
+	for i := range d.Changes {
+		paths := d.Changes[i].Paths
+		if len(paths) == 0 {
+			continue
+		}
+		oldAny, oldAll := registryStatusGitPathSetExists(repoDir, oldRef, paths)
+		newAny, newAll := registryStatusGitPathSetExists(repoDir, newRef, paths)
+		switch {
+		case !oldAny && newAll:
+			d.Changes[i].Kind = regdiff.KindAdded
+		case oldAll && !newAny:
+			d.Changes[i].Kind = regdiff.KindRemoved
+		}
+	}
+}
+
+func registryStatusGitPathSetExists(repoDir, ref string, paths []string) (anyExist, allExist bool) {
+	allExist = true
+	for _, path := range paths {
+		exists := registryStatusGitPathExists(repoDir, ref, path)
+		anyExist = anyExist || exists
+		allExist = allExist && exists
+	}
+	return anyExist, allExist
+}
+
+func registryStatusGitPathExists(repoDir, ref, path string) bool {
+	cmd := exec.Command("git", "-C", repoDir, "cat-file", "-e", ref+":"+path)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	return cmd.Run() == nil
+}
+
+func registryStatusKind(reg *config.Registry) string {
+	if reg.IsMOAT() {
+		return "moat"
+	}
+	return "git"
+}
+
+func classifyMOATStatusError(name string, err error) error {
+	if status, ok := registryops.IsTrustedRootStale(err); ok {
+		return output.NewStructuredErrorDetail(
+			output.ErrMoatTrustedRootStale,
+			fmt.Sprintf("bundled trusted root unusable while checking registry %q", name),
+			"Run `syllago update` to refresh the bundled Sigstore trusted root.",
+			status.String(),
+		)
+	}
+	var ve *moat.VerifyError
+	if errors.As(err, &ve) {
+		return classifyVerifyError(name, err)
+	}
+	return output.NewStructuredErrorDetail(
+		output.ErrMoatInvalid,
+		fmt.Sprintf("status failed for registry %q", name),
+		"Run `syllago registry sync` after checking network connectivity and the registry's manifest URL.",
+		err.Error(),
+	)
+}

--- a/cli/cmd/syllago/registry_status_test.go
+++ b/cli/cmd/syllago/registry_status_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
+)
+
+func TestRegistryStatusMOATTextOutput(t *testing.T) {
+	cases := []struct {
+		name       string
+		result     moat.SyncResult
+		seedCache  *moat.Manifest
+		wantOutput string
+	}{
+		{
+			name: "up-to-date",
+			result: moat.SyncResult{
+				NotModified: true,
+				ETag:        `"old"`,
+				FetchedAt:   registryStatusTestNow(),
+				Staleness:   moat.StalenessFresh,
+			},
+			wantOutput: "moat-reg (moat): up to date\n",
+		},
+		{
+			name: "changes",
+			result: registryStatusSyncResult(t, registryStatusManifest(t, "2026-04-21T00:00:00Z", []moat.ContentEntry{
+				registryStatusEntry("added", "skill", "3"),
+				registryStatusEntry("kept", "skill", "4"),
+			})),
+			seedCache: registryStatusManifest(t, "2026-04-20T00:00:00Z", []moat.ContentEntry{
+				registryStatusEntry("kept", "skill", "1"),
+				registryStatusEntry("removed", "skill", "2"),
+			}),
+			wantOutput: "moat-reg (moat): 3 upstream change(s)\n" +
+				"  + skill/added\n" +
+				"  ~ skill/kept\n" +
+				"  - skill/removed\n",
+		},
+		{
+			name: "not-synced",
+			result: func() moat.SyncResult {
+				res := registryStatusSyncResult(t, registryStatusManifest(t, "2026-04-21T00:00:00Z", []moat.ContentEntry{
+					registryStatusEntry("first", "skill", "1"),
+				}))
+				res.IsTOFU = true
+				return res
+			}(),
+			wantOutput: "moat-reg (moat): not synced yet — run 'syllago registry sync moat-reg'\n",
+		},
+		{
+			name: "profile-changed",
+			result: func() moat.SyncResult {
+				res := registryStatusSyncResult(t, registryStatusManifest(t, "2026-04-21T00:00:00Z", []moat.ContentEntry{
+					registryStatusEntry("changed", "skill", "1"),
+				}))
+				res.ProfileChanged = true
+				return res
+			}(),
+			wantOutput: "moat-reg (moat): signing profile changed upstream — run 'syllago registry sync moat-reg'\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, cacheDir := setupRegistryStatusMOATTest(t, tc.seedCache)
+			oldCacheBytes := readCachedManifestIfPresent(t, cacheDir, "moat-reg")
+			withStubbedMoatSync(t, func(_ context.Context, _ *config.Registry, _ *moat.Lockfile, _ []byte, _ *moat.Fetcher, _ time.Time) (moat.SyncResult, error) {
+				return tc.result, nil
+			})
+			stdout, _ := output.SetForTest(t)
+
+			registryStatusCmd.SilenceUsage = true
+			registryStatusCmd.SilenceErrors = true
+			if err := registryStatusCmd.RunE(registryStatusCmd, nil); err != nil {
+				t.Fatalf("registry status: %v", err)
+			}
+			if got := stdout.String(); got != tc.wantOutput {
+				t.Fatalf("stdout = %q; want %q", got, tc.wantOutput)
+			}
+			assertRegistryStatusReadOnly(t, root, cacheDir, "moat-reg", oldCacheBytes)
+		})
+	}
+}
+
+func TestRegistryStatusGitShowsUpstreamChangesWithoutConsumingSync(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	bare, work, branch := createBareGitRegistryForSyncTest(t)
+	cfg := &config.Config{
+		Providers: []string{"claude-code"},
+		Registries: []config.Registry{
+			{Name: "git-status", URL: bare},
+		},
+	}
+	withRegistryProjectAndCache(t, nil, cfg)
+	stdout, _ := output.SetForTest(t)
+	overrideProbe(t, func(url string) (string, error) {
+		return registry.VisibilityPublic, nil
+	})
+
+	registrySyncCmd.SilenceUsage = true
+	registrySyncCmd.SilenceErrors = true
+	if err := registrySyncCmd.RunE(registrySyncCmd, []string{"git-status"}); err != nil {
+		t.Fatalf("initial registry sync: %v", err)
+	}
+
+	updateBareGitRegistryForStatusDiffTest(t, work, bare, branch)
+
+	stdout.Reset()
+	registryStatusCmd.SilenceUsage = true
+	registryStatusCmd.SilenceErrors = true
+	if err := registryStatusCmd.RunE(registryStatusCmd, []string{"git-status"}); err != nil {
+		t.Fatalf("registry status: %v", err)
+	}
+	wantStatus := "git-status (git): 2 upstream change(s)\n" +
+		"  ~ rules/updated-rule\n" +
+		"  + skills/new-thing\n"
+	if got := stdout.String(); got != wantStatus {
+		t.Fatalf("status stdout = %q; want %q", got, wantStatus)
+	}
+
+	stdout.Reset()
+	if err := registrySyncCmd.RunE(registrySyncCmd, []string{"git-status"}); err != nil {
+		t.Fatalf("registry sync after status: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Synced: git-status\nChanges since last sync:\n") {
+		t.Fatalf("sync after status stdout = %q; want sync to still pull and print diff", got)
+	}
+
+	stdout.Reset()
+	if err := registryStatusCmd.RunE(registryStatusCmd, []string{"git-status"}); err != nil {
+		t.Fatalf("registry status after sync: %v", err)
+	}
+	if got := stdout.String(); got != "git-status (git): up to date\n" {
+		t.Fatalf("status after sync stdout = %q; want up to date", got)
+	}
+}
+
+func TestRegistryStatusJSON(t *testing.T) {
+	setupRegistryStatusMOATTest(t, registryStatusManifest(t, "2026-04-20T00:00:00Z", []moat.ContentEntry{
+		registryStatusEntry("kept", "skill", "1"),
+		registryStatusEntry("removed", "skill", "2"),
+	}))
+	withStubbedMoatSync(t, func(_ context.Context, _ *config.Registry, _ *moat.Lockfile, _ []byte, _ *moat.Fetcher, _ time.Time) (moat.SyncResult, error) {
+		return registryStatusSyncResult(t, registryStatusManifest(t, "2026-04-21T00:00:00Z", []moat.ContentEntry{
+			registryStatusEntry("added", "skill", "3"),
+			registryStatusEntry("kept", "skill", "4"),
+		})), nil
+	})
+	stdout, _ := output.SetForTest(t)
+	output.JSON = true
+
+	registryStatusCmd.SilenceUsage = true
+	registryStatusCmd.SilenceErrors = true
+	if err := registryStatusCmd.RunE(registryStatusCmd, nil); err != nil {
+		t.Fatalf("registry status: %v", err)
+	}
+
+	var rows []struct {
+		Name     string `json:"name"`
+		Kind     string `json:"kind"`
+		State    string `json:"state"`
+		Added    int    `json:"added"`
+		Modified int    `json:"modified"`
+		Removed  int    `json:"removed"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("unmarshal status JSON: %v\n%s", err, stdout.String())
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows; want 1", len(rows))
+	}
+	got := rows[0]
+	if got.Name != "moat-reg" || got.Kind != "moat" || got.State != "changes" || got.Added != 1 || got.Modified != 1 || got.Removed != 1 {
+		t.Fatalf("JSON row = %+v; want moat-reg changes with 1/1/1 counts", got)
+	}
+}
+
+func TestRegistryStatusUnknownExplicitName(t *testing.T) {
+	cfg := &config.Config{
+		Providers: []string{"claude-code"},
+		Registries: []config.Registry{
+			{Name: "exists", URL: "https://example.com/exists.git"},
+		},
+	}
+	withRegistryProjectAndCache(t, nil, cfg)
+	output.SetForTest(t)
+
+	registryStatusCmd.SilenceUsage = true
+	registryStatusCmd.SilenceErrors = true
+	err := registryStatusCmd.RunE(registryStatusCmd, []string{"missing"})
+	if err == nil || !strings.Contains(err.Error(), "registry \"missing\" not found in config") {
+		t.Fatalf("got %v; want missing registry error", err)
+	}
+}
+
+func setupRegistryStatusMOATTest(t *testing.T, cached *moat.Manifest) (root, cacheDir string) {
+	t.Helper()
+	profile := incomingProfile()
+	cfg := &config.Config{
+		Providers: []string{"claude-code"},
+		Registries: []config.Registry{
+			{
+				Name:           "moat-reg",
+				URL:            "https://registry.example.com/manifest.json",
+				Type:           config.RegistryTypeMOAT,
+				ManifestURI:    "https://registry.example.com/manifest.json",
+				SigningProfile: &profile,
+				ManifestETag:   `"old"`,
+			},
+		},
+	}
+	root = withRegistryProjectAndCache(t, nil, cfg)
+	var err error
+	cacheDir, err = config.GlobalDirPath()
+	if err != nil {
+		t.Fatalf("GlobalDirPath: %v", err)
+	}
+	if cached != nil {
+		if err := moat.WriteManifestCache(cacheDir, "moat-reg", registryStatusManifestBytes(t, cached), []byte(`{"bundle":true}`)); err != nil {
+			t.Fatalf("WriteManifestCache: %v", err)
+		}
+	}
+	return root, cacheDir
+}
+
+func assertRegistryStatusReadOnly(t *testing.T, root, cacheDir, name string, oldCacheBytes []byte) {
+	t.Helper()
+	reloaded, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if reloaded.Registries[0].ManifestETag != `"old"` {
+		t.Fatalf("ManifestETag = %q; want unchanged", reloaded.Registries[0].ManifestETag)
+	}
+	if _, err := os.Stat(moat.LockfilePath(root)); !os.IsNotExist(err) {
+		t.Fatalf("lockfile exists after registry status: %v", err)
+	}
+	gotCacheBytes := readCachedManifestIfPresent(t, cacheDir, name)
+	if string(gotCacheBytes) != string(oldCacheBytes) {
+		t.Fatalf("cached manifest changed:\n got %s\nwant %s", gotCacheBytes, oldCacheBytes)
+	}
+}
+
+func readCachedManifestIfPresent(t *testing.T, cacheDir, name string) []byte {
+	t.Helper()
+	path, err := moat.ManifestCachePath(cacheDir, name)
+	if err != nil {
+		t.Fatalf("ManifestCachePath: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("ReadFile cached manifest: %v", err)
+	}
+	return data
+}
+
+func registryStatusSyncResult(t *testing.T, manifest *moat.Manifest) moat.SyncResult {
+	t.Helper()
+	return moat.SyncResult{
+		ManifestURL:     "https://registry.example.com/manifest.json",
+		BundleURL:       "https://registry.example.com/manifest.json.sigstore",
+		ETag:            `"fresh"`,
+		Manifest:        manifest,
+		ManifestBytes:   registryStatusManifestBytes(t, manifest),
+		BundleBytes:     []byte(`{"bundle":true}`),
+		IncomingProfile: incomingProfile(),
+		FetchedAt:       registryStatusTestNow(),
+		Staleness:       moat.StalenessFresh,
+	}
+}
+
+func registryStatusManifest(t *testing.T, updatedAt string, entries []moat.ContentEntry) *moat.Manifest {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, updatedAt)
+	if err != nil {
+		t.Fatalf("parse updated_at: %v", err)
+	}
+	return &moat.Manifest{
+		SchemaVersion:          moat.ManifestSchemaVersion,
+		ManifestURI:            "https://registry.example.com/manifest.json",
+		Name:                   "Status Registry",
+		Operator:               "Status Operator",
+		UpdatedAt:              ts,
+		RegistrySigningProfile: moat.SigningProfile{Issuer: incomingProfile().Issuer, Subject: incomingProfile().Subject},
+		Content:                entries,
+		Revocations:            []moat.Revocation{},
+	}
+}
+
+func registryStatusEntry(name, typ, digit string) moat.ContentEntry {
+	return moat.ContentEntry{
+		Name:        name,
+		DisplayName: name,
+		Type:        typ,
+		ContentHash: "sha256:" + strings.Repeat(digit, 64),
+		SourceURI:   "fixture-source",
+		AttestedAt:  registryStatusTestNow(),
+	}
+}
+
+func registryStatusManifestBytes(t *testing.T, manifest *moat.Manifest) []byte {
+	t.Helper()
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	return data
+}
+
+func registryStatusTestNow() time.Time {
+	return time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+}
+
+func updateBareGitRegistryForStatusDiffTest(t *testing.T, work, bare, branch string) {
+	t.Helper()
+	writeRepoFileForSyncTest(t, work, "rules/claude-code/updated-rule.md", "# Updated Rule\n\nv2\n")
+	writeRepoFileForSyncTest(t, work, "skills/new-thing/SKILL.md", "# New Thing\n")
+	gitRunForSyncTest(t, work, "add", "-A")
+	gitRunForSyncTest(t, work, "commit", "-m", "update content for status")
+	gitRunForSyncTest(t, work, "push", bare, "HEAD:refs/heads/"+branch)
+}

--- a/cli/commands.json
+++ b/cli/commands.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generatedAt": "2026-08-23T00:25:37Z",
+  "generatedAt": "2026-08-23T01:52:59Z",
   "syllagoVersion": "0.14.0",
   "commands": [
     {
@@ -2647,6 +2647,7 @@
         "items",
         "list",
         "remove",
+        "status",
         "sync"
       ],
       "seeAlso": [],
@@ -2777,6 +2778,7 @@
         "registry items",
         "registry list",
         "registry remove",
+        "registry status",
         "registry sync"
       ],
       "examples": "  # Register a registry (no clone — run 'registry sync' to fetch content)\n  syllago registry add https://github.com/team/rules.git\n\n  # Register and clone immediately\n  syllago registry add https://github.com/team/rules.git --sync\n\n  # Register with a custom name\n  syllago registry add https://github.com/team/rules.git --name team-rules\n\n  # Pin to a specific branch\n  syllago registry add https://github.com/team/rules.git --ref main",
@@ -2866,6 +2868,7 @@
         "registry items",
         "registry list",
         "registry remove",
+        "registry status",
         "registry sync"
       ],
       "examples": "  # Scaffold an empty registry\n  syllago registry create --new my-rules\n\n  # Scaffold with a description\n  syllago registry create --new my-rules --description \"Team coding standards\"\n\n  # Index existing provider-native content\n  syllago registry create --from-native",
@@ -2931,6 +2934,7 @@
         "registry create",
         "registry list",
         "registry remove",
+        "registry status",
         "registry sync"
       ],
       "examples": "  # List all items from all registries\n  syllago registry items\n\n  # List items from a specific registry\n  syllago registry items my-rules\n\n  # Filter by content type\n  syllago registry items --type skills",
@@ -2987,6 +2991,7 @@
         "registry create",
         "registry items",
         "registry remove",
+        "registry status",
         "registry sync"
       ],
       "examples": "  # List all configured registries\n  syllago registry list\n\n  # JSON output\n  syllago registry list --json",
@@ -3043,9 +3048,67 @@
         "registry create",
         "registry items",
         "registry list",
+        "registry status",
         "registry sync"
       ],
       "examples": "  syllago registry remove team-rules",
+      "source": "cli/cmd/syllago/registry_cmd.go"
+    },
+    {
+      "name": "registry status",
+      "displayName": "Registry Status",
+      "slug": "registry-status",
+      "parent": "registry",
+      "synopsis": "syllago registry status [name]",
+      "description": "Show upstream registry changes without syncing",
+      "longDescription": "Fetches registry metadata and reports what \"registry sync\" would pull\nwithout moving git checkouts or persisting MOAT trust/cache state.",
+      "aliases": [],
+      "flags": [],
+      "inheritedFlags": [
+        {
+          "name": "--json",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Output in JSON format"
+        },
+        {
+          "name": "--no-color",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Disable color output"
+        },
+        {
+          "name": "--quiet",
+          "shorthand": "-q",
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Suppress non-essential output"
+        },
+        {
+          "name": "--verbose",
+          "shorthand": "-v",
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Verbose output"
+        }
+      ],
+      "subcommands": [],
+      "seeAlso": [
+        "registry",
+        "registry add",
+        "registry create",
+        "registry items",
+        "registry list",
+        "registry remove",
+        "registry sync"
+      ],
+      "examples": "  # Check all registries\n  syllago registry status\n\n  # Check a specific registry\n  syllago registry status my-rules",
       "source": "cli/cmd/syllago/registry_cmd.go"
     },
     {
@@ -3108,7 +3171,8 @@
         "registry create",
         "registry items",
         "registry list",
-        "registry remove"
+        "registry remove",
+        "registry status"
       ],
       "examples": "  # Sync all registries\n  syllago registry sync\n\n  # Sync a specific registry\n  syllago registry sync my-rules",
       "source": "cli/cmd/syllago/registry_cmd.go"

--- a/cli/internal/registry/integration_test.go
+++ b/cli/internal/registry/integration_test.go
@@ -264,6 +264,62 @@ func TestIntegration_Sync(t *testing.T) {
 	}
 }
 
+func TestIntegration_StatusFetchesRemoteWithoutMovingCheckout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	requireGit(t)
+	setupCacheOverride(t)
+
+	bare := createBareRepo(t, "valid")
+	if err := Clone(bare, "test-reg", ""); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+
+	initial, err := Status("test-reg")
+	if err != nil {
+		t.Fatalf("Status initial: %v", err)
+	}
+	if initial.Head == "" {
+		t.Fatal("Status initial Head is empty")
+	}
+	if initial.Head != initial.RemoteHead {
+		t.Fatalf("Status initial Head=%q RemoteHead=%q; want equal", initial.Head, initial.RemoteHead)
+	}
+
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	run(t, "", "git", "clone", bare, workspace)
+	run(t, workspace, "git", "config", "user.email", "test@example.com")
+	run(t, workspace, "git", "config", "user.name", "Test User")
+	writeFile(t, workspace, "skills/status-only/SKILL.md", "---\nname: Status Only\ndescription: Added upstream\n---\n\nNew skill.\n")
+	run(t, workspace, "git", "add", "-A")
+	run(t, workspace, "git", "commit", "-m", "add status-only skill")
+	run(t, workspace, "git", "push")
+
+	cloneDir, err := CloneDir("test-reg")
+	if err != nil {
+		t.Fatalf("CloneDir: %v", err)
+	}
+	beforeHead := gitOutput(t, cloneDir, "rev-parse", "HEAD")
+	outcome, err := Status("test-reg")
+	if err != nil {
+		t.Fatalf("Status after upstream commit: %v", err)
+	}
+	if outcome.Head != beforeHead {
+		t.Fatalf("Status Head=%q; want checkout HEAD %q", outcome.Head, beforeHead)
+	}
+	if outcome.RemoteHead == "" {
+		t.Fatal("Status RemoteHead is empty")
+	}
+	if outcome.RemoteHead == outcome.Head {
+		t.Fatalf("Status RemoteHead=%q; want different from local Head", outcome.RemoteHead)
+	}
+	afterHead := gitOutput(t, cloneDir, "rev-parse", "HEAD")
+	if afterHead != beforeHead {
+		t.Fatalf("checkout HEAD moved to %q; want %q", afterHead, beforeHead)
+	}
+}
+
 func TestIntegration_SyncOutcome(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/cli/internal/registry/registry.go
+++ b/cli/internal/registry/registry.go
@@ -169,6 +169,13 @@ type GitSyncOutcome struct {
 	NewHead string // HEAD sha after the pull
 }
 
+// GitStatusOutcome reports the local and upstream heads of a registry clone
+// after a fetch. Head == RemoteHead means the clone is up to date.
+type GitStatusOutcome struct {
+	Head       string
+	RemoteHead string
+}
+
 // Head returns the current HEAD sha for a git registry clone.
 func Head(name string) (string, error) {
 	if err := checkGit(); err != nil {
@@ -183,6 +190,40 @@ func Head(name string) (string, error) {
 		return "", fmt.Errorf("git rev-parse HEAD failed for %q: %w", name, err)
 	}
 	return head, nil
+}
+
+// Status fetches the registry clone's upstream refs without moving the
+// checkout, then returns local HEAD vs FETCH_HEAD.
+func Status(name string) (GitStatusOutcome, error) {
+	var outcome GitStatusOutcome
+	if err := checkGit(); err != nil {
+		return outcome, err
+	}
+	dir, err := CloneDir(name)
+	if err != nil {
+		return outcome, err
+	}
+	cmd := exec.Command("git",
+		"-C", dir,
+		"-c", "core.hooksPath=/dev/null",
+		"fetch", "--quiet", "--no-recurse-submodules",
+	)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return outcome, fmt.Errorf("git fetch failed for %q: %s\n(Hint: delete the clone at ~/.syllago/registries/%s and re-run `syllago registry sync %s`)", name, strings.TrimSpace(string(out)), name, name)
+	}
+	head, err := gitHead(dir)
+	if err != nil {
+		return outcome, fmt.Errorf("reading HEAD after git fetch for %q: %w", name, err)
+	}
+	remoteHead, err := gitRevParse(dir, "FETCH_HEAD")
+	if err != nil {
+		return outcome, fmt.Errorf("reading FETCH_HEAD after git fetch for %q: %w", name, err)
+	}
+	outcome.Head = head
+	outcome.RemoteHead = remoteHead
+	return outcome, nil
 }
 
 // Sync runs git pull --ff-only in the registry clone directory.
@@ -218,7 +259,11 @@ func Sync(name string) (GitSyncOutcome, error) {
 }
 
 func gitHead(dir string) (string, error) {
-	cmd := exec.Command("git", "-C", dir, "rev-parse", "HEAD")
+	return gitRevParse(dir, "HEAD")
+}
+
+func gitRevParse(dir, ref string) (string, error) {
+	cmd := exec.Command("git", "-C", dir, "rev-parse", ref)
 	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cli/internal/registryops/ops.go
+++ b/cli/internal/registryops/ops.go
@@ -100,6 +100,15 @@ type SyncOutcome struct {
 	Diff *regdiff.Diff
 }
 
+// StatusOutcome reports what a MOAT sync would change, with no persistence.
+type StatusOutcome struct {
+	MoatResult     moat.SyncResult
+	UpToDate       bool          // 304 — upstream manifest unchanged
+	ProfileChanged bool          // upstream signing profile differs from the pinned one; diff withheld
+	NotSynced      bool          // no pinned profile (TOFU would be needed) or no cached manifest baseline
+	Diff           *regdiff.Diff // populated only when none of the above; may still be nil if the cache read fails
+}
+
 // trustedRootStaleError is returned when the bundled Sigstore trusted root is
 // expired/missing/corrupt. Callers errors.As() this to surface a structured
 // "run syllago update" error with the appropriate code.
@@ -139,55 +148,7 @@ var SyncOneFn = moat.Sync
 // Surface-neutral by design: the function returns a typed outcome; callers
 // translate it into their own error/message shape.
 func SyncOne(ctx context.Context, name string, opts SyncOpts) (SyncOutcome, error) {
-	now := opts.Now
-	if now.IsZero() {
-		now = time.Now()
-	}
-
-	// Trusted-root is environmental state — checking it before LoadGlobal
-	// means a stale bundle surfaces with the right "run syllago update" error
-	// even on first run before any registries are configured.
-	rootInfo := moat.BundledTrustedRoot(now)
-	switch rootInfo.Status {
-	case moat.TrustedRootStatusExpired,
-		moat.TrustedRootStatusMissing,
-		moat.TrustedRootStatusCorrupt:
-		return SyncOutcome{}, &trustedRootStaleError{Status: rootInfo.Status}
-	}
-
-	cfg, err := config.LoadGlobal()
-	if err != nil {
-		return SyncOutcome{}, fmt.Errorf("load global config: %w", err)
-	}
-	var reg *config.Registry
-	for i := range cfg.Registries {
-		if cfg.Registries[i].Name == name {
-			reg = &cfg.Registries[i]
-			break
-		}
-	}
-	if reg == nil {
-		return SyncOutcome{}, fmt.Errorf("registry %q not found in config", name)
-	}
-	if !reg.IsMOAT() {
-		return SyncOutcome{}, fmt.Errorf("registry %q is not MOAT-typed", name)
-	}
-
-	cacheDir := opts.CacheDir
-	if cacheDir == "" {
-		cacheDir, err = config.GlobalDirPath()
-		if err != nil {
-			return SyncOutcome{}, fmt.Errorf("resolve cache dir: %w", err)
-		}
-	}
-
-	lockfilePath := moat.LockfilePath(opts.LockfileRoot)
-	lf, err := moat.LoadLockfile(lockfilePath)
-	if err != nil {
-		return SyncOutcome{}, fmt.Errorf("load lockfile: %w", err)
-	}
-
-	res, err := SyncOneFn(ctx, reg, lf, rootInfo.Bytes, nil, now)
+	cfg, reg, lf, lockfilePath, cacheDir, res, err := syncFetch(ctx, name, opts)
 	if err != nil {
 		return SyncOutcome{MoatResult: res}, err
 	}
@@ -262,4 +223,95 @@ func SyncOne(ctx context.Context, name string, opts SyncOpts) (SyncOutcome, erro
 
 	out.Persisted = true
 	return out, nil
+}
+
+// StatusOne is the read-only counterpart of SyncOne: it fetches and verifies
+// the upstream manifest but persists NOTHING — no config, lockfile, or
+// manifest-cache writes. The in-memory lockfile mutations moat.Sync makes are
+// discarded.
+func StatusOne(ctx context.Context, name string, opts SyncOpts) (StatusOutcome, error) {
+	_, reg, _, _, cacheDir, res, err := syncFetch(ctx, name, opts)
+	out := StatusOutcome{MoatResult: res}
+	if err != nil {
+		return out, err
+	}
+	if res.NotModified {
+		out.UpToDate = true
+		return out, nil
+	}
+	if res.ProfileChanged {
+		out.ProfileChanged = true
+		return out, nil
+	}
+	if res.IsTOFU {
+		out.NotSynced = true
+		return out, nil
+	}
+
+	old, err := regdiff.LoadCachedManifest(cacheDir, reg.Name)
+	if err != nil {
+		return out, nil
+	}
+	if old == nil {
+		out.NotSynced = true
+		return out, nil
+	}
+	d := regdiff.MOATDiff(reg.Name, old, res.Manifest)
+	out.Diff = &d
+	return out, nil
+}
+
+func syncFetch(ctx context.Context, name string, opts SyncOpts) (cfg *config.Config, reg *config.Registry, lf *moat.Lockfile, lockfilePath, cacheDir string, res moat.SyncResult, err error) {
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	// Trusted-root is environmental state — checking it before LoadGlobal
+	// means a stale bundle surfaces with the right "run syllago update" error
+	// even on first run before any registries are configured.
+	rootInfo := moat.BundledTrustedRoot(now)
+	switch rootInfo.Status {
+	case moat.TrustedRootStatusExpired,
+		moat.TrustedRootStatusMissing,
+		moat.TrustedRootStatusCorrupt:
+		return nil, nil, nil, "", "", moat.SyncResult{}, &trustedRootStaleError{Status: rootInfo.Status}
+	}
+
+	cfg, err = config.LoadGlobal()
+	if err != nil {
+		return nil, nil, nil, "", "", moat.SyncResult{}, fmt.Errorf("load global config: %w", err)
+	}
+	for i := range cfg.Registries {
+		if cfg.Registries[i].Name == name {
+			reg = &cfg.Registries[i]
+			break
+		}
+	}
+	if reg == nil {
+		return cfg, nil, nil, "", "", moat.SyncResult{}, fmt.Errorf("registry %q not found in config", name)
+	}
+	if !reg.IsMOAT() {
+		return cfg, reg, nil, "", "", moat.SyncResult{}, fmt.Errorf("registry %q is not MOAT-typed", name)
+	}
+
+	cacheDir = opts.CacheDir
+	if cacheDir == "" {
+		cacheDir, err = config.GlobalDirPath()
+		if err != nil {
+			return cfg, reg, nil, "", "", moat.SyncResult{}, fmt.Errorf("resolve cache dir: %w", err)
+		}
+	}
+
+	lockfilePath = moat.LockfilePath(opts.LockfileRoot)
+	lf, err = moat.LoadLockfile(lockfilePath)
+	if err != nil {
+		return cfg, reg, nil, lockfilePath, cacheDir, moat.SyncResult{}, fmt.Errorf("load lockfile: %w", err)
+	}
+
+	res, err = SyncOneFn(ctx, reg, lf, rootInfo.Bytes, nil, now)
+	if err != nil {
+		return cfg, reg, lf, lockfilePath, cacheDir, res, err
+	}
+	return cfg, reg, lf, lockfilePath, cacheDir, res, nil
 }

--- a/cli/internal/registryops/ops_test.go
+++ b/cli/internal/registryops/ops_test.go
@@ -3,6 +3,7 @@ package registryops
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -102,6 +103,130 @@ func TestSyncOneNotModifiedHasNoDiff(t *testing.T) {
 	}
 }
 
+func TestStatusOneNotModifiedIsUpToDateAndReadOnly(t *testing.T) {
+	root, cacheDir := setupSyncOneDiffTest(t)
+	stubSyncOneDiff(t, syncOneDiffResult(t, nil, true))
+
+	outcome, err := StatusOne(context.Background(), "example", SyncOpts{
+		LockfileRoot: root,
+		CacheDir:     cacheDir,
+		Now:          syncOneDiffNow(),
+	})
+	if err != nil {
+		t.Fatalf("StatusOne: %v", err)
+	}
+	if !outcome.UpToDate {
+		t.Fatalf("UpToDate = false; want true")
+	}
+	if outcome.Diff != nil {
+		t.Fatalf("Diff = %#v; want nil", outcome.Diff)
+	}
+	assertStatusOneNoPersistence(t, root, `"old"`)
+}
+
+func TestStatusOneFreshManifestDiffsCachedBaselineWithoutPersisting(t *testing.T) {
+	root, cacheDir := setupSyncOneDiffTest(t)
+	oldManifest := syncOneDiffManifest(t, "2026-04-20T00:00:00Z", []moat.ContentEntry{
+		syncOneDiffEntry("kept", "1"),
+		syncOneDiffEntry("removed", "2"),
+	})
+	oldBytes := syncOneDiffManifestBytes(t, oldManifest)
+	if err := moat.WriteManifestCache(cacheDir, "example", oldBytes, []byte(`{"bundle":true}`)); err != nil {
+		t.Fatalf("WriteManifestCache: %v", err)
+	}
+
+	newManifest := syncOneDiffManifest(t, "2026-04-21T00:00:00Z", []moat.ContentEntry{
+		syncOneDiffEntry("added", "3"),
+		syncOneDiffEntry("kept", "4"),
+	})
+	stubSyncOneDiff(t, syncOneDiffResult(t, newManifest, false))
+
+	outcome, err := StatusOne(context.Background(), "example", SyncOpts{
+		LockfileRoot: root,
+		CacheDir:     cacheDir,
+		Now:          syncOneDiffNow(),
+	})
+	if err != nil {
+		t.Fatalf("StatusOne: %v", err)
+	}
+	if outcome.NotSynced || outcome.UpToDate || outcome.ProfileChanged {
+		t.Fatalf("unexpected gate flags: %+v", outcome)
+	}
+	if outcome.Diff == nil {
+		t.Fatal("Diff = nil; want cached-baseline diff")
+	}
+	want := []regdiff.ItemChange{
+		{Type: "skill", Name: "added", Kind: regdiff.KindAdded},
+		{Type: "skill", Name: "kept", Kind: regdiff.KindModified},
+		{Type: "skill", Name: "removed", Kind: regdiff.KindRemoved},
+	}
+	if !reflect.DeepEqual(outcome.Diff.Changes, want) {
+		t.Fatalf("Diff.Changes = %#v; want %#v", outcome.Diff.Changes, want)
+	}
+	assertStatusOneNoPersistence(t, root, `"old"`)
+	manifestPath, err := moat.ManifestCachePath(cacheDir, "example")
+	if err != nil {
+		t.Fatalf("ManifestCachePath: %v", err)
+	}
+	gotBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadFile cached manifest: %v", err)
+	}
+	if string(gotBytes) != string(oldBytes) {
+		t.Fatalf("cached manifest was overwritten:\n got %s\nwant %s", gotBytes, oldBytes)
+	}
+}
+
+func TestStatusOneProfileChangedWithholdsDiff(t *testing.T) {
+	root, cacheDir := setupSyncOneDiffTest(t)
+	res := syncOneDiffResult(t, syncOneDiffManifest(t, "2026-04-21T00:00:00Z", []moat.ContentEntry{
+		syncOneDiffEntry("added", "3"),
+	}), false)
+	res.ProfileChanged = true
+	stubSyncOneDiff(t, res)
+
+	outcome, err := StatusOne(context.Background(), "example", SyncOpts{
+		LockfileRoot: root,
+		CacheDir:     cacheDir,
+		Now:          syncOneDiffNow(),
+	})
+	if err != nil {
+		t.Fatalf("StatusOne: %v", err)
+	}
+	if !outcome.ProfileChanged {
+		t.Fatalf("ProfileChanged = false; want true")
+	}
+	if outcome.Diff != nil {
+		t.Fatalf("Diff = %#v; want nil", outcome.Diff)
+	}
+	assertStatusOneNoPersistence(t, root, `"old"`)
+}
+
+func TestStatusOneTOFUIsNotSynced(t *testing.T) {
+	root, cacheDir := setupSyncOneDiffTest(t)
+	res := syncOneDiffResult(t, syncOneDiffManifest(t, "2026-04-21T00:00:00Z", []moat.ContentEntry{
+		syncOneDiffEntry("first", "1"),
+	}), false)
+	res.IsTOFU = true
+	stubSyncOneDiff(t, res)
+
+	outcome, err := StatusOne(context.Background(), "example", SyncOpts{
+		LockfileRoot: root,
+		CacheDir:     cacheDir,
+		Now:          syncOneDiffNow(),
+	})
+	if err != nil {
+		t.Fatalf("StatusOne: %v", err)
+	}
+	if !outcome.NotSynced {
+		t.Fatalf("NotSynced = false; want true")
+	}
+	if outcome.Diff != nil {
+		t.Fatalf("Diff = %#v; want nil", outcome.Diff)
+	}
+	assertStatusOneNoPersistence(t, root, `"old"`)
+}
+
 func setupSyncOneDiffTest(t *testing.T) (root, cacheDir string) {
 	t.Helper()
 	root = t.TempDir()
@@ -120,6 +245,7 @@ func setupSyncOneDiffTest(t *testing.T) (root, cacheDir string) {
 				Type:           config.RegistryTypeMOAT,
 				ManifestURI:    "https://registry.example.com/manifest.json",
 				SigningProfile: &profile,
+				ManifestETag:   `"old"`,
 			},
 		},
 	}
@@ -127,6 +253,23 @@ func setupSyncOneDiffTest(t *testing.T) (root, cacheDir string) {
 		t.Fatalf("SaveGlobal: %v", err)
 	}
 	return root, cacheDir
+}
+
+func assertStatusOneNoPersistence(t *testing.T, root, wantETag string) {
+	t.Helper()
+	reloaded, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if len(reloaded.Registries) != 1 {
+		t.Fatalf("loaded %d registries; want 1", len(reloaded.Registries))
+	}
+	if reloaded.Registries[0].ManifestETag != wantETag {
+		t.Fatalf("ManifestETag = %q; want unchanged %q", reloaded.Registries[0].ManifestETag, wantETag)
+	}
+	if _, err := os.Stat(moat.LockfilePath(root)); !os.IsNotExist(err) {
+		t.Fatalf("lockfile exists after StatusOne: %v", err)
+	}
 }
 
 func stubSyncOneDiff(t *testing.T, result moat.SyncResult) {

--- a/cli/internal/telemetry/catalog.go
+++ b/cli/internal/telemetry/catalog.go
@@ -177,7 +177,7 @@ func EventCatalog() []EventDef {
 					Type:        "int",
 					Description: "Number of registries involved",
 					Example:     2,
-					Commands:    []string{"registry_sync"},
+					Commands:    []string{"registry_sync", "registry_status"},
 				},
 				{
 					Name:        "moat_tier",

--- a/cli/telemetry.json
+++ b/cli/telemetry.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generatedAt": "2026-08-23T00:25:38Z",
+  "generatedAt": "2026-08-23T01:52:59Z",
   "syllagoVersion": "0.14.0",
   "events": [
     {
@@ -215,7 +215,8 @@
           "description": "Number of registries involved",
           "example": 2,
           "commands": [
-            "registry_sync"
+            "registry_sync",
+            "registry_status"
           ]
         },
         {


### PR DESCRIPTION
## Summary
- Part of #542 (item 6c-ii). Complements #555's sync-time diff display with a read-only probe: `syllago registry status [name]` shows upstream changes without moving git checkouts or persisting MOAT trust/cache state.
- Git registries: new `registry.Status` runs `git fetch` (checkout untouched) and compares HEAD vs FETCH_HEAD; changes render through the same regdiff pipeline as sync, with a kind-refinement pass because `GitDiff` classifies adds/removes against the working tree, which status intentionally leaves at the old head.
- MOAT registries: new `registryops.StatusOne` mirrors `SyncOne`'s fetch+verify via a shared `syncFetch` prologue but writes nothing — no config ETag, no lockfile, no manifest cache. 304 → up to date; signing-profile change and TOFU-needed are reported with a "run registry sync" hint instead of gating; otherwise the fresh manifest is diffed against the cached baseline.
- Output: per-registry status lines (`up to date` / `N upstream change(s)` + diff lines via the extracted `printRegistryDiffLines`), per-registry errors as stderr warnings with exit 0 on a completed walk; `--json` emits `{name, kind, state, added, modified, removed}` rows.

## Testing
- `StatusOne` unit tests for all four states, each asserting nothing persisted (on-disk ETag unchanged, no lockfile, no cache write).
- Bare-repo integration tests: `registry.Status` fetches without moving the checkout; command-level test asserts exact text output and that a later `registry sync` still pulls the update.
- JSON-mode and unknown-registry tests; existing sync/diff tests pass unchanged.
- Full suite: `go test -count=1 ./...` — 40 packages ok, gofmt clean; `TestGentelemetry_CatalogMatchesEnrichCalls` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
