### PR TITLE
feat(tui): show upstream change counts in registry sync toasts (#542 item 6c-iii)

### DIFF
--- a/cli/cmd/syllago/registry_cmd.go
+++ b/cli/cmd/syllago/registry_cmd.go
@@ -17,7 +17,6 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/gitutil"
 	"github.com/OpenScribbler/syllago/cli/internal/moat"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
-	"github.com/OpenScribbler/syllago/cli/internal/regdiff"
 	"github.com/OpenScribbler/syllago/cli/internal/registry"
 	"github.com/OpenScribbler/syllago/cli/internal/registryops"
 	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
@@ -595,16 +594,8 @@ func syncGitOrMOATRegistry(ctx context.Context, cfg *config.Config, r *config.Re
 	reprobeRegistryVisibility(cfg, r.Name)
 	fmt.Fprintf(output.Writer, "Synced: %s\n", r.Name)
 	if !justCloned && outcome.OldHead != "" && outcome.OldHead != outcome.NewHead {
-		if cloneDir, err := registry.CloneDir(r.Name); err == nil {
-			items := gitItemRefs(r.Name, cloneDir)
-			types := catalog.AllContentTypes()
-			knownTypeDirs := make([]string, 0, len(types))
-			for _, ct := range types {
-				knownTypeDirs = append(knownTypeDirs, string(ct))
-			}
-			if d, err := regdiff.GitDiff(r.Name, cloneDir, outcome.OldHead, outcome.NewHead, items, knownTypeDirs); err == nil {
-				printRegistryDiff(output.Writer, &d)
-			}
+		if d := registryops.GitSyncDiff(r.Name, outcome.OldHead, outcome.NewHead); d != nil {
+			printRegistryDiff(output.Writer, d)
 		}
 	}
 	return 0, nil

--- a/cli/cmd/syllago/registry_diff.go
+++ b/cli/cmd/syllago/registry_diff.go
@@ -3,10 +3,8 @@ package main
 import (
 	"fmt"
 	"io"
-	"path/filepath"
 	"strings"
 
-	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/regdiff"
 )
@@ -65,32 +63,4 @@ func trimRegistryDiffName(name string) string {
 		}
 	}
 	return name
-}
-
-func gitItemRefs(regName, cloneDir string) []regdiff.ItemRef {
-	cat, err := catalog.ScanRegistriesOnly([]catalog.RegistrySource{
-		{Name: regName, Path: cloneDir},
-	})
-	if err != nil {
-		return nil
-	}
-
-	refs := make([]regdiff.ItemRef, 0, len(cat.Items))
-	for _, item := range cat.Items {
-		rel, err := filepath.Rel(cloneDir, item.Path)
-		if err != nil {
-			continue
-		}
-		cleaned := filepath.Clean(rel)
-		relSlash := filepath.ToSlash(cleaned)
-		if filepath.IsAbs(cleaned) || relSlash == ".." || strings.HasPrefix(relSlash, "../") {
-			continue
-		}
-		refs = append(refs, regdiff.ItemRef{
-			Type: string(item.Type),
-			Name: item.Name,
-			Dir:  relSlash,
-		})
-	}
-	return refs
 }

--- a/cli/cmd/syllago/registry_diff_test.go
+++ b/cli/cmd/syllago/registry_diff_test.go
@@ -3,9 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"os"
-	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/OpenScribbler/syllago/cli/internal/output"
@@ -200,40 +197,4 @@ func TestPrintRegistryDiff_QuietAndJSONSuppressOutput(t *testing.T) {
 			t.Fatalf("json output = %q; want empty", got)
 		}
 	})
-}
-
-func TestGitItemRefs(t *testing.T) {
-	t.Parallel()
-
-	cloneDir := t.TempDir()
-	writeRegistryDiffTestFile(t, cloneDir, "skills/my-skill/SKILL.md", "# My Skill\n")
-	writeRegistryDiffTestFile(t, cloneDir, "rules/a-rule.md", "# A Rule\n")
-	writeRegistryDiffTestFile(t, cloneDir, "registry.yaml", `items:
-  - name: my-skill
-    type: skills
-    path: skills/my-skill
-  - name: a-rule
-    type: rules
-    path: rules/a-rule.md
-`)
-
-	got := gitItemRefs("example", cloneDir)
-	want := []regdiff.ItemRef{
-		{Type: "skills", Name: "my-skill", Dir: "skills/my-skill"},
-		{Type: "rules", Name: "a-rule", Dir: "rules/a-rule.md"},
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("gitItemRefs() = %#v; want %#v", got, want)
-	}
-}
-
-func writeRegistryDiffTestFile(t *testing.T, root, rel, contents string) {
-	t.Helper()
-	path := filepath.Join(root, filepath.FromSlash(rel))
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
-	}
-	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
-		t.Fatalf("write %s: %v", rel, err)
-	}
 }

--- a/cli/cmd/syllago/registry_status.go
+++ b/cli/cmd/syllago/registry_status.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/moat"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
@@ -162,30 +161,24 @@ func registryStatusGit(reg *config.Registry) (registryStatusJSON, error) {
 		return row, nil
 	}
 
+	d := registryops.GitSyncDiff(reg.Name, outcome.Head, outcome.RemoteHead)
+	if d == nil {
+		row.State = "error"
+		row.Error = "could not compare"
+		registryStatusPrintLine("%s (git): could not compare — run 'syllago registry sync %s'\n", reg.Name, reg.Name)
+		return row, nil
+	}
 	cloneDir, err := registry.CloneDir(reg.Name)
 	if err != nil {
 		row.State = "error"
-		row.Error = err.Error()
+		row.Error = "could not compare"
 		registryStatusPrintLine("%s (git): could not compare — run 'syllago registry sync %s'\n", reg.Name, reg.Name)
 		return row, nil
 	}
-	items := gitItemRefs(reg.Name, cloneDir)
-	types := catalog.AllContentTypes()
-	knownTypeDirs := make([]string, 0, len(types))
-	for _, ct := range types {
-		knownTypeDirs = append(knownTypeDirs, string(ct))
-	}
-	d, err := regdiff.GitDiff(reg.Name, cloneDir, outcome.Head, outcome.RemoteHead, items, knownTypeDirs)
-	if err != nil {
-		row.State = "error"
-		row.Error = err.Error()
-		registryStatusPrintLine("%s (git): could not compare — run 'syllago registry sync %s'\n", reg.Name, reg.Name)
-		return row, nil
-	}
-	refineRegistryStatusGitKinds(cloneDir, outcome.Head, outcome.RemoteHead, &d)
-	if registryStatusHasChanges(&d) {
-		registryStatusSetChangeCounts(&row, &d)
-		registryStatusPrintDiff(reg.Name, "git", &d)
+	refineRegistryStatusGitKinds(cloneDir, outcome.Head, outcome.RemoteHead, d)
+	if registryStatusHasChanges(d) {
+		registryStatusSetChangeCounts(&row, d)
+		registryStatusPrintDiff(reg.Name, "git", d)
 		return row, nil
 	}
 

--- a/cli/internal/registryops/gitdiff.go
+++ b/cli/internal/registryops/gitdiff.go
@@ -1,0 +1,61 @@
+package registryops
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/regdiff"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
+)
+
+// GitSyncDiff computes the item-level diff between two refs of a plain git
+// registry's clone. Returns nil when the diff cannot be computed; diff display
+// is best-effort for presentation surfaces.
+func GitSyncDiff(regName, oldHead, newHead string) *regdiff.Diff {
+	cloneDir, err := registry.CloneDir(regName)
+	if err != nil {
+		return nil
+	}
+
+	items := gitItemRefs(regName, cloneDir)
+	types := catalog.AllContentTypes()
+	knownTypeDirs := make([]string, 0, len(types))
+	for _, ct := range types {
+		knownTypeDirs = append(knownTypeDirs, string(ct))
+	}
+
+	d, err := regdiff.GitDiff(regName, cloneDir, oldHead, newHead, items, knownTypeDirs)
+	if err != nil {
+		return nil
+	}
+	return &d
+}
+
+func gitItemRefs(regName, cloneDir string) []regdiff.ItemRef {
+	cat, err := catalog.ScanRegistriesOnly([]catalog.RegistrySource{
+		{Name: regName, Path: cloneDir},
+	})
+	if err != nil {
+		return nil
+	}
+
+	refs := make([]regdiff.ItemRef, 0, len(cat.Items))
+	for _, item := range cat.Items {
+		rel, err := filepath.Rel(cloneDir, item.Path)
+		if err != nil {
+			continue
+		}
+		cleaned := filepath.Clean(rel)
+		relSlash := filepath.ToSlash(cleaned)
+		if filepath.IsAbs(cleaned) || relSlash == ".." || strings.HasPrefix(relSlash, "../") {
+			continue
+		}
+		refs = append(refs, regdiff.ItemRef{
+			Type: string(item.Type),
+			Name: item.Name,
+			Dir:  relSlash,
+		})
+	}
+	return refs
+}

--- a/cli/internal/registryops/gitdiff_test.go
+++ b/cli/internal/registryops/gitdiff_test.go
@@ -1,0 +1,96 @@
+package registryops
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/regdiff"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
+)
+
+func TestGitSyncDiff(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	cacheDir := t.TempDir()
+	oldCacheDir := registry.CacheDirOverride
+	registry.CacheDirOverride = cacheDir
+	t.Cleanup(func() { registry.CacheDirOverride = oldCacheDir })
+
+	repoDir := filepath.Join(cacheDir, "test-reg")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	gitDiffTestGit(t, repoDir, "init")
+	gitDiffTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	gitDiffTestGit(t, repoDir, "config", "user.name", "Test User")
+	gitDiffTestGit(t, repoDir, "config", "commit.gpgsign", "false")
+
+	gitDiffTestWriteFile(t, repoDir, "skills/alpha/SKILL.md", "# Alpha\n\nv1\n")
+	gitDiffTestGit(t, repoDir, "add", "-A")
+	gitDiffTestGit(t, repoDir, "commit", "-m", "initial")
+	oldHead := gitDiffTestGit(t, repoDir, "rev-parse", "HEAD")
+
+	gitDiffTestWriteFile(t, repoDir, "skills/alpha/SKILL.md", "# Alpha\n\nv2\n")
+	gitDiffTestWriteFile(t, repoDir, "skills/beta/SKILL.md", "# Beta\n\nv1\n")
+	gitDiffTestGit(t, repoDir, "add", "-A")
+	gitDiffTestGit(t, repoDir, "commit", "-m", "update content")
+	newHead := gitDiffTestGit(t, repoDir, "rev-parse", "HEAD")
+
+	got := GitSyncDiff("test-reg", oldHead, newHead)
+	if got == nil {
+		t.Fatal("GitSyncDiff = nil; want diff")
+	}
+	wantChanges := []regdiff.ItemChange{
+		{Type: "skills", Name: "alpha", Kind: regdiff.KindModified, Paths: []string{"skills/alpha/SKILL.md"}},
+		{Type: "skills", Name: "beta", Kind: regdiff.KindAdded, Paths: []string{"skills/beta/SKILL.md"}},
+	}
+	if !reflect.DeepEqual(got.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v; want %#v", got.Changes, wantChanges)
+	}
+	if got.Registry != "test-reg" || got.OldRef != oldHead || got.NewRef != newHead {
+		t.Fatalf("refs = (%q, %q, %q); want (%q, %q, %q)", got.Registry, got.OldRef, got.NewRef, "test-reg", oldHead, newHead)
+	}
+	if len(got.OtherPaths) != 0 {
+		t.Fatalf("OtherPaths = %#v; want empty", got.OtherPaths)
+	}
+}
+
+func TestGitSyncDiffMissingRegistry(t *testing.T) {
+	cacheDir := t.TempDir()
+	oldCacheDir := registry.CacheDirOverride
+	registry.CacheDirOverride = cacheDir
+	t.Cleanup(func() { registry.CacheDirOverride = oldCacheDir })
+
+	if got := GitSyncDiff("missing-reg", "old", "new"); got != nil {
+		t.Fatalf("GitSyncDiff missing registry = %#v; want nil", got)
+	}
+}
+
+func gitDiffTestWriteFile(t *testing.T, repoDir, rel, contents string) {
+	t.Helper()
+	path := filepath.Join(repoDir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func gitDiffTestGit(t *testing.T, repoDir string, args ...string) string {
+	t.Helper()
+	cmdArgs := append([]string{"-C", repoDir}, args...)
+	cmd := exec.Command("git", cmdArgs...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", cmdArgs, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/cli/internal/tui/actions.go
+++ b/cli/internal/tui/actions.go
@@ -20,6 +20,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/moatinstall"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/OpenScribbler/syllago/cli/internal/regdiff"
 	"github.com/OpenScribbler/syllago/cli/internal/registry"
 	"github.com/OpenScribbler/syllago/cli/internal/registryops"
 	"github.com/OpenScribbler/syllago/cli/internal/rulestore"
@@ -404,6 +405,7 @@ type registryAddDoneMsg struct {
 type registrySyncDoneMsg struct {
 	name string
 	err  error
+	diff *regdiff.Diff
 }
 
 // registryRemoveDoneMsg is sent when a registry remove operation completes.
@@ -569,11 +571,18 @@ func (a App) handleSync() (tea.Model, tea.Cmd) {
 	}
 
 	cmd1 := a.toast.Push("Syncing "+name+"...", toastSuccess)
-	cmd2 := func() tea.Msg {
-		_, err := registry.Sync(name)
-		return registrySyncDoneMsg{name: name, err: err}
+	return a, tea.Batch(cmd1, a.doGitSyncCmd(name))
+}
+
+func (a App) doGitSyncCmd(name string) tea.Cmd {
+	return func() tea.Msg {
+		outcome, err := registry.Sync(name)
+		msg := registrySyncDoneMsg{name: name, err: err}
+		if err == nil && outcome.OldHead != "" && outcome.OldHead != outcome.NewHead {
+			msg.diff = registryops.GitSyncDiff(name, outcome.OldHead, outcome.NewHead)
+		}
+		return msg
 	}
-	return a, tea.Batch(cmd1, tea.Cmd(cmd2))
 }
 
 // registryIsMOAT reports whether the named registry is MOAT-typed in the
@@ -614,7 +623,11 @@ func (a App) handleMOATSyncDone(msg moatSyncDoneMsg) (tea.Model, tea.Cmd) {
 	if msg.stale {
 		verb = "Synced (stale) "
 	}
-	cmd1 := a.toast.Push(verb+msg.name, toastSuccess)
+	text := verb + msg.name
+	if summary := syncDiffSummary(msg.diff); summary != "" {
+		text += ": " + summary
+	}
+	cmd1 := a.toast.Push(text, toastSuccess)
 	cmd2 := a.rescanCatalog()
 	return a, tea.Batch(cmd1, cmd2)
 }
@@ -626,9 +639,43 @@ func (a App) handleSyncDone(msg registrySyncDoneMsg) (tea.Model, tea.Cmd) {
 		cmd := a.toast.Push("Sync failed: "+msg.err.Error(), toastError)
 		return a, cmd
 	}
-	cmd1 := a.toast.Push("Synced "+msg.name, toastSuccess)
+	text := "Synced " + msg.name
+	if summary := syncDiffSummary(msg.diff); summary != "" {
+		text += ": " + summary
+	}
+	cmd1 := a.toast.Push(text, toastSuccess)
 	cmd2 := a.rescanCatalog()
 	return a, tea.Batch(cmd1, cmd2)
+}
+
+func syncDiffSummary(d *regdiff.Diff) string {
+	if d == nil || len(d.Changes) == 0 {
+		return ""
+	}
+
+	var added, modified, removed int
+	for _, change := range d.Changes {
+		switch change.Kind {
+		case regdiff.KindAdded:
+			added++
+		case regdiff.KindRemoved:
+			removed++
+		default:
+			modified++
+		}
+	}
+
+	var parts []string
+	if added > 0 {
+		parts = append(parts, fmt.Sprintf("+%d", added))
+	}
+	if modified > 0 {
+		parts = append(parts, fmt.Sprintf("~%d", modified))
+	}
+	if removed > 0 {
+		parts = append(parts, fmt.Sprintf("-%d", removed))
+	}
+	return fmt.Sprintf("%d upstream change(s) (%s)", len(d.Changes), strings.Join(parts, " "))
 }
 
 // handleTOFUResult routes the user's accept/reject decision from the TOFU

--- a/cli/internal/tui/actions_test.go
+++ b/cli/internal/tui/actions_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/moat"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/OpenScribbler/syllago/cli/internal/regdiff"
 	"github.com/OpenScribbler/syllago/cli/internal/registry"
 	"github.com/OpenScribbler/syllago/cli/internal/registryops"
 )
@@ -68,6 +69,17 @@ func testAppWithInstalledRule(t *testing.T) (App, catalog.ContentItem, provider.
 	app := NewApp(cat, []provider.Provider{prov}, "0.0.0-test", false, nil, testConfig(), false, "", t.TempDir())
 	m, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	return m.(App), item, prov
+}
+
+func assertCurrentToastMessage(t *testing.T, app App, want string) {
+	t.Helper()
+	cur := app.toast.Current()
+	if cur == nil {
+		t.Fatalf("toast.Current() = nil; want %q", want)
+	}
+	if cur.message != want {
+		t.Fatalf("toast message = %q; want %q", cur.message, want)
+	}
 }
 
 // TestHandleInstall_AcceptsUndetectedProviders verifies that the install wizard
@@ -218,6 +230,73 @@ func TestActions_HandleInstallAllDone_EmptyName(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected cmd when itemName empty (default to \"item\")")
 	}
+}
+
+func TestSyncDiffSummary(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		diff *regdiff.Diff
+		want string
+	}{
+		{name: "nil", diff: nil, want: ""},
+		{name: "empty", diff: &regdiff.Diff{}, want: ""},
+		{name: "only-other-paths", diff: &regdiff.Diff{OtherPaths: []string{"README.md"}}, want: ""},
+		{
+			name: "adds-only",
+			diff: &regdiff.Diff{Changes: []regdiff.ItemChange{
+				{Kind: regdiff.KindAdded},
+				{Kind: regdiff.KindAdded},
+			}},
+			want: "2 upstream change(s) (+2)",
+		},
+		{
+			name: "mixed",
+			diff: &regdiff.Diff{Changes: []regdiff.ItemChange{
+				{Kind: regdiff.KindAdded},
+				{Kind: regdiff.KindModified},
+				{Kind: regdiff.KindRemoved},
+				{Kind: regdiff.Kind("renamed")},
+			}},
+			want: "4 upstream change(s) (+1 ~2 -1)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := syncDiffSummary(tc.diff); got != tc.want {
+				t.Fatalf("syncDiffSummary() = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHandleSyncDone_WithDiffSummary(t *testing.T) {
+	t.Parallel()
+	app := testApp(t)
+	app.registryOpInProgress = true
+	diff := &regdiff.Diff{Changes: []regdiff.ItemChange{
+		{Kind: regdiff.KindAdded},
+		{Kind: regdiff.KindModified},
+	}}
+
+	m, _ := app.handleSyncDone(registrySyncDoneMsg{name: "test-reg", diff: diff})
+	a := m.(App)
+
+	if a.registryOpInProgress {
+		t.Fatal("registryOpInProgress should clear on success")
+	}
+	assertCurrentToastMessage(t, a, "Synced test-reg: 2 upstream change(s) (+1 ~1)")
+}
+
+func TestHandleSyncDone_NoDiffKeepsPlainToast(t *testing.T) {
+	t.Parallel()
+	app := testApp(t)
+
+	m, _ := app.handleSyncDone(registrySyncDoneMsg{name: "test-reg"})
+	a := m.(App)
+
+	assertCurrentToastMessage(t, a, "Synced test-reg")
 }
 
 func TestActions_HandleRemoveResult_NotConfirmed(t *testing.T) {

--- a/cli/internal/tui/moat_sync.go
+++ b/cli/internal/tui/moat_sync.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"github.com/OpenScribbler/syllago/cli/internal/regdiff"
 	"github.com/OpenScribbler/syllago/cli/internal/registryops"
 )
 
@@ -50,6 +51,10 @@ type moatSyncDoneMsg struct {
 	// stale is true when the manifest has aged past its 72h window and is
 	// not safe to extend trust from. Surfaced as a warning toast.
 	stale bool
+
+	// diff is best-effort item-level upstream change information. Nil means
+	// no changes or no comparable baseline.
+	diff *regdiff.Diff
 }
 
 // moatSyncFnTUI is the indirection point so tests can stub the end-to-end
@@ -108,5 +113,6 @@ func runMOATSync(ctx context.Context, name, projectRoot string, acceptTOFU bool)
 	return moatSyncDoneMsg{
 		name:  name,
 		stale: outcome.MoatResult.Staleness == moat.StalenessExpired,
+		diff:  outcome.Diff,
 	}
 }

--- a/cli/internal/tui/moat_sync_test.go
+++ b/cli/internal/tui/moat_sync_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/regdiff"
 )
 
 func TestRegistryIsMOAT_True(t *testing.T) {
@@ -140,6 +141,20 @@ func TestHandleMOATSyncDone_HappyPath(t *testing.T) {
 	}
 }
 
+func TestHandleMOATSyncDone_HappyPathWithDiffSummary(t *testing.T) {
+	t.Parallel()
+	app := testApp(t)
+	diff := &regdiff.Diff{Changes: []regdiff.ItemChange{
+		{Kind: regdiff.KindAdded},
+		{Kind: regdiff.KindModified},
+	}}
+
+	m, _ := app.handleMOATSyncDone(moatSyncDoneMsg{name: "reg", diff: diff})
+	a := m.(App)
+
+	assertCurrentToastMessage(t, a, "Synced reg: 2 upstream change(s) (+1 ~1)")
+}
+
 func TestHandleMOATSyncDone_Stale(t *testing.T) {
 	t.Parallel()
 	app := testApp(t)
@@ -151,6 +166,20 @@ func TestHandleMOATSyncDone_Stale(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("stale path should still toast + rescan")
 	}
+}
+
+func TestHandleMOATSyncDone_StaleWithDiffSummary(t *testing.T) {
+	t.Parallel()
+	app := testApp(t)
+	diff := &regdiff.Diff{Changes: []regdiff.ItemChange{
+		{Kind: regdiff.KindAdded},
+		{Kind: regdiff.KindModified},
+	}}
+
+	m, _ := app.handleMOATSyncDone(moatSyncDoneMsg{name: "reg", stale: true, diff: diff})
+	a := m.(App)
+
+	assertCurrentToastMessage(t, a, "Synced (stale) reg: 2 upstream change(s) (+1 ~1)")
 }
 
 func TestHandleTOFUResult_Rejected(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `registryops.GitSyncDiff`, a shared best-effort helper that computes the item-level diff between two refs of a plain git registry clone (moves `gitItemRefs` out of the cmd package); migrates `registry sync` and `registry status` to it and deletes the cmd-level duplicate.
- Threads upstream diff data through both TUI sync paths: `registrySyncDoneMsg` (git, computed after `registry.Sync` when HEAD moved) and `moatSyncDoneMsg` (MOAT, from the `SyncOutcome.Diff` the orchestrator already returned but the TUI dropped).
- Sync success toasts now append change counts — `Synced my-reg: 3 upstream change(s) (+1 ~1 -1)` — for both git and MOAT registries, including the stale-MOAT variant. Syncs with no item changes keep the existing plain toast.

Part of #542 (item 6c-iii: surface sync diffs in the TUI).

## Testing
- New `registryops` tests build a real two-commit git fixture and assert added/modified classification, plus a nil result for a missing registry.
- New TUI tests cover `syncDiffSummary` (nil/empty/adds-only/mixed), git sync toast with and without a diff, and MOAT happy/stale toasts with diff summaries.
- Full suite: `go build ./...` + `go test -count=1 ./...` — 40 packages ok, gofmt clean. No golden updates needed (toast text is asserted via unit tests, not goldens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
