### PR TITLE
feat(registry): MOAT installed-item drift + TUI sync drift counts (#542 item 3b)

### DIFF
--- a/cli/cmd/syllago/registry_cmd.go
+++ b/cli/cmd/syllago/registry_cmd.go
@@ -600,7 +600,7 @@ func syncGitOrMOATRegistry(ctx context.Context, cfg *config.Config, r *config.Re
 	}
 	drifts := registryops.InstalledGitDrift(r.Name)
 	if len(drifts) > 0 {
-		printInstalledDrift(output.Writer, drifts)
+		printInstalledDrift(output.Writer, drifts, gitDriftHints)
 	}
 	telemetry.Enrich("drift_count", len(drifts))
 	return 0, nil

--- a/cli/cmd/syllago/registry_diff.go
+++ b/cli/cmd/syllago/registry_diff.go
@@ -12,6 +12,13 @@ import (
 
 const registryDiffChangeLimit = 20
 
+type installedDriftHintMode int
+
+const (
+	gitDriftHints installedDriftHintMode = iota
+	moatDriftHints
+)
+
 // printRegistryDiff renders an item-level change summary for one registry
 // sync. No-op when d is nil, d.OldRef is empty (no baseline - first sync
 // would list every item as added), d.UpToDate, or there are no changes.
@@ -46,7 +53,7 @@ func printRegistryDiffLines(w io.Writer, d *regdiff.Diff) {
 	}
 }
 
-func printInstalledDrift(w io.Writer, drifts []registryops.InstalledDrift) {
+func printInstalledDrift(w io.Writer, drifts []registryops.InstalledDrift, hints installedDriftHintMode) {
 	if output.JSON || output.Quiet || len(drifts) == 0 {
 		return
 	}
@@ -55,7 +62,12 @@ func printInstalledDrift(w io.Writer, drifts []registryops.InstalledDrift) {
 	for _, drift := range drifts {
 		switch drift.Kind {
 		case registryops.DriftChanged:
-			fmt.Fprintf(w, "  ~ %s/%s changed upstream — refresh: syllago add %s --from %s --force\n", drift.Type, drift.Name, drift.Name, drift.Registry)
+			switch hints {
+			case moatDriftHints:
+				fmt.Fprintf(w, "  ~ %s/%s changed upstream — refresh: syllago install %s/%s\n", drift.Type, drift.Name, drift.Registry, drift.Name)
+			default:
+				fmt.Fprintf(w, "  ~ %s/%s changed upstream — refresh: syllago add %s --from %s --force\n", drift.Type, drift.Name, drift.Name, drift.Registry)
+			}
 		case registryops.DriftMissing:
 			fmt.Fprintf(w, "  ! %s/%s no longer in registry%s — remove: syllago remove %s\n", drift.Type, drift.Name, installedDriftProviderText(drift.Providers), drift.Name)
 		}

--- a/cli/cmd/syllago/registry_sync_moat.go
+++ b/cli/cmd/syllago/registry_sync_moat.go
@@ -30,6 +30,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/moat"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/registryops"
+	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
 )
 
 // moatSyncFn is the low-level test seam used by install_moat.go (which runs
@@ -135,6 +136,11 @@ func syncMOATRegistry(
 			reg.Name, res.RevocationsAdded, res.PrivateContentCount)
 	}
 	printRegistryDiff(out, outcome.Diff)
+	drifts := registryops.InstalledMOATDrift(reg.Name, outcome.Diff)
+	if len(drifts) > 0 {
+		printInstalledDrift(out, drifts, moatDriftHints)
+	}
+	telemetry.Enrich("drift_count", len(drifts))
 
 	for _, w := range outcome.ContentCacheReport.Warnings {
 		fmt.Fprintf(errW, "Warning: %s\n", w)

--- a/cli/cmd/syllago/registry_sync_moat_test.go
+++ b/cli/cmd/syllago/registry_sync_moat_test.go
@@ -12,6 +12,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/moat"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/registryops"
 )
 
@@ -74,6 +76,44 @@ func incomingProfile() config.SigningProfile {
 		ProfileVersion:    1,
 		RepositoryID:      "100",
 		RepositoryOwnerID: "200",
+	}
+}
+
+func syncMOATDriftManifest(t *testing.T, updatedAt string, entries []moat.ContentEntry) *moat.Manifest {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, updatedAt)
+	if err != nil {
+		t.Fatalf("parse updated_at: %v", err)
+	}
+	return &moat.Manifest{
+		SchemaVersion:          moat.ManifestSchemaVersion,
+		ManifestURI:            "https://registry.example.com/manifest.json",
+		Name:                   "Example Registry",
+		Operator:               "Example Operator",
+		UpdatedAt:              ts,
+		RegistrySigningProfile: moat.SigningProfile{Issuer: incomingProfile().Issuer, Subject: incomingProfile().Subject},
+		Content:                entries,
+		Revocations:            []moat.Revocation{},
+	}
+}
+
+func syncMOATDriftManifestBytes(t *testing.T, manifest *moat.Manifest) []byte {
+	t.Helper()
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	return data
+}
+
+func syncMOATDriftEntry(name, digit string) moat.ContentEntry {
+	return moat.ContentEntry{
+		Name:        name,
+		DisplayName: name,
+		Type:        "skill",
+		ContentHash: "sha256:" + strings.Repeat(digit, 64),
+		SourceURI:   "https://registry.example.com/source.git",
+		AttestedAt:  time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
 	}
 }
 
@@ -132,6 +172,72 @@ func TestSyncMOAT_HappyPath_PinnedProfile(t *testing.T) {
 	// Lockfile should exist on disk.
 	if _, err := os.Stat(filepath.Join(root, ".syllago", "moat-lockfile.json")); err != nil {
 		t.Errorf("lockfile not saved: %v", err)
+	}
+}
+
+func TestSyncMOAT_PrintsInstalledDrift(t *testing.T) {
+	output.SetForTest(t)
+	root := tempProjectRoot(t)
+	cacheDir := filepath.Join(root, "cache")
+	pinned := incomingProfile()
+	reg := moatRegFixture("https://registry.example.com/manifest.json")
+	reg.SigningProfile = &pinned
+	cfg := &config.Config{Registries: []config.Registry{reg}}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("save initial cfg: %v", err)
+	}
+
+	oldManifest := syncMOATDriftManifest(t, "2026-04-20T00:00:00Z", []moat.ContentEntry{
+		syncMOATDriftEntry("foo", "1"),
+	})
+	if err := moat.WriteManifestCache(cacheDir, "example", syncMOATDriftManifestBytes(t, oldManifest), []byte(`{"bundle":true}`)); err != nil {
+		t.Fatalf("WriteManifestCache: %v", err)
+	}
+
+	newManifest := syncMOATDriftManifest(t, "2026-04-21T00:00:00Z", []moat.ContentEntry{
+		syncMOATDriftEntry("foo", "2"),
+	})
+	withStubbedMoatSync(t, func(_ context.Context, _ *config.Registry, _ *moat.Lockfile, _ []byte, _ *moat.Fetcher, _ time.Time) (moat.SyncResult, error) {
+		return moat.SyncResult{
+			ManifestURL:      "https://registry.example.com/manifest.json",
+			BundleURL:        "https://registry.example.com/manifest.json.sigstore",
+			ETag:             `"v42"`,
+			FetchedAt:        time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+			IncomingProfile:  incomingProfile(),
+			Staleness:        moat.StalenessFresh,
+			RevocationsAdded: 1,
+			Manifest:         newManifest,
+			ManifestBytes:    syncMOATDriftManifestBytes(t, newManifest),
+			BundleBytes:      []byte(`{"bundle":true}`),
+		}, nil
+	})
+
+	origClone := moat.CloneRepoFn
+	moat.CloneRepoFn = func(context.Context, string, string) error {
+		return nil
+	}
+	t.Cleanup(func() { moat.CloneRepoFn = origClone })
+
+	saveRegistrySyncDriftStore(t,
+		registrySyncDriftRecord("example", "skill", "foo", filepath.Join(root, "library", "foo"), "claude-code"),
+	)
+
+	var out, errW bytes.Buffer
+	code, err := syncMOATRegistry(context.Background(), &out, &errW, cfg, &cfg.Registries[0], root, cacheDir, time.Now(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d; want 0", code)
+	}
+	gotOut := out.String()
+	for _, want := range []string{
+		"Installed items drifted from upstream:\n",
+		"  ~ skill/foo changed upstream — refresh: syllago install example/foo\n",
+	} {
+		if !strings.Contains(gotOut, want) {
+			t.Fatalf("sync output = %q; want to contain %q", gotOut, want)
+		}
 	}
 }
 

--- a/cli/internal/registryops/drift.go
+++ b/cli/internal/registryops/drift.go
@@ -7,6 +7,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/add"
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/regdiff"
 	"github.com/OpenScribbler/syllago/cli/internal/registry"
 )
 
@@ -88,6 +89,68 @@ func InstalledGitDrift(regName string) []InstalledDrift {
 				Type:      rec.Type,
 				Name:      rec.Name,
 				Kind:      DriftChanged,
+				Providers: installedDriftProviders(rec),
+			})
+		}
+	}
+
+	sort.Slice(drifts, func(i, j int) bool {
+		if drifts[i].Type != drifts[j].Type {
+			return drifts[i].Type < drifts[j].Type
+		}
+		return drifts[i].Name < drifts[j].Name
+	})
+	return drifts
+}
+
+// InstalledMOATDrift reports drift for installed items from the MOAT
+// registry regName, derived from this sync's manifest diff. Unlike the git
+// path this is diff-based: only items whose manifest entry changed in THIS
+// sync are reported (library-copy hashes are not comparable to manifest
+// content hashes, so there is no baseline for pre-existing staleness).
+// Best-effort: nil diff, no changes, or any store error returns nil.
+func InstalledMOATDrift(regName string, diff *regdiff.Diff) []InstalledDrift {
+	if diff == nil || len(diff.Changes) == 0 {
+		return nil
+	}
+
+	path, err := installstore.DefaultPath()
+	if err != nil {
+		return nil
+	}
+	store, err := installstore.Load(path)
+	if err != nil {
+		return nil
+	}
+	records := store.ByRegistry(regName)
+	if len(records) == 0 {
+		return nil
+	}
+
+	changes := make(map[installedDriftKey]regdiff.Kind, len(diff.Changes))
+	for _, change := range diff.Changes {
+		key := installedDriftKey{contentType: change.Type, name: change.Name}
+		changes[key] = change.Kind
+	}
+
+	drifts := make([]InstalledDrift, 0)
+	for _, rec := range records {
+		key := installedDriftKey{contentType: rec.Type, name: rec.Name}
+		switch changes[key] {
+		case regdiff.KindModified:
+			drifts = append(drifts, InstalledDrift{
+				Registry:  regName,
+				Type:      rec.Type,
+				Name:      rec.Name,
+				Kind:      DriftChanged,
+				Providers: installedDriftProviders(rec),
+			})
+		case regdiff.KindRemoved:
+			drifts = append(drifts, InstalledDrift{
+				Registry:  regName,
+				Type:      rec.Type,
+				Name:      rec.Name,
+				Kind:      DriftMissing,
 				Providers: installedDriftProviders(rec),
 			})
 		}

--- a/cli/internal/registryops/drift_test.go
+++ b/cli/internal/registryops/drift_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/installstore"
 	"github.com/OpenScribbler/syllago/cli/internal/metadata"
+	"github.com/OpenScribbler/syllago/cli/internal/regdiff"
 	"github.com/OpenScribbler/syllago/cli/internal/registry"
 )
 
@@ -93,6 +94,65 @@ func TestInstalledGitDrift_UninstalledRegistryItemsIgnored(t *testing.T) {
 	}
 }
 
+func TestInstalledMOATDrift_MixedDrift(t *testing.T) {
+	setupInstalledMOATDriftTest(t)
+	saveDriftInstallStore(t,
+		driftRecord("test-reg", "skills", "foo", "", "claude-code"),
+		driftRecord("test-reg", "rules", "bar", "", "claude-code", "cursor"),
+	)
+
+	diff := &regdiff.Diff{Changes: []regdiff.ItemChange{
+		{Type: "skills", Name: "foo", Kind: regdiff.KindModified},
+		{Type: "rules", Name: "bar", Kind: regdiff.KindRemoved},
+		{Type: "skills", Name: "baz", Kind: regdiff.KindAdded},
+		{Type: "skills", Name: "tracked", Kind: regdiff.KindModified},
+	}}
+
+	got := InstalledMOATDrift("test-reg", diff)
+	want := []InstalledDrift{
+		{
+			Registry:  "test-reg",
+			Type:      "rules",
+			Name:      "bar",
+			Kind:      DriftMissing,
+			Providers: []string{"claude-code", "cursor"},
+		},
+		{
+			Registry:  "test-reg",
+			Type:      "skills",
+			Name:      "foo",
+			Kind:      DriftChanged,
+			Providers: []string{"claude-code"},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("InstalledMOATDrift() = %#v; want %#v", got, want)
+	}
+}
+
+func TestInstalledMOATDrift_NilOrEmptyDiff(t *testing.T) {
+	setupInstalledMOATDriftTest(t)
+	saveDriftInstallStore(t, driftRecord("test-reg", "skills", "foo", "", "claude-code"))
+
+	if got := InstalledMOATDrift("test-reg", nil); got != nil {
+		t.Fatalf("InstalledMOATDrift(nil) = %#v; want nil", got)
+	}
+	if got := InstalledMOATDrift("test-reg", &regdiff.Diff{}); got != nil {
+		t.Fatalf("InstalledMOATDrift(empty diff) = %#v; want nil", got)
+	}
+}
+
+func TestInstalledMOATDrift_NoRecords(t *testing.T) {
+	setupInstalledMOATDriftTest(t)
+
+	diff := &regdiff.Diff{Changes: []regdiff.ItemChange{
+		{Type: "skills", Name: "foo", Kind: regdiff.KindModified},
+	}}
+	if got := InstalledMOATDrift("test-reg", diff); got != nil {
+		t.Fatalf("InstalledMOATDrift() with no records = %#v; want nil", got)
+	}
+}
+
 type installedGitDriftTestEnv struct {
 	cacheDir  string
 	globalDir string
@@ -120,6 +180,15 @@ func setupInstalledGitDriftTest(t *testing.T) installedGitDriftTestEnv {
 	t.Cleanup(func() { config.GlobalDirOverride = origConfig })
 
 	return env
+}
+
+func setupInstalledMOATDriftTest(t *testing.T) string {
+	t.Helper()
+	configDir := t.TempDir()
+	origConfig := config.GlobalDirOverride
+	config.GlobalDirOverride = configDir
+	t.Cleanup(func() { config.GlobalDirOverride = origConfig })
+	return configDir
 }
 
 func (e installedGitDriftTestEnv) cloneDir(registryName string) string {

--- a/cli/internal/tui/actions.go
+++ b/cli/internal/tui/actions.go
@@ -403,9 +403,10 @@ type registryAddDoneMsg struct {
 
 // registrySyncDoneMsg is sent when a registry sync operation completes.
 type registrySyncDoneMsg struct {
-	name string
-	err  error
-	diff *regdiff.Diff
+	name           string
+	err            error
+	diff           *regdiff.Diff
+	installedDrift int
 }
 
 // registryRemoveDoneMsg is sent when a registry remove operation completes.
@@ -578,8 +579,11 @@ func (a App) doGitSyncCmd(name string) tea.Cmd {
 	return func() tea.Msg {
 		outcome, err := registry.Sync(name)
 		msg := registrySyncDoneMsg{name: name, err: err}
-		if err == nil && outcome.OldHead != "" && outcome.OldHead != outcome.NewHead {
-			msg.diff = registryops.GitSyncDiff(name, outcome.OldHead, outcome.NewHead)
+		if err == nil {
+			msg.installedDrift = len(registryops.InstalledGitDrift(name))
+			if outcome.OldHead != "" && outcome.OldHead != outcome.NewHead {
+				msg.diff = registryops.GitSyncDiff(name, outcome.OldHead, outcome.NewHead)
+			}
 		}
 		return msg
 	}
@@ -627,6 +631,9 @@ func (a App) handleMOATSyncDone(msg moatSyncDoneMsg) (tea.Model, tea.Cmd) {
 	if summary := syncDiffSummary(msg.diff); summary != "" {
 		text += ": " + summary
 	}
+	if msg.installedDrift > 0 {
+		text += fmt.Sprintf(" — %d installed item(s) affected", msg.installedDrift)
+	}
 	cmd1 := a.toast.Push(text, toastSuccess)
 	cmd2 := a.rescanCatalog()
 	return a, tea.Batch(cmd1, cmd2)
@@ -642,6 +649,9 @@ func (a App) handleSyncDone(msg registrySyncDoneMsg) (tea.Model, tea.Cmd) {
 	text := "Synced " + msg.name
 	if summary := syncDiffSummary(msg.diff); summary != "" {
 		text += ": " + summary
+	}
+	if msg.installedDrift > 0 {
+		text += fmt.Sprintf(" — %d installed item(s) affected", msg.installedDrift)
 	}
 	cmd1 := a.toast.Push(text, toastSuccess)
 	cmd2 := a.rescanCatalog()

--- a/cli/internal/tui/actions_test.go
+++ b/cli/internal/tui/actions_test.go
@@ -289,6 +289,19 @@ func TestHandleSyncDone_WithDiffSummary(t *testing.T) {
 	assertCurrentToastMessage(t, a, "Synced test-reg: 2 upstream change(s) (+1 ~1)")
 }
 
+func TestHandleSyncDone_WithInstalledDriftSuffix(t *testing.T) {
+	t.Parallel()
+	app := testApp(t)
+	diff := &regdiff.Diff{Changes: []regdiff.ItemChange{
+		{Kind: regdiff.KindModified},
+	}}
+
+	m, _ := app.handleSyncDone(registrySyncDoneMsg{name: "test-reg", diff: diff, installedDrift: 2})
+	a := m.(App)
+
+	assertCurrentToastMessage(t, a, "Synced test-reg: 1 upstream change(s) (~1) — 2 installed item(s) affected")
+}
+
 func TestHandleSyncDone_NoDiffKeepsPlainToast(t *testing.T) {
 	t.Parallel()
 	app := testApp(t)
@@ -297,6 +310,21 @@ func TestHandleSyncDone_NoDiffKeepsPlainToast(t *testing.T) {
 	a := m.(App)
 
 	assertCurrentToastMessage(t, a, "Synced test-reg")
+}
+
+func TestHandleSyncDone_ZeroInstalledDriftOmitsSuffix(t *testing.T) {
+	t.Parallel()
+	app := testApp(t)
+	diff := &regdiff.Diff{Changes: []regdiff.ItemChange{
+		{Kind: regdiff.KindModified},
+	}}
+
+	m, _ := app.handleSyncDone(registrySyncDoneMsg{name: "test-reg", diff: diff})
+	a := m.(App)
+
+	if got := a.toast.Current().message; strings.Contains(got, "installed item(s) affected") {
+		t.Fatalf("toast message = %q; want no installed drift suffix", got)
+	}
 }
 
 func TestActions_HandleRemoveResult_NotConfirmed(t *testing.T) {

--- a/cli/internal/tui/moat_sync.go
+++ b/cli/internal/tui/moat_sync.go
@@ -55,6 +55,8 @@ type moatSyncDoneMsg struct {
 	// diff is best-effort item-level upstream change information. Nil means
 	// no changes or no comparable baseline.
 	diff *regdiff.Diff
+
+	installedDrift int
 }
 
 // moatSyncFnTUI is the indirection point so tests can stub the end-to-end
@@ -111,8 +113,9 @@ func runMOATSync(ctx context.Context, name, projectRoot string, acceptTOFU bool)
 	}
 
 	return moatSyncDoneMsg{
-		name:  name,
-		stale: outcome.MoatResult.Staleness == moat.StalenessExpired,
-		diff:  outcome.Diff,
+		name:           name,
+		stale:          outcome.MoatResult.Staleness == moat.StalenessExpired,
+		diff:           outcome.Diff,
+		installedDrift: len(registryops.InstalledMOATDrift(name, outcome.Diff)),
 	}
 }

--- a/cli/internal/tui/moat_sync_test.go
+++ b/cli/internal/tui/moat_sync_test.go
@@ -20,6 +20,7 @@ package tui
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
@@ -153,6 +154,34 @@ func TestHandleMOATSyncDone_HappyPathWithDiffSummary(t *testing.T) {
 	a := m.(App)
 
 	assertCurrentToastMessage(t, a, "Synced reg: 2 upstream change(s) (+1 ~1)")
+}
+
+func TestHandleMOATSyncDone_WithInstalledDriftSuffix(t *testing.T) {
+	t.Parallel()
+	app := testApp(t)
+	diff := &regdiff.Diff{Changes: []regdiff.ItemChange{
+		{Kind: regdiff.KindModified},
+	}}
+
+	m, _ := app.handleMOATSyncDone(moatSyncDoneMsg{name: "reg", diff: diff, installedDrift: 1})
+	a := m.(App)
+
+	assertCurrentToastMessage(t, a, "Synced reg: 1 upstream change(s) (~1) — 1 installed item(s) affected")
+}
+
+func TestHandleMOATSyncDone_ZeroInstalledDriftOmitsSuffix(t *testing.T) {
+	t.Parallel()
+	app := testApp(t)
+	diff := &regdiff.Diff{Changes: []regdiff.ItemChange{
+		{Kind: regdiff.KindModified},
+	}}
+
+	m, _ := app.handleMOATSyncDone(moatSyncDoneMsg{name: "reg", diff: diff})
+	a := m.(App)
+
+	if got := a.toast.Current().message; strings.Contains(got, "installed item(s) affected") {
+		t.Fatalf("toast message = %q; want no installed drift suffix", got)
+	}
 }
 
 func TestHandleMOATSyncDone_Stale(t *testing.T) {


### PR DESCRIPTION
## Summary

Chunk 3b of #542 item 3 (healing sync / drift visibility). Extends the installed-item drift reporting merged in #560 to MOAT registries, and surfaces drift counts in TUI sync toasts.

- **`registryops.InstalledMOATDrift(regName, diff)`** — diff-based drift for MOAT registries: intersects this sync's manifest diff with install records (`KindModified` → changed, `KindRemoved` → missing; `KindAdded`/untracked skipped). Diff-based rather than hash-based because install-record content hashes cover the library copy (including `.syllago.yaml`) while manifest `content_hash` is the tree-merkle of the pristine source subdirectory — the two are not comparable, so only changes observed in this sync are reportable (documented on the function).
- **Hint modes for `printInstalledDrift`** — MOAT changed items get `refresh: syllago install <registry>/<name>` (the MOAT-only install syntax; `--force` deliberately not suggested since on install it means "proceed past scanner findings"). Git-path output stays byte-identical.
- **CLI wiring** — `syncMOATRegistry` prints the drift block after the manifest diff and enriches `drift_count` (already in the catalog for `registry_sync`; no catalog change needed).
- **TUI** — `registrySyncDoneMsg` and `moatSyncDoneMsg` gain `installedDrift int`, computed inside the async `tea.Cmd` functions; both sync toasts append `— N installed item(s) affected` when positive.

## Testing

- New: `TestInstalledMOATDrift_MixedDrift` / `_NilOrEmptyDiff` / `_NoRecords` (registryops); `TestSyncMOAT_PrintsInstalledDrift` (RunE-level, stubbed sync seam + real cached-manifest baseline); toast suffix tests for both handlers (present when positive, absent at zero).
- Full suite green locally: 40 packages ok, `gofmt -l cmd internal` clean.

Part of #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)