### PR TITLE
feat(registry): report installed-item drift after git registry sync (#542 item 3a)

### DIFF
--- a/cli/cmd/syllago/registry_cmd.go
+++ b/cli/cmd/syllago/registry_cmd.go
@@ -598,6 +598,11 @@ func syncGitOrMOATRegistry(ctx context.Context, cfg *config.Config, r *config.Re
 			printRegistryDiff(output.Writer, d)
 		}
 	}
+	drifts := registryops.InstalledGitDrift(r.Name)
+	if len(drifts) > 0 {
+		printInstalledDrift(output.Writer, drifts)
+	}
+	telemetry.Enrich("drift_count", len(drifts))
 	return 0, nil
 }
 

--- a/cli/cmd/syllago/registry_diff.go
+++ b/cli/cmd/syllago/registry_diff.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/regdiff"
+	"github.com/OpenScribbler/syllago/cli/internal/registryops"
 )
 
 const registryDiffChangeLimit = 20
@@ -43,6 +44,29 @@ func printRegistryDiffLines(w io.Writer, d *regdiff.Diff) {
 	if len(d.OtherPaths) > 0 {
 		fmt.Fprintf(w, "  (plus %d other changed files)\n", len(d.OtherPaths))
 	}
+}
+
+func printInstalledDrift(w io.Writer, drifts []registryops.InstalledDrift) {
+	if output.JSON || output.Quiet || len(drifts) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w, "Installed items drifted from upstream:")
+	for _, drift := range drifts {
+		switch drift.Kind {
+		case registryops.DriftChanged:
+			fmt.Fprintf(w, "  ~ %s/%s changed upstream — refresh: syllago add %s --from %s --force\n", drift.Type, drift.Name, drift.Name, drift.Registry)
+		case registryops.DriftMissing:
+			fmt.Fprintf(w, "  ! %s/%s no longer in registry%s — remove: syllago remove %s\n", drift.Type, drift.Name, installedDriftProviderText(drift.Providers), drift.Name)
+		}
+	}
+}
+
+func installedDriftProviderText(providers []string) string {
+	if len(providers) == 0 {
+		return ""
+	}
+	return " (installed to: " + strings.Join(providers, ", ") + ")"
 }
 
 func registryDiffSymbol(kind regdiff.Kind) string {

--- a/cli/cmd/syllago/registry_sync_git_test.go
+++ b/cli/cmd/syllago/registry_sync_git_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -8,7 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/metadata"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/registry"
 )
@@ -80,6 +85,88 @@ func TestRegistrySync_PersistsGitLastSyncBookkeeping(t *testing.T) {
 	}
 }
 
+func TestRegistrySync_PrintsInstalledDrift(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	bare := createBareGitRegistryForSyncDriftTest(t, map[string]string{
+		"skills/foo/SKILL.md": "# Foo\n\nupstream\n",
+	})
+	cfg := &config.Config{
+		Providers: []string{"claude-code", "cursor"},
+		Registries: []config.Registry{
+			{Name: "drift-reg", URL: bare},
+		},
+	}
+	withRegistryProjectAndCache(t, nil, cfg)
+	withRegistrySyncDriftLibrary(t, t.TempDir())
+	stdout, _ := output.SetForTest(t)
+	overrideProbe(t, func(url string) (string, error) {
+		return registry.VisibilityPublic, nil
+	})
+
+	fooLibrary := writeRegistrySyncDriftLibraryItem(t, catalog.Skills, "", "foo", "SKILL.md", "# Foo\n\nlibrary\n", registrySyncDriftSourceHash("# Foo\n\nold\n"))
+	barLibrary := writeRegistrySyncDriftLibraryItem(t, catalog.Rules, "claude-code", "bar", "rule.md", "# Bar\n\nlibrary\n", registrySyncDriftSourceHash("# Bar\n\nold\n"))
+	saveRegistrySyncDriftStore(t,
+		registrySyncDriftRecord("drift-reg", string(catalog.Skills), "foo", fooLibrary, "claude-code"),
+		registrySyncDriftRecord("drift-reg", string(catalog.Rules), "bar", barLibrary, "claude-code", "cursor"),
+	)
+
+	registrySyncCmd.SilenceUsage = true
+	registrySyncCmd.SilenceErrors = true
+	if err := registrySyncCmd.RunE(registrySyncCmd, []string{"drift-reg"}); err != nil {
+		t.Fatalf("registry sync: %v", err)
+	}
+
+	gotOut := stdout.String()
+	for _, want := range []string{
+		"Installed items drifted from upstream:\n",
+		"  ~ skills/foo changed upstream — refresh: syllago add foo --from drift-reg --force\n",
+		"  ! rules/bar no longer in registry (installed to: claude-code, cursor) — remove: syllago remove bar\n",
+	} {
+		if !strings.Contains(gotOut, want) {
+			t.Fatalf("sync output = %q; want to contain %q", gotOut, want)
+		}
+	}
+}
+
+func TestRegistrySync_NoInstalledDriftOmitsBlock(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	const content = "# Foo\n\nupstream\n"
+	bare := createBareGitRegistryForSyncDriftTest(t, map[string]string{
+		"skills/foo/SKILL.md": content,
+	})
+	cfg := &config.Config{
+		Providers: []string{"claude-code"},
+		Registries: []config.Registry{
+			{Name: "clean-reg", URL: bare},
+		},
+	}
+	withRegistryProjectAndCache(t, nil, cfg)
+	withRegistrySyncDriftLibrary(t, t.TempDir())
+	stdout, _ := output.SetForTest(t)
+	overrideProbe(t, func(url string) (string, error) {
+		return registry.VisibilityPublic, nil
+	})
+
+	fooLibrary := writeRegistrySyncDriftLibraryItem(t, catalog.Skills, "", "foo", "SKILL.md", content, registrySyncDriftSourceHash(content))
+	saveRegistrySyncDriftStore(t, registrySyncDriftRecord("clean-reg", string(catalog.Skills), "foo", fooLibrary, "claude-code"))
+
+	registrySyncCmd.SilenceUsage = true
+	registrySyncCmd.SilenceErrors = true
+	if err := registrySyncCmd.RunE(registrySyncCmd, []string{"clean-reg"}); err != nil {
+		t.Fatalf("registry sync: %v", err)
+	}
+
+	if gotOut := stdout.String(); strings.Contains(gotOut, "Installed items drifted from upstream:") {
+		t.Fatalf("sync output = %q; want no installed drift block", gotOut)
+	}
+}
+
 func createBareGitRegistryForSyncTest(t *testing.T) (bare, work, branch string) {
 	t.Helper()
 	work = filepath.Join(t.TempDir(), "work")
@@ -113,6 +200,111 @@ func updateBareGitRegistryForSyncDiffTest(t *testing.T, work, bare, branch strin
 	gitRunForSyncTest(t, work, "add", "-A")
 	gitRunForSyncTest(t, work, "commit", "-m", "update content")
 	gitRunForSyncTest(t, work, "push", bare, "HEAD:refs/heads/"+branch)
+}
+
+func createBareGitRegistryForSyncDriftTest(t *testing.T, files map[string]string) string {
+	t.Helper()
+	work := filepath.Join(t.TempDir(), "work")
+	if err := os.MkdirAll(work, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	gitRunForSyncTest(t, work, "init")
+	gitRunForSyncTest(t, work, "config", "user.email", "test@example.com")
+	gitRunForSyncTest(t, work, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(work, "registry.yaml"), []byte("name: drift-reg\nversion: \"1.0\"\n"), 0644); err != nil {
+		t.Fatalf("WriteFile registry.yaml: %v", err)
+	}
+	for rel, contents := range files {
+		writeRepoFileForSyncTest(t, work, rel, contents)
+	}
+	gitRunForSyncTest(t, work, "add", "-A")
+	gitRunForSyncTest(t, work, "commit", "-m", "initial")
+
+	bare := filepath.Join(t.TempDir(), "registry.git")
+	gitRunForSyncTest(t, "", "clone", "--bare", work, bare)
+	return bare
+}
+
+func withRegistrySyncDriftLibrary(t *testing.T, dir string) {
+	t.Helper()
+	orig := catalog.GlobalContentDirOverride
+	catalog.GlobalContentDirOverride = dir
+	t.Cleanup(func() { catalog.GlobalContentDirOverride = orig })
+}
+
+func writeRegistrySyncDriftLibraryItem(t *testing.T, ct catalog.ContentType, providerSlug, name, filename, contents, sourceHash string) string {
+	t.Helper()
+	globalDir := catalog.GlobalContentDir()
+	parts := []string{globalDir, string(ct)}
+	if !ct.IsUniversal() {
+		parts = append(parts, providerSlug)
+	}
+	parts = append(parts, name)
+	itemDir := filepath.Join(parts...)
+	if err := os.MkdirAll(itemDir, 0755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", itemDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(itemDir, filename), []byte(contents), 0644); err != nil {
+		t.Fatalf("WriteFile library %s/%s: %v", itemDir, filename, err)
+	}
+	if err := metadata.Save(itemDir, &metadata.Meta{
+		ID:             "test-" + name,
+		Name:           name,
+		Type:           string(ct),
+		SourceRegistry: "drift-reg",
+		SourceHash:     sourceHash,
+	}); err != nil {
+		t.Fatalf("metadata.Save %s: %v", itemDir, err)
+	}
+	return itemDir
+}
+
+func saveRegistrySyncDriftStore(t *testing.T, records ...installstore.Record) {
+	t.Helper()
+	path, err := installstore.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	store, err := installstore.Load(path)
+	if err != nil {
+		t.Fatalf("installstore.Load: %v", err)
+	}
+	for _, rec := range records {
+		store.Upsert(rec)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("installstore.Save: %v", err)
+	}
+}
+
+func registrySyncDriftRecord(registryName, contentType, name, libraryPath string, providers ...string) installstore.Record {
+	now := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+	placements := make([]installstore.Placement, 0, len(providers))
+	for _, providerSlug := range providers {
+		placements = append(placements, installstore.Placement{
+			Provider:    providerSlug,
+			Mechanism:   installstore.MechanismSymlink,
+			Path:        filepath.Join("/providers", providerSlug, name),
+			InstalledAt: now,
+		})
+	}
+	return installstore.Record{
+		Coord: installstore.Coord{
+			Registry: registryName,
+			Type:     contentType,
+			Name:     name,
+		},
+		ContentHash: "sha256:test",
+		LibraryPath: libraryPath,
+		InstalledAt: now,
+		UpdatedAt:   now,
+		Placements:  placements,
+	}
+}
+
+func registrySyncDriftSourceHash(contents string) string {
+	sum := sha256.Sum256([]byte(contents))
+	return fmt.Sprintf("sha256:%x", sum)
 }
 
 func writeRepoFileForSyncTest(t *testing.T, repoDir, rel, contents string) {

--- a/cli/internal/registryops/drift.go
+++ b/cli/internal/registryops/drift.go
@@ -1,0 +1,134 @@
+package registryops
+
+import (
+	"os"
+	"sort"
+
+	"github.com/OpenScribbler/syllago/cli/internal/add"
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
+)
+
+// DriftKind classifies one installed item's divergence from its source registry.
+type DriftKind string
+
+const (
+	DriftChanged DriftKind = "changed" // upstream content differs from the library copy
+	DriftMissing DriftKind = "missing" // item no longer exists upstream (renamed or deleted)
+)
+
+// InstalledDrift is one installed item's drift against its source registry.
+type InstalledDrift struct {
+	Registry  string
+	Type      string // content type slug, e.g. "skills"
+	Name      string
+	Kind      DriftKind
+	Providers []string // provider slugs with placements for this item, sorted, deduped
+}
+
+// InstalledGitDrift reports drift for every installed item that originated
+// from the plain git registry regName, comparing the current clone contents
+// against the library copies. Best-effort: any store/clone/discovery error
+// returns nil (drift display must never fail a sync).
+func InstalledGitDrift(regName string) []InstalledDrift {
+	path, err := installstore.DefaultPath()
+	if err != nil {
+		return nil
+	}
+	store, err := installstore.Load(path)
+	if err != nil {
+		return nil
+	}
+	records := store.ByRegistry(regName)
+	if len(records) == 0 {
+		return nil
+	}
+
+	cloneDir, err := registry.CloneDir(regName)
+	if err != nil {
+		return nil
+	}
+	info, err := os.Stat(cloneDir)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+	globalDir := catalog.GlobalContentDir()
+	if globalDir == "" {
+		return nil
+	}
+
+	items, err := add.DiscoverFromRegistry(regName, cloneDir, globalDir)
+	if err != nil {
+		return nil
+	}
+	discovered := make(map[installedDriftKey]add.ItemStatus, len(items))
+	for _, item := range items {
+		key := installedDriftKey{contentType: string(item.Type), name: item.Name}
+		discovered[key] = mergeInstalledDriftStatus(discovered[key], item.Status)
+	}
+
+	drifts := make([]InstalledDrift, 0)
+	for _, rec := range records {
+		key := installedDriftKey{contentType: rec.Type, name: rec.Name}
+		status, ok := discovered[key]
+		if !ok {
+			drifts = append(drifts, InstalledDrift{
+				Registry:  regName,
+				Type:      rec.Type,
+				Name:      rec.Name,
+				Kind:      DriftMissing,
+				Providers: installedDriftProviders(rec),
+			})
+			continue
+		}
+		if status == add.StatusOutdated {
+			drifts = append(drifts, InstalledDrift{
+				Registry:  regName,
+				Type:      rec.Type,
+				Name:      rec.Name,
+				Kind:      DriftChanged,
+				Providers: installedDriftProviders(rec),
+			})
+		}
+	}
+
+	sort.Slice(drifts, func(i, j int) bool {
+		if drifts[i].Type != drifts[j].Type {
+			return drifts[i].Type < drifts[j].Type
+		}
+		return drifts[i].Name < drifts[j].Name
+	})
+	return drifts
+}
+
+type installedDriftKey struct {
+	contentType string
+	name        string
+}
+
+func mergeInstalledDriftStatus(existing, incoming add.ItemStatus) add.ItemStatus {
+	if existing == add.StatusOutdated || incoming == add.StatusOutdated {
+		return add.StatusOutdated
+	}
+	if existing == add.StatusInLibrary || incoming == add.StatusInLibrary {
+		return add.StatusInLibrary
+	}
+	return add.StatusNew
+}
+
+func installedDriftProviders(rec installstore.Record) []string {
+	seen := make(map[string]struct{}, len(rec.Placements))
+	for _, placement := range rec.Placements {
+		if placement.Provider == "" {
+			continue
+		}
+		seen[placement.Provider] = struct{}{}
+	}
+	providers := make([]string, 0, len(seen))
+	for provider := range seen {
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+	return providers
+}

--- a/cli/internal/registryops/drift_test.go
+++ b/cli/internal/registryops/drift_test.go
@@ -1,0 +1,213 @@
+package registryops
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/metadata"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
+)
+
+func TestInstalledGitDrift_MixedDrift(t *testing.T) {
+	env := setupInstalledGitDriftTest(t)
+
+	writeDriftCloneFile(t, env.cloneDir("test-reg"), "skills/foo/SKILL.md", "upstream foo\n")
+	fooLibrary := writeDriftLibraryItem(t, env.globalDir, catalog.Skills, "", "foo", "SKILL.md", "library foo\n", driftSourceHash("old foo\n"))
+	barLibrary := writeDriftLibraryItem(t, env.globalDir, catalog.Rules, "claude-code", "bar", "rule.md", "library bar\n", driftSourceHash("old bar\n"))
+	saveDriftInstallStore(t,
+		driftRecord("test-reg", string(catalog.Skills), "foo", fooLibrary, "claude-code"),
+		driftRecord("test-reg", string(catalog.Rules), "bar", barLibrary, "cursor", "claude-code", "cursor"),
+	)
+
+	got := InstalledGitDrift("test-reg")
+	want := []InstalledDrift{
+		{
+			Registry:  "test-reg",
+			Type:      string(catalog.Rules),
+			Name:      "bar",
+			Kind:      DriftMissing,
+			Providers: []string{"claude-code", "cursor"},
+		},
+		{
+			Registry:  "test-reg",
+			Type:      string(catalog.Skills),
+			Name:      "foo",
+			Kind:      DriftChanged,
+			Providers: []string{"claude-code"},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("InstalledGitDrift() = %#v; want %#v", got, want)
+	}
+}
+
+func TestInstalledGitDrift_UpToDateItemSkipped(t *testing.T) {
+	env := setupInstalledGitDriftTest(t)
+
+	const content = "current foo\n"
+	writeDriftCloneFile(t, env.cloneDir("test-reg"), "skills/foo/SKILL.md", content)
+	fooLibrary := writeDriftLibraryItem(t, env.globalDir, catalog.Skills, "", "foo", "SKILL.md", content, driftSourceHash(content))
+	saveDriftInstallStore(t, driftRecord("test-reg", string(catalog.Skills), "foo", fooLibrary, "claude-code"))
+
+	if got := InstalledGitDrift("test-reg"); len(got) != 0 {
+		t.Fatalf("InstalledGitDrift() = %#v; want empty", got)
+	}
+}
+
+func TestInstalledGitDrift_NoRecordsOrUnknownRegistry(t *testing.T) {
+	env := setupInstalledGitDriftTest(t)
+
+	writeDriftCloneFile(t, env.cloneDir("test-reg"), "skills/foo/SKILL.md", "current foo\n")
+	if got := InstalledGitDrift("test-reg"); got != nil {
+		t.Fatalf("InstalledGitDrift() with no records = %#v; want nil", got)
+	}
+
+	otherLibrary := writeDriftLibraryItem(t, env.globalDir, catalog.Skills, "", "other", "SKILL.md", "other\n", driftSourceHash("other\n"))
+	saveDriftInstallStore(t, driftRecord("other-reg", string(catalog.Skills), "other", otherLibrary, "claude-code"))
+	if got := InstalledGitDrift("test-reg"); got != nil {
+		t.Fatalf("InstalledGitDrift() for unknown registry = %#v; want nil", got)
+	}
+}
+
+func TestInstalledGitDrift_UninstalledRegistryItemsIgnored(t *testing.T) {
+	env := setupInstalledGitDriftTest(t)
+
+	writeDriftCloneFile(t, env.cloneDir("test-reg"), "skills/foo/SKILL.md", "upstream foo\n")
+	writeDriftLibraryItem(t, env.globalDir, catalog.Skills, "", "foo", "SKILL.md", "library foo\n", driftSourceHash("old foo\n"))
+
+	const trackedContent = "tracked current\n"
+	writeDriftCloneFile(t, env.cloneDir("test-reg"), "skills/tracked/SKILL.md", trackedContent)
+	trackedLibrary := writeDriftLibraryItem(t, env.globalDir, catalog.Skills, "", "tracked", "SKILL.md", trackedContent, driftSourceHash(trackedContent))
+	saveDriftInstallStore(t, driftRecord("test-reg", string(catalog.Skills), "tracked", trackedLibrary, "claude-code"))
+
+	if got := InstalledGitDrift("test-reg"); len(got) != 0 {
+		t.Fatalf("InstalledGitDrift() = %#v; want empty", got)
+	}
+}
+
+type installedGitDriftTestEnv struct {
+	cacheDir  string
+	globalDir string
+	configDir string
+}
+
+func setupInstalledGitDriftTest(t *testing.T) installedGitDriftTestEnv {
+	t.Helper()
+	env := installedGitDriftTestEnv{
+		cacheDir:  t.TempDir(),
+		globalDir: t.TempDir(),
+		configDir: t.TempDir(),
+	}
+
+	origCache := registry.CacheDirOverride
+	registry.CacheDirOverride = env.cacheDir
+	t.Cleanup(func() { registry.CacheDirOverride = origCache })
+
+	origContent := catalog.GlobalContentDirOverride
+	catalog.GlobalContentDirOverride = env.globalDir
+	t.Cleanup(func() { catalog.GlobalContentDirOverride = origContent })
+
+	origConfig := config.GlobalDirOverride
+	config.GlobalDirOverride = env.configDir
+	t.Cleanup(func() { config.GlobalDirOverride = origConfig })
+
+	return env
+}
+
+func (e installedGitDriftTestEnv) cloneDir(registryName string) string {
+	return filepath.Join(e.cacheDir, registryName)
+}
+
+func writeDriftCloneFile(t *testing.T, cloneDir, rel, contents string) string {
+	t.Helper()
+	path := filepath.Join(cloneDir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("WriteFile %s: %v", rel, err)
+	}
+	return path
+}
+
+func writeDriftLibraryItem(t *testing.T, globalDir string, ct catalog.ContentType, providerSlug, name, filename, contents, sourceHash string) string {
+	t.Helper()
+	parts := []string{globalDir, string(ct)}
+	if !ct.IsUniversal() {
+		parts = append(parts, providerSlug)
+	}
+	parts = append(parts, name)
+	itemDir := filepath.Join(parts...)
+	if err := os.MkdirAll(itemDir, 0755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", itemDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(itemDir, filename), []byte(contents), 0644); err != nil {
+		t.Fatalf("WriteFile library %s/%s: %v", itemDir, filename, err)
+	}
+	if err := metadata.Save(itemDir, &metadata.Meta{
+		ID:             "test-" + name,
+		Name:           name,
+		Type:           string(ct),
+		SourceRegistry: "test-reg",
+		SourceHash:     sourceHash,
+	}); err != nil {
+		t.Fatalf("metadata.Save %s: %v", itemDir, err)
+	}
+	return itemDir
+}
+
+func saveDriftInstallStore(t *testing.T, records ...installstore.Record) {
+	t.Helper()
+	path, err := installstore.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	store, err := installstore.Load(path)
+	if err != nil {
+		t.Fatalf("installstore.Load: %v", err)
+	}
+	for _, rec := range records {
+		store.Upsert(rec)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("installstore.Save: %v", err)
+	}
+}
+
+func driftRecord(registryName, contentType, name, libraryPath string, providers ...string) installstore.Record {
+	now := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+	placements := make([]installstore.Placement, 0, len(providers))
+	for _, providerSlug := range providers {
+		placements = append(placements, installstore.Placement{
+			Provider:    providerSlug,
+			Mechanism:   installstore.MechanismSymlink,
+			Path:        filepath.Join("/providers", providerSlug, name),
+			InstalledAt: now,
+		})
+	}
+	return installstore.Record{
+		Coord: installstore.Coord{
+			Registry: registryName,
+			Type:     contentType,
+			Name:     name,
+		},
+		ContentHash: "sha256:test",
+		LibraryPath: libraryPath,
+		InstalledAt: now,
+		UpdatedAt:   now,
+		Placements:  placements,
+	}
+}
+
+func driftSourceHash(contents string) string {
+	sum := sha256.Sum256([]byte(contents))
+	return fmt.Sprintf("sha256:%x", sum)
+}

--- a/cli/internal/telemetry/catalog.go
+++ b/cli/internal/telemetry/catalog.go
@@ -180,6 +180,13 @@ func EventCatalog() []EventDef {
 					Commands:    []string{"registry_sync", "registry_status"},
 				},
 				{
+					Name:        "drift_count",
+					Type:        "int",
+					Description: "Number of installed items drifted from upstream after a registry sync",
+					Example:     2,
+					Commands:    []string{"registry_sync"},
+				},
+				{
 					Name:        "moat_tier",
 					Type:        "string",
 					Description: "Resolved MOAT trust tier for the item (UNSIGNED, SIGNED, DUAL-ATTESTED)",

--- a/cli/telemetry.json
+++ b/cli/telemetry.json
@@ -220,6 +220,15 @@
           ]
         },
         {
+          "name": "drift_count",
+          "type": "int",
+          "description": "Number of installed items drifted from upstream after a registry sync",
+          "example": 2,
+          "commands": [
+            "registry_sync"
+          ]
+        },
+        {
           "name": "moat_tier",
           "type": "string",
           "description": "Resolved MOAT trust tier for the item (UNSIGNED, SIGNED, DUAL-ATTESTED)",


### PR DESCRIPTION
## Summary

- New `registryops.InstalledGitDrift(regName)` (`cli/internal/registryops/drift.go`): after a plain-git registry sync, compares every installed item recorded for that registry in the install-record store against the freshly synced clone, using `add.DiscoverFromRegistry`'s existing `source_hash` comparison — no new hashing.
- `registry sync` (git path) prints a drift block after the item diff:
  ```
  Installed items drifted from upstream:
    ~ skills/foo changed upstream — refresh: syllago add foo --from my-reg --force
    ! rules/bar no longer in registry (installed to: claude-code, cursor) — remove: syllago remove bar
  ```
- Best-effort by design: any store/clone/discovery error yields no drift output and never fails the sync. Report-and-hint only — no healing actions, prompts, or new flags in this chunk.
- Adds `drift_count` telemetry property (registry_sync) to the catalog; `telemetry.json` regenerated.

Part of #542 (item 3: healing sync). Chunk 3a — MOAT installed-drift and TUI surfacing follow in the next chunk.

## Test plan

- [x] `registryops` unit tests: mixed changed+missing drift (sorted, provider lists deduped), up-to-date item skipped, no records / unknown registry → nil, uninstalled registry items ignored
- [x] RunE-level `registry sync` tests against real bare git registries: drift block printed with both hint commands; block absent when nothing drifted
- [x] `TestGentelemetry_CatalogMatchesEnrichCalls` passes
- [x] Full suite: `go build ./... && go test -count=1 ./...` — 40 packages ok, `gofmt -l cmd internal` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)