### PR TITLE
fix(cli): root hook/MCP installs at the project root (#542 item 2b-iii)

### DIFF
--- a/cli/cmd/syllago/add_cmd.go
+++ b/cli/cmd/syllago/add_cmd.go
@@ -318,7 +318,7 @@ func chainInstallAfterAdd(results []add.AddResult, toSlug, globalDir, projectRoo
 
 	for _, item := range globalCat.Items {
 		if addedSet[nameType{item.Name, item.Type}] {
-			placement, err := installer.Install(item, *prov, globalDir, installer.MethodSymlink, "")
+			placement, err := installer.Install(item, *prov, projectRoot, installer.MethodSymlink, "")
 			if err != nil {
 				fmt.Fprintf(output.ErrWriter, "Warning: install %s to %s: %v\n", item.Name, toSlug, err)
 			} else {

--- a/cli/cmd/syllago/install_cmd.go
+++ b/cli/cmd/syllago/install_cmd.go
@@ -316,7 +316,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(output.Writer, "Installing %d items to %s...\n", len(items), prov.Name)
 	}
 
-	result, _ := installToProvider(items, *prov, globalDir, method, dryRun, resolver, toSlug, projectRoot)
+	result, _ := installToProvider(items, *prov, method, dryRun, resolver, toSlug, projectRoot)
 
 	if output.JSON {
 		output.Print(result)
@@ -343,7 +343,6 @@ func runInstall(cmd *cobra.Command, args []string) error {
 func installToProvider(
 	items []catalog.ContentItem,
 	prov provider.Provider,
-	globalDir string,
 	method installer.InstallMethod,
 	dryRun bool,
 	resolver *config.PathResolver,
@@ -376,7 +375,7 @@ func installToProvider(
 			continue
 		}
 
-		placement, err := installer.InstallWithResolver(item, prov, globalDir, method, resolver)
+		placement, err := installer.InstallWithResolver(item, prov, projectRoot, method, resolver)
 		if err != nil {
 			result.Skipped = append(result.Skipped, skippedItem{Name: item.Name, Reason: err.Error()})
 			if !output.JSON {
@@ -572,7 +571,7 @@ func runInstallToAll(
 			fmt.Fprintf(output.Writer, "→ %s\n", prov.Name)
 		}
 
-		result, _ := installToProvider(items, prov, globalDir, method, dryRun, resolver, prov.Slug, projectRoot)
+		result, _ := installToProvider(items, prov, method, dryRun, resolver, prov.Slug, projectRoot)
 
 		pr := providerInstallResult{
 			Provider: prov.Name,

--- a/cli/cmd/syllago/install_cmd_test.go
+++ b/cli/cmd/syllago/install_cmd_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/installer"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
 	"github.com/OpenScribbler/syllago/cli/internal/registry"
@@ -343,6 +344,52 @@ func TestInstallAllInstallsEverything(t *testing.T) {
 	out := stdout.String()
 	if !strings.Contains(out, "my-skill") {
 		t.Errorf("expected 'my-skill' in output, got: %s", out)
+	}
+}
+
+func TestInstallMCPRunERecordsAtProjectRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	globalDir := filepath.Join(tmpDir, "global-content")
+	projectRoot := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(filepath.Join(globalDir, "mcp", "cli-root-mcp"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, "mcp", "cli-root-mcp", "config.json"), []byte(`{"command":"node","args":["server.js"]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".syllago"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, ".syllago", "config.json"), []byte(`{"providers":[]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	withGlobalLibrary(t, globalDir)
+	withFakeRepoRoot(t, projectRoot)
+	origCfgDir := config.GlobalDirOverride
+	config.GlobalDirOverride = filepath.Join(tmpDir, "global-config")
+	t.Cleanup(func() { config.GlobalDirOverride = origCfgDir })
+
+	_, _ = output.SetForTest(t)
+
+	installCmd.Flags().Set("to", "cursor")
+	defer installCmd.Flags().Set("to", "")
+	installCmd.Flags().Set("type", "mcp")
+	defer installCmd.Flags().Set("type", "")
+
+	if err := installCmd.RunE(installCmd, []string{"cli-root-mcp"}); err != nil {
+		t.Fatalf("install RunE: %v", err)
+	}
+
+	inst, err := installer.LoadInstalled(projectRoot)
+	if err != nil {
+		t.Fatalf("LoadInstalled(projectRoot): %v", err)
+	}
+	if inst.FindMCPByServerKey("cli-root-mcp", "cli-root-mcp") < 0 {
+		t.Fatal("expected MCP install record under project root")
+	}
+	if _, err := os.Stat(filepath.Join(globalDir, ".syllago", "installed.json")); !os.IsNotExist(err) {
+		t.Fatalf("global installed.json should not be created, stat err = %v", err)
 	}
 }
 

--- a/cli/cmd/syllago/install_trust_test.go
+++ b/cli/cmd/syllago/install_trust_test.go
@@ -53,7 +53,7 @@ func TestInstallTrustLine_DualAttested(t *testing.T) {
 	stdout, _ := output.SetForTest(t)
 
 	items := buildTrustItems(t, globalDir, catalog.TrustTierDualAttested, false, "")
-	result, err := installToProvider(items, *prov, globalDir, installer.MethodSymlink,
+	result, err := installToProvider(items, *prov, installer.MethodSymlink,
 		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir())
 	if err != nil {
 		t.Fatalf("installToProvider: %v", err)
@@ -86,7 +86,7 @@ func TestInstallTrustLine_Signed(t *testing.T) {
 	stdout, _ := output.SetForTest(t)
 
 	items := buildTrustItems(t, globalDir, catalog.TrustTierSigned, false, "")
-	result, _ := installToProvider(items, *prov, globalDir, installer.MethodSymlink,
+	result, _ := installToProvider(items, *prov, installer.MethodSymlink,
 		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir())
 
 	if !strings.Contains(stdout.String(), "Verified (registry-attested)") {
@@ -110,7 +110,7 @@ func TestInstallTrustLine_Revoked(t *testing.T) {
 	// Revoked takes precedence over TrustTier per AD-7 collapse rule —
 	// DualAttested + Revoked must still render as Revoked, not Verified.
 	items := buildTrustItems(t, globalDir, catalog.TrustTierDualAttested, true, "publisher revoked 2026-04-18")
-	result, _ := installToProvider(items, *prov, globalDir, installer.MethodSymlink,
+	result, _ := installToProvider(items, *prov, installer.MethodSymlink,
 		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir())
 
 	out := stdout.String()
@@ -143,7 +143,7 @@ func TestInstallTrustLine_UnknownSuppressed(t *testing.T) {
 	stdout, _ := output.SetForTest(t)
 
 	items := buildTrustItems(t, globalDir, catalog.TrustTierUnknown, false, "")
-	result, _ := installToProvider(items, *prov, globalDir, installer.MethodSymlink,
+	result, _ := installToProvider(items, *prov, installer.MethodSymlink,
 		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir())
 
 	out := stdout.String()
@@ -171,7 +171,7 @@ func TestInstallTrustLine_JSONModeSuppressesText(t *testing.T) {
 	t.Cleanup(func() { output.JSON = false })
 
 	items := buildTrustItems(t, globalDir, catalog.TrustTierSigned, false, "")
-	result, _ := installToProvider(items, *prov, globalDir, installer.MethodSymlink,
+	result, _ := installToProvider(items, *prov, installer.MethodSymlink,
 		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir())
 
 	// installToProvider does not print the result JSON itself — that's the
@@ -192,7 +192,7 @@ func TestInstallTrustLine_JSONModeSuppressesText(t *testing.T) {
 
 	// And an Unknown-tier item must omit the trust key entirely (omitempty).
 	itemsUnknown := buildTrustItems(t, globalDir, catalog.TrustTierUnknown, false, "")
-	resultU, _ := installToProvider(itemsUnknown, *prov, globalDir, installer.MethodSymlink,
+	resultU, _ := installToProvider(itemsUnknown, *prov, installer.MethodSymlink,
 		true /* dryRun so we don't re-install to the same target */, config.NewResolver(nil, ""), prov.Slug, t.TempDir())
 	if len(resultU.Installed) > 0 {
 		t.Fatalf("dry-run should not produce Installed entries, got %d", len(resultU.Installed))

--- a/cli/cmd/syllago/remove_cmd.go
+++ b/cli/cmd/syllago/remove_cmd.go
@@ -62,6 +62,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	if globalDir == "" {
 		return output.NewStructuredError(output.ErrSystemHomedir, "cannot determine home directory", "Ensure $HOME is set in your environment")
 	}
+	projectRoot, _ := findProjectRoot()
 
 	// Use an empty temp dir as the project root so the project scan finds
 	// nothing, leaving only global items in the catalog.
@@ -105,7 +106,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	installedByProvider := make(map[string]bool)
 	var installedIn []string
 	for _, prov := range provider.AllProviders {
-		if installer.CheckStatus(item, prov, globalDir) == installer.StatusInstalled {
+		if installer.CheckStatus(item, prov, projectRoot) == installer.StatusInstalled {
 			installedIn = append(installedIn, prov.Name)
 			installedByProvider[prov.Slug] = true
 		}
@@ -152,10 +153,10 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 	var uninstalledFrom []string
 	for _, prov := range provider.AllProviders {
-		if installer.CheckStatus(item, prov, globalDir) != installer.StatusInstalled {
+		if installer.CheckStatus(item, prov, projectRoot) != installer.StatusInstalled {
 			continue
 		}
-		placement, err := installer.Uninstall(item, prov, globalDir)
+		placement, err := installer.Uninstall(item, prov, projectRoot)
 		if err != nil {
 			fmt.Fprintf(output.ErrWriter, "  warning: failed to uninstall from %s: %s\n", prov.Name, err)
 		} else {

--- a/cli/cmd/syllago/uninstall_cmd.go
+++ b/cli/cmd/syllago/uninstall_cmd.go
@@ -68,6 +68,7 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 	if globalDir == "" {
 		return output.NewStructuredError(output.ErrSystemHomedir, "cannot determine home directory", "Set the HOME environment variable")
 	}
+	projectRoot, _ := findProjectRoot()
 
 	// D7 routing: if installed.json has a matching RuleAppend record, the
 	// rule was installed via --method=append and the uninstall must route
@@ -117,7 +118,7 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 			return output.NewStructuredError(output.ErrProviderNotFound, "unknown provider: "+fromSlug, "Available: "+strings.Join(slugs, ", "))
 		}
 		// Verify it is actually installed there
-		status := installer.CheckStatus(*item, *prov, globalDir)
+		status := installer.CheckStatus(*item, *prov, projectRoot)
 		if status != installer.StatusInstalled {
 			return output.NewStructuredError(output.ErrInstallNotInstalled,
 				fmt.Sprintf("%q is not installed in %s", name, prov.Name),
@@ -127,7 +128,7 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 	} else {
 		// Uninstall from all providers where it is currently installed
 		for _, prov := range provider.AllProviders {
-			status := installer.CheckStatus(*item, prov, globalDir)
+			status := installer.CheckStatus(*item, prov, projectRoot)
 			if status == installer.StatusInstalled {
 				targets = append(targets, prov)
 			}
@@ -168,7 +169,7 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 	// Perform uninstall
 	var removedFrom []string
 	for _, prov := range targets {
-		placement, err := installer.Uninstall(*item, prov, globalDir)
+		placement, err := installer.Uninstall(*item, prov, projectRoot)
 		if err != nil {
 			fmt.Fprintf(output.ErrWriter, "  warning: failed to uninstall from %s: %s\n", prov.Name, err)
 			continue

--- a/cli/internal/installer/hooks.go
+++ b/cli/internal/installer/hooks.go
@@ -126,6 +126,9 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 	if inst.FindHook(item.Name, nativeEvent) >= 0 {
 		return Placement{}, fmt.Errorf("hook %s already installed for %s event", item.Name, nativeEvent)
 	}
+	if hookInstalledAtLegacyRoot(repoRoot, item.Name, nativeEvent) {
+		return Placement{}, fmt.Errorf("hook %s already installed for %s event", item.Name, nativeEvent)
+	}
 
 	settingsPath, err := hookSettingsPath(prov)
 	if err != nil {
@@ -180,6 +183,10 @@ func installHook(item catalog.ContentItem, prov provider.Provider, repoRoot stri
 }
 
 func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot string) (Placement, error) {
+	return uninstallHookAtRoot(item, prov, repoRoot, true)
+}
+
+func uninstallHookAtRoot(item catalog.ContentItem, prov provider.Provider, repoRoot string, allowLegacyFallback bool) (Placement, error) {
 	h, err := readSingleManifestHook(item.Path)
 	if err != nil {
 		return Placement{}, fmt.Errorf("parsing hook file: %w", err)
@@ -208,6 +215,11 @@ func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot st
 	}
 	instIdx := inst.FindHook(item.Name, nativeEvent)
 	if instIdx < 0 {
+		if allowLegacyFallback {
+			if legacyRoot := legacyRootWithHookRecord(repoRoot, item.Name, nativeEvent); legacyRoot != "" {
+				return uninstallHookAtRoot(item, prov, legacyRoot, false)
+			}
+		}
 		return Placement{}, fmt.Errorf("hook %s not tracked for %s event (not installed by syllago)", item.Name, nativeEvent)
 	}
 	storedHash := inst.Hooks[instIdx].GroupHash
@@ -273,6 +285,19 @@ func uninstallHook(item catalog.ContentItem, prov provider.Provider, repoRoot st
 }
 
 func checkHookStatus(item catalog.ContentItem, prov provider.Provider, repoRoot string) Status {
+	status := checkHookStatusAtRoot(item, prov, repoRoot)
+	if status != StatusNotInstalled {
+		return status
+	}
+	if legacyRoot := legacyInstalledRoot(repoRoot); legacyRoot != "" {
+		if legacyStatus := checkHookStatusAtRoot(item, prov, legacyRoot); legacyStatus == StatusInstalled {
+			return StatusInstalled
+		}
+	}
+	return status
+}
+
+func checkHookStatusAtRoot(item catalog.ContentItem, prov provider.Provider, repoRoot string) Status {
 	h, err := readSingleManifestHook(item.Path)
 	if err != nil {
 		return StatusNotAvailable
@@ -314,6 +339,25 @@ func checkHookStatus(item catalog.ContentItem, prov provider.Provider, repoRoot 
 		}
 	}
 	return StatusNotInstalled
+}
+
+func hookInstalledAtLegacyRoot(repoRoot, name, nativeEvent string) bool {
+	return legacyRootWithHookRecord(repoRoot, name, nativeEvent) != ""
+}
+
+func legacyRootWithHookRecord(repoRoot, name, nativeEvent string) string {
+	legacyRoot := legacyInstalledRoot(repoRoot)
+	if legacyRoot == "" {
+		return ""
+	}
+	inst, err := LoadInstalled(legacyRoot)
+	if err != nil {
+		return ""
+	}
+	if inst.FindHook(name, nativeEvent) < 0 {
+		return ""
+	}
+	return legacyRoot
 }
 
 // hookScriptsDir returns ~/.syllago/hooks/<name>/ for storing copied scripts.

--- a/cli/internal/installer/hooks_test.go
+++ b/cli/internal/installer/hooks_test.go
@@ -150,6 +150,93 @@ func TestCheckHookStatus_UsesInstalledJSON(t *testing.T) {
 	}
 }
 
+func TestUninstallHook_LegacyRootFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	legacyRoot := filepath.Join(tmpDir, "legacy-content")
+	projectRoot := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(legacyRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(projectRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origGlobal := catalog.GlobalContentDirOverride
+	catalog.GlobalContentDirOverride = legacyRoot
+	t.Cleanup(func() { catalog.GlobalContentDirOverride = origGlobal })
+
+	settingsPath := filepath.Join(tmpDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	overrideHookSettingsPath(t, settingsPath)
+
+	item := writeCanonicalHookItemInProject(t, projectRoot, "legacy-hook", "PreToolUse", "Bash", "echo legacy")
+	prov := provider.ClaudeCode
+
+	if _, err := installHook(item, prov, legacyRoot); err != nil {
+		t.Fatalf("seed legacy installHook: %v", err)
+	}
+	if _, err := uninstallHook(item, prov, projectRoot); err != nil {
+		t.Fatalf("uninstallHook with legacy root fallback: %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if gjson.GetBytes(data, "hooks.PreToolUse.0").Exists() {
+		t.Fatalf("legacy hook was not removed from settings: %s", data)
+	}
+
+	inst, err := LoadInstalled(legacyRoot)
+	if err != nil {
+		t.Fatalf("LoadInstalled(legacyRoot): %v", err)
+	}
+	if inst.FindHook("legacy-hook", "PreToolUse") >= 0 {
+		t.Fatal("legacy hook record was not removed")
+	}
+	if _, err := os.Stat(filepath.Join(projectRoot, ".syllago", "installed.json")); !os.IsNotExist(err) {
+		t.Fatalf("project installed.json should not be created, stat err = %v", err)
+	}
+}
+
+func TestCheckHookStatus_LegacyRootFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	legacyRoot := filepath.Join(tmpDir, "legacy-content")
+	projectRoot := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(legacyRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(projectRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origGlobal := catalog.GlobalContentDirOverride
+	catalog.GlobalContentDirOverride = legacyRoot
+	t.Cleanup(func() { catalog.GlobalContentDirOverride = origGlobal })
+
+	settingsPath := filepath.Join(tmpDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	overrideHookSettingsPath(t, settingsPath)
+
+	prov := provider.ClaudeCode
+	item := writeCanonicalHookItemInProject(t, projectRoot, "legacy-status-hook", "PreToolUse", "Bash", "echo status")
+	if _, err := installHook(item, prov, legacyRoot); err != nil {
+		t.Fatalf("seed legacy installHook: %v", err)
+	}
+	if status := CheckStatus(item, prov, projectRoot); status != StatusInstalled {
+		t.Fatalf("CheckStatus with legacy hook record = %v, want StatusInstalled", status)
+	}
+
+	missing := writeCanonicalHookItemInProject(t, projectRoot, "missing-status-hook", "PreToolUse", "Bash", "echo missing")
+	if status := CheckStatus(missing, prov, projectRoot); status != StatusNotInstalled {
+		t.Fatalf("CheckStatus without any record = %v, want StatusNotInstalled", status)
+	}
+}
+
 func TestReadSingleManifestHook_Valid(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
@@ -362,6 +449,51 @@ func TestInstallHook_RejectsDuplicate(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "already installed") {
 		t.Errorf("expected 'already installed' error, got: %v", err)
+	}
+}
+
+func TestInstallHook_DeduplicatesAgainstLegacyRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	legacyRoot := filepath.Join(tmpDir, "legacy-content")
+	projectRoot := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(legacyRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(projectRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origGlobal := catalog.GlobalContentDirOverride
+	catalog.GlobalContentDirOverride = legacyRoot
+	t.Cleanup(func() { catalog.GlobalContentDirOverride = origGlobal })
+
+	settingsPath := filepath.Join(tmpDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	overrideHookSettingsPath(t, settingsPath)
+
+	item := writeCanonicalHookItemInProject(t, projectRoot, "legacy-dup-hook", "PreToolUse", "Bash", "echo dup")
+	prov := provider.ClaudeCode
+
+	if _, err := installHook(item, prov, legacyRoot); err != nil {
+		t.Fatalf("seed legacy installHook: %v", err)
+	}
+	if _, err := Install(item, prov, projectRoot, MethodSymlink, ""); err == nil {
+		t.Fatal("expected duplicate install to be rejected via legacy root record")
+	} else if !strings.Contains(err.Error(), "already installed") {
+		t.Fatalf("duplicate error = %v, want already installed", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if entries := gjson.GetBytes(data, "hooks.PreToolUse").Array(); len(entries) != 1 {
+		t.Fatalf("expected one hook entry after dedup, got %d: %s", len(entries), data)
+	}
+	if _, err := os.Stat(filepath.Join(projectRoot, ".syllago", "installed.json")); !os.IsNotExist(err) {
+		t.Fatalf("project installed.json should not be created by rejected duplicate, stat err = %v", err)
 	}
 }
 

--- a/cli/internal/installer/legacy_root.go
+++ b/cli/internal/installer/legacy_root.go
@@ -1,0 +1,32 @@
+package installer
+
+import (
+	"path/filepath"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+)
+
+// legacyInstalledRoot returns the global library dir where pre-v0.15 CLI
+// installs recorded hook/MCP state, or "" when it is unavailable or equal
+// to repoRoot.
+func legacyInstalledRoot(repoRoot string) string {
+	legacyRoot := catalog.GlobalContentDir()
+	if legacyRoot == "" {
+		return ""
+	}
+
+	legacyAbs, err := filepath.Abs(legacyRoot)
+	if err != nil {
+		return ""
+	}
+	repoAbs, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return ""
+	}
+	legacyAbs = filepath.Clean(legacyAbs)
+	repoAbs = filepath.Clean(repoAbs)
+	if legacyAbs == repoAbs {
+		return ""
+	}
+	return legacyAbs
+}

--- a/cli/internal/installer/mcp.go
+++ b/cli/internal/installer/mcp.go
@@ -326,10 +326,6 @@ func installMCP(item catalog.ContentItem, prov provider.Provider, repoRoot strin
 		return Placement{}, err
 	}
 
-	if err := backupFile(cfgPath); err != nil {
-		return Placement{}, fmt.Errorf("backing up %s: %w", cfgPath, err)
-	}
-
 	fileData, err := readMCPConfig(cfgPath, prov)
 	if err != nil {
 		return Placement{}, fmt.Errorf("reading %s: %w", cfgPath, err)
@@ -339,6 +335,9 @@ func installMCP(item catalog.ContentItem, prov provider.Provider, repoRoot strin
 	inst, err := LoadInstalled(repoRoot)
 	if err != nil {
 		return Placement{}, fmt.Errorf("loading installed.json: %w", err)
+	}
+	if serverName, ok := legacyMCPInstalled(repoRoot, item, entries); ok {
+		return Placement{}, fmt.Errorf("MCP server %q already installed", serverName)
 	}
 
 	// Merge each server entry into the target config
@@ -353,22 +352,7 @@ func installMCP(item catalog.ContentItem, prov provider.Provider, repoRoot strin
 		// H2: Check for collision with user-defined (non-syllago) server keys
 		if gjson.GetBytes(fileData, key).Exists() {
 			// Check if this key was installed by syllago (safe to overwrite)
-			syllagoManaged := false
-			for _, m := range inst.MCP {
-				if m.ServerKey == name {
-					syllagoManaged = true
-					break
-				}
-				for _, sn := range m.ServerNames {
-					if sn == name {
-						syllagoManaged = true
-						break
-					}
-				}
-				if syllagoManaged {
-					break
-				}
-			}
+			syllagoManaged := mcpServerManagedBy(inst, name)
 			if !syllagoManaged {
 				return Placement{}, fmt.Errorf("MCP server %q already exists in %s and was not installed by syllago; use --force to overwrite", name, cfgPath)
 			}
@@ -380,6 +364,10 @@ func installMCP(item catalog.ContentItem, prov provider.Provider, repoRoot strin
 		}
 		serverNames = append(serverNames, name)
 		keys = append(keys, key)
+	}
+
+	if err := backupFile(cfgPath); err != nil {
+		return Placement{}, fmt.Errorf("backing up %s: %w", cfgPath, err)
 	}
 
 	if err := writeJSONFile(cfgPath, fileData); err != nil {
@@ -419,6 +407,10 @@ func installMCP(item catalog.ContentItem, prov provider.Provider, repoRoot strin
 }
 
 func uninstallMCP(item catalog.ContentItem, prov provider.Provider, repoRoot string) (Placement, error) {
+	return uninstallMCPAtRoot(item, prov, repoRoot, true)
+}
+
+func uninstallMCPAtRoot(item catalog.ContentItem, prov provider.Provider, repoRoot string, allowLegacyFallback bool) (Placement, error) {
 	cfgPath, err := mcpConfigPath(prov, repoRoot)
 	if err != nil {
 		return Placement{}, err
@@ -438,14 +430,13 @@ func uninstallMCP(item catalog.ContentItem, prov provider.Provider, repoRoot str
 	}
 
 	// Try per-server lookup first (new format), then legacy bulk lookup.
-	instIdx := -1
-	if item.ServerKey != "" {
-		instIdx = inst.FindMCPByServerKey(item.Name, item.ServerKey)
-	}
+	instIdx := findMCPInstallRecord(inst, item)
 	if instIdx < 0 {
-		instIdx = inst.FindMCP(item.Name)
-	}
-	if instIdx < 0 {
+		if allowLegacyFallback {
+			if legacyRoot := legacyRootWithMCPRecord(repoRoot, item); legacyRoot != "" {
+				return uninstallMCPAtRoot(item, prov, legacyRoot, false)
+			}
+		}
 		return Placement{}, fmt.Errorf("%s was not installed by syllago", item.Name)
 	}
 
@@ -499,6 +490,19 @@ func uninstallMCP(item catalog.ContentItem, prov provider.Provider, repoRoot str
 }
 
 func checkMCPStatus(item catalog.ContentItem, prov provider.Provider, repoRoot string) Status {
+	status := checkMCPStatusAtRoot(item, prov, repoRoot)
+	if status != StatusNotInstalled {
+		return status
+	}
+	if legacyRoot := legacyInstalledRoot(repoRoot); legacyRoot != "" {
+		if legacyStatus := checkMCPStatusAtRoot(item, prov, legacyRoot); legacyStatus == StatusInstalled {
+			return StatusInstalled
+		}
+	}
+	return status
+}
+
+func checkMCPStatusAtRoot(item catalog.ContentItem, prov provider.Provider, repoRoot string) Status {
 	cfgPath, err := mcpConfigPath(prov, repoRoot)
 	if err != nil {
 		return StatusNotAvailable
@@ -542,4 +546,62 @@ func checkMCPStatus(item catalog.ContentItem, prov provider.Provider, repoRoot s
 		return StatusInstalled
 	}
 	return StatusNotInstalled
+}
+
+func legacyMCPInstalled(repoRoot string, item catalog.ContentItem, entries map[string]json.RawMessage) (string, bool) {
+	legacyRoot := legacyInstalledRoot(repoRoot)
+	if legacyRoot == "" {
+		return "", false
+	}
+	inst, err := LoadInstalled(legacyRoot)
+	if err != nil {
+		return "", false
+	}
+	if findMCPInstallRecord(inst, item) >= 0 {
+		return item.Name, true
+	}
+	for name := range entries {
+		if mcpServerManagedBy(inst, name) {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+func legacyRootWithMCPRecord(repoRoot string, item catalog.ContentItem) string {
+	legacyRoot := legacyInstalledRoot(repoRoot)
+	if legacyRoot == "" {
+		return ""
+	}
+	inst, err := LoadInstalled(legacyRoot)
+	if err != nil {
+		return ""
+	}
+	if findMCPInstallRecord(inst, item) < 0 {
+		return ""
+	}
+	return legacyRoot
+}
+
+func findMCPInstallRecord(inst *Installed, item catalog.ContentItem) int {
+	if item.ServerKey != "" {
+		if idx := inst.FindMCPByServerKey(item.Name, item.ServerKey); idx >= 0 {
+			return idx
+		}
+	}
+	return inst.FindMCP(item.Name)
+}
+
+func mcpServerManagedBy(inst *Installed, serverName string) bool {
+	for _, m := range inst.MCP {
+		if m.ServerKey == serverName {
+			return true
+		}
+		for _, sn := range m.ServerNames {
+			if sn == serverName {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/cli/internal/installer/mcp_test.go
+++ b/cli/internal/installer/mcp_test.go
@@ -228,6 +228,50 @@ func TestInstallMCP_Cursor_ProductionPath(t *testing.T) {
 	}
 }
 
+func TestInstallMCP_Cursor_RootsConfigAndRecordAtProjectRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectRoot := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	itemDir := filepath.Join(tmpDir, "cursor-mcp")
+	if err := os.MkdirAll(itemDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configJSON, _ := json.Marshal(map[string]interface{}{
+		"command": "npx",
+		"args":    []string{"-y", "@example/project-root"},
+	})
+	if err := os.WriteFile(filepath.Join(itemDir, "config.json"), configJSON, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	item := catalog.ContentItem{Name: "project-root-mcp", Type: catalog.MCP, Path: itemDir}
+	prov := provider.Cursor
+
+	if _, err := Install(item, prov, projectRoot, MethodSymlink, ""); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	cfgPath := filepath.Join(projectRoot, ".cursor", "mcp.json")
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("expected cursor MCP config at project root: %v", err)
+	}
+	if got := gjson.GetBytes(data, "mcpServers.project-root-mcp.command").String(); got != "npx" {
+		t.Errorf("mcpServers.project-root-mcp.command = %q, want npx", got)
+	}
+
+	inst, err := LoadInstalled(projectRoot)
+	if err != nil {
+		t.Fatalf("LoadInstalled(projectRoot): %v", err)
+	}
+	if inst.FindMCP("project-root-mcp") < 0 {
+		t.Fatal("expected MCP record under project root")
+	}
+}
+
 // TestInstallMCP_Windsurf_ProductionPath exercises slug=windsurf without
 // the test seam. Windsurf's MCP config lives at the user's home dir, so the
 // test has to HOME-swap to avoid polluting the real developer machine.
@@ -721,6 +765,142 @@ func TestCheckMCPStatus_NotInstalled(t *testing.T) {
 	status := checkMCPStatus(item, prov, tmpDir)
 	if status != StatusNotInstalled {
 		t.Errorf("expected StatusNotInstalled, got %v", status)
+	}
+}
+
+func TestUninstallMCP_LegacyRootFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	legacyRoot := filepath.Join(tmpDir, "legacy-content")
+	projectRoot := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(filepath.Join(legacyRoot, ".cursor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(projectRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origGlobal := catalog.GlobalContentDirOverride
+	catalog.GlobalContentDirOverride = legacyRoot
+	t.Cleanup(func() { catalog.GlobalContentDirOverride = origGlobal })
+
+	legacyConfig := filepath.Join(legacyRoot, ".cursor", "mcp.json")
+	if err := os.WriteFile(legacyConfig, []byte(`{"mcpServers":{"legacy-mcp":{"command":"node"}}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveInstalled(legacyRoot, &Installed{
+		MCP: []InstalledMCP{{Name: "legacy-mcp", ServerKey: "legacy-mcp", Source: "export"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	item := catalog.ContentItem{Name: "legacy-mcp", Type: catalog.MCP, ServerKey: "legacy-mcp"}
+	prov := provider.Cursor
+
+	if _, err := Uninstall(item, prov, projectRoot); err != nil {
+		t.Fatalf("Uninstall with legacy root fallback: %v", err)
+	}
+
+	data, err := os.ReadFile(legacyConfig)
+	if err != nil {
+		t.Fatalf("read legacy config: %v", err)
+	}
+	if gjson.GetBytes(data, "mcpServers.legacy-mcp").Exists() {
+		t.Fatalf("legacy MCP server was not removed: %s", data)
+	}
+
+	inst, err := LoadInstalled(legacyRoot)
+	if err != nil {
+		t.Fatalf("LoadInstalled(legacyRoot): %v", err)
+	}
+	if inst.FindMCPByServerKey("legacy-mcp", "legacy-mcp") >= 0 {
+		t.Fatal("legacy MCP record was not removed")
+	}
+	if _, err := os.Stat(filepath.Join(projectRoot, ".syllago", "installed.json")); !os.IsNotExist(err) {
+		t.Fatalf("project installed.json should not be created, stat err = %v", err)
+	}
+}
+
+func TestCheckMCPStatus_LegacyRootFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	legacyRoot := filepath.Join(tmpDir, "legacy-content")
+	projectRoot := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(filepath.Join(legacyRoot, ".cursor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(projectRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origGlobal := catalog.GlobalContentDirOverride
+	catalog.GlobalContentDirOverride = legacyRoot
+	t.Cleanup(func() { catalog.GlobalContentDirOverride = origGlobal })
+
+	legacyConfig := filepath.Join(legacyRoot, ".cursor", "mcp.json")
+	if err := os.WriteFile(legacyConfig, []byte(`{"mcpServers":{"legacy-status":{"command":"node"}}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveInstalled(legacyRoot, &Installed{
+		MCP: []InstalledMCP{{Name: "legacy-status", ServerKey: "legacy-status", Source: "export"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	prov := provider.Cursor
+	item := catalog.ContentItem{Name: "legacy-status", Type: catalog.MCP, ServerKey: "legacy-status"}
+	if status := CheckStatus(item, prov, projectRoot); status != StatusInstalled {
+		t.Fatalf("CheckStatus with legacy record = %v, want StatusInstalled", status)
+	}
+
+	missing := catalog.ContentItem{Name: "missing-status", Type: catalog.MCP, ServerKey: "missing-status"}
+	if status := CheckStatus(missing, prov, projectRoot); status != StatusNotInstalled {
+		t.Fatalf("CheckStatus without any record = %v, want StatusNotInstalled", status)
+	}
+}
+
+func TestInstallMCP_DeduplicatesAgainstLegacyRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	legacyRoot := filepath.Join(tmpDir, "legacy-content")
+	projectRoot := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(filepath.Join(legacyRoot, ".cursor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(projectRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origGlobal := catalog.GlobalContentDirOverride
+	catalog.GlobalContentDirOverride = legacyRoot
+	t.Cleanup(func() { catalog.GlobalContentDirOverride = origGlobal })
+
+	legacyConfig := filepath.Join(legacyRoot, ".cursor", "mcp.json")
+	if err := os.WriteFile(legacyConfig, []byte(`{"mcpServers":{"legacy-dup":{"command":"node"}}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveInstalled(legacyRoot, &Installed{
+		MCP: []InstalledMCP{{Name: "legacy-dup", ServerKey: "legacy-dup", Source: "export"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	itemDir := filepath.Join(tmpDir, "legacy-dup")
+	if err := os.MkdirAll(itemDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(itemDir, "config.json"), []byte(`{"command":"node"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	item := catalog.ContentItem{Name: "legacy-dup", Type: catalog.MCP, Path: itemDir, ServerKey: "legacy-dup"}
+	prov := provider.Cursor
+	if _, err := Install(item, prov, projectRoot, MethodSymlink, ""); err == nil {
+		t.Fatal("expected duplicate MCP install to be rejected via legacy root record")
+	}
+
+	if _, err := os.Stat(filepath.Join(projectRoot, ".cursor", "mcp.json")); !os.IsNotExist(err) {
+		t.Fatalf("project MCP config should not be created by rejected duplicate, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectRoot, ".syllago", "installed.json")); !os.IsNotExist(err) {
+		t.Fatalf("project installed.json should not be created by rejected duplicate, stat err = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Part of #542 (item 2b-iii). The CLI's `install`, `add`, `uninstall`, and `remove` commands passed the global library dir (`~/.syllago/content`) as `repoRoot` to the JSON-merge installer paths (hooks, MCP). For providers with project-scoped MCP configs (cursor, kiro, opencode, roo-code, copilot-cli) this wrote configs under `~/.syllago/content/` where the tools never read them, and recorded installs at `~/.syllago/content/.syllago/installed.json` — divergent from the TUI, which always used the real project root.

- **CLI wiring**: all four call sites now pass the project root from `findProjectRoot()`; `installToProvider` drops its unused `globalDir` parameter.
- **Legacy fallback (read-only)**: `legacyInstalledRoot()` resolves the old global root; uninstall and status checks fall back to it when an item isn't tracked at the project root, so pre-fix installs remain uninstallable and report `StatusInstalled`. Install dedup also consults the legacy root. New records are never written there, so legacy state drains naturally as items are uninstalled.

## Testing

- 9 new tests: legacy uninstall/status/dedup fallbacks for hooks and MCP, project-root config placement for cursor, and a RunE-level regression test proving install records land at the project root.
- Full suite: 40 packages ok, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)