### PR TITLE
feat(registry): per-item git-log excerpts in registry diff display (#542 item 6d)

### DIFF
--- a/cli/cmd/syllago/registry_diff.go
+++ b/cli/cmd/syllago/registry_diff.go
@@ -44,6 +44,9 @@ func printRegistryDiffLines(w io.Writer, d *regdiff.Diff) {
 	}
 	for _, change := range d.Changes[:limit] {
 		fmt.Fprintf(w, "  %s %s/%s\n", registryDiffSymbol(change.Kind), change.Type, trimRegistryDiffName(change.Name))
+		for _, line := range change.LogLines {
+			fmt.Fprintf(w, "      · %s\n", line)
+		}
 	}
 	if more := len(d.Changes) - limit; more > 0 {
 		fmt.Fprintf(w, "  … and %d more\n", more)

--- a/cli/cmd/syllago/registry_diff_test.go
+++ b/cli/cmd/syllago/registry_diff_test.go
@@ -93,6 +93,31 @@ func TestPrintRegistryDiffLines_RendersBodyWithoutHeaderOrGuards(t *testing.T) {
 	}
 }
 
+func TestPrintRegistryDiffLines_RendersLogLinesUnderChangedItem(t *testing.T) {
+	output.SetForTest(t)
+	d := &regdiff.Diff{
+		Changes: []regdiff.ItemChange{
+			{
+				Type:     "skills",
+				Name:     "foo",
+				Kind:     regdiff.KindModified,
+				LogLines: []string{"fix foo prompt wording", "add usage examples"},
+			},
+			{Type: "skills", Name: "bar", Kind: regdiff.KindAdded},
+		},
+	}
+
+	var buf bytes.Buffer
+	printRegistryDiffLines(&buf, d)
+	want := "  ~ skills/foo\n" +
+		"      · fix foo prompt wording\n" +
+		"      · add usage examples\n" +
+		"  + skills/bar\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("printRegistryDiffLines() = %q; want %q", got, want)
+	}
+}
+
 func TestPrintRegistryDiff_TrimsKnownExtensionsForDisplay(t *testing.T) {
 	output.SetForTest(t)
 	d := &regdiff.Diff{

--- a/cli/cmd/syllago/registry_status_test.go
+++ b/cli/cmd/syllago/registry_status_test.go
@@ -127,7 +127,9 @@ func TestRegistryStatusGitShowsUpstreamChangesWithoutConsumingSync(t *testing.T)
 	}
 	wantStatus := "git-status (git): 2 upstream change(s)\n" +
 		"  ~ rules/updated-rule\n" +
-		"  + skills/new-thing\n"
+		"      · update content for status\n" +
+		"  + skills/new-thing\n" +
+		"      · update content for status\n"
 	if got := stdout.String(); got != wantStatus {
 		t.Fatalf("status stdout = %q; want %q", got, wantStatus)
 	}

--- a/cli/cmd/syllago/registry_sync_git_test.go
+++ b/cli/cmd/syllago/registry_sync_git_test.go
@@ -78,8 +78,11 @@ func TestRegistrySync_PersistsGitLastSyncBookkeeping(t *testing.T) {
 	syncedLine := "Synced: git-sync-bookkeeping\n"
 	diffBlock := "Changes since last sync:\n" +
 		"  - agents/old-agent\n" +
+		"      · update content\n" +
 		"  ~ rules/updated-rule\n" +
-		"  + skills/new-thing\n"
+		"      · update content\n" +
+		"  + skills/new-thing\n" +
+		"      · update content\n"
 	if !strings.Contains(gotOut, syncedLine+diffBlock) {
 		t.Fatalf("second sync output = %q; want Synced line followed by diff block %q", gotOut, diffBlock)
 	}

--- a/cli/internal/regdiff/git.go
+++ b/cli/internal/regdiff/git.go
@@ -26,6 +26,8 @@ type itemAccum struct {
 	statuses []byte
 }
 
+const logExcerptItemLimit = 20
+
 // GitDiff computes the item-level change set between two commits of a git
 // registry checkout at repoDir. items describes the CURRENT checkout's
 // items; knownTypeDirs lists top-level content-type directory names
@@ -54,6 +56,7 @@ func GitDiff(registry, repoDir, oldHead, newHead string, items []ItemRef, knownT
 
 	current := make(map[itemKey]*itemAccum)
 	fallback := make(map[itemKey]*itemAccum)
+	changeDirs := make(map[itemKey]string)
 	var otherPaths []string
 
 	for _, ps := range parseNameStatus(out) {
@@ -95,6 +98,7 @@ func GitDiff(registry, repoDir, oldHead, newHead string, items []ItemRef, knownT
 			}
 		}
 		diff.Changes = append(diff.Changes, itemChangeFromAccum(acc, kind))
+		changeDirs[acc.key] = acc.dir
 	}
 
 	for _, acc := range fallback {
@@ -109,6 +113,7 @@ func GitDiff(registry, repoDir, oldHead, newHead string, items []ItemRef, knownT
 			}
 		}
 		diff.Changes = append(diff.Changes, itemChangeFromAccum(acc, kind))
+		changeDirs[acc.key] = acc.dir
 	}
 
 	sort.Slice(diff.Changes, func(i, j int) bool {
@@ -119,8 +124,41 @@ func GitDiff(registry, repoDir, oldHead, newHead string, items []ItemRef, knownT
 	})
 	sort.Strings(otherPaths)
 	diff.OtherPaths = otherPaths
+	if len(diff.Changes) <= logExcerptItemLimit {
+		populateGitLogLines(repoDir, oldHead, newHead, diff.Changes, changeDirs)
+	}
 
 	return diff, nil
+}
+
+func populateGitLogLines(repoDir, oldHead, newHead string, changes []ItemChange, changeDirs map[itemKey]string) {
+	revRange := oldHead + ".." + newHead
+	for i := range changes {
+		dir := changeDirs[itemKey{Type: changes[i].Type, Name: changes[i].Name}]
+		if dir == "" {
+			continue
+		}
+		out, err := runGit(repoDir, "log", "--no-merges", "--format=%s", "-n", "3", revRange, "--", dir)
+		if err != nil {
+			continue
+		}
+		lines := splitNonEmptyLines(out)
+		if len(lines) > 0 {
+			changes[i].LogLines = lines
+		}
+	}
+}
+
+func splitNonEmptyLines(out []byte) []string {
+	var lines []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
 }
 
 func parseNameStatus(out []byte) []gitPathStatus {

--- a/cli/internal/regdiff/git_test.go
+++ b/cli/internal/regdiff/git_test.go
@@ -1,6 +1,7 @@
 package regdiff
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,9 +29,9 @@ func TestGitDiff_FullDiff(t *testing.T) {
 		OldRef:   commit1,
 		NewRef:   commit2,
 		Changes: []ItemChange{
-			{Type: "skills", Name: "alpha", Kind: KindModified, Paths: []string{"skills/alpha/SKILL.md"}},
-			{Type: "skills", Name: "beta", Kind: KindRemoved, Paths: []string{"skills/beta/SKILL.md"}},
-			{Type: "skills", Name: "delta", Kind: KindAdded, Paths: []string{"skills/delta/SKILL.md"}},
+			{Type: "skills", Name: "alpha", Kind: KindModified, Paths: []string{"skills/alpha/SKILL.md"}, LogLines: []string{"second"}},
+			{Type: "skills", Name: "beta", Kind: KindRemoved, Paths: []string{"skills/beta/SKILL.md"}, LogLines: []string{"second"}},
+			{Type: "skills", Name: "delta", Kind: KindAdded, Paths: []string{"skills/delta/SKILL.md"}, LogLines: []string{"second"}},
 		},
 		OtherPaths: []string{"README.md"},
 	}
@@ -109,8 +110,8 @@ func TestGitDiff_RenameUsesDeleteAndAdd(t *testing.T) {
 	}
 
 	wantChanges := []ItemChange{
-		{Type: "skills", Name: "delta", Kind: KindRemoved, Paths: []string{"skills/delta/SKILL.md"}},
-		{Type: "skills", Name: "epsilon", Kind: KindAdded, Paths: []string{"skills/epsilon/SKILL.md"}},
+		{Type: "skills", Name: "delta", Kind: KindRemoved, Paths: []string{"skills/delta/SKILL.md"}, LogLines: []string{"rename delta"}},
+		{Type: "skills", Name: "epsilon", Kind: KindAdded, Paths: []string{"skills/epsilon/SKILL.md"}, LogLines: []string{"rename delta"}},
 	}
 	if !reflect.DeepEqual(got.Changes, wantChanges) {
 		t.Fatalf("Changes mismatch:\n got: %#v\nwant: %#v", got.Changes, wantChanges)
@@ -120,12 +121,157 @@ func TestGitDiff_RenameUsesDeleteAndAdd(t *testing.T) {
 	}
 }
 
+func TestGitDiff_LogExcerptCaptured(t *testing.T) {
+	t.Parallel()
+	repoDir := buildGitRepo(t)
+
+	writeRepoFile(t, repoDir, "skills/foo/SKILL.md", "foo v1\n")
+	commitAll(t, repoDir, "initial")
+	oldHead := gitIn(t, repoDir, "rev-parse", "HEAD")
+
+	writeRepoFile(t, repoDir, "skills/foo/SKILL.md", "foo v2\n")
+	commitAll(t, repoDir, "fix foo prompt wording")
+	writeRepoFile(t, repoDir, "skills/foo/SKILL.md", "foo v3\n")
+	commitAll(t, repoDir, "add usage examples")
+	newHead := gitIn(t, repoDir, "rev-parse", "HEAD")
+
+	got, err := GitDiff("example", repoDir, oldHead, newHead, []ItemRef{
+		{Type: "skills", Name: "foo", Dir: "skills/foo"},
+	}, []string{"skills"})
+	if err != nil {
+		t.Fatalf("GitDiff: %v", err)
+	}
+	if len(got.Changes) != 1 {
+		t.Fatalf("Changes len = %d; want 1: %#v", len(got.Changes), got.Changes)
+	}
+	want := []string{"add usage examples", "fix foo prompt wording"}
+	if !reflect.DeepEqual(got.Changes[0].LogLines, want) {
+		t.Fatalf("LogLines = %#v; want %#v", got.Changes[0].LogLines, want)
+	}
+}
+
+func TestGitDiff_LogExcerptCapsAtThree(t *testing.T) {
+	t.Parallel()
+	repoDir := buildGitRepo(t)
+
+	writeRepoFile(t, repoDir, "skills/foo/SKILL.md", "foo v1\n")
+	commitAll(t, repoDir, "initial")
+	oldHead := gitIn(t, repoDir, "rev-parse", "HEAD")
+
+	for i := 1; i <= 4; i++ {
+		subject := fmt.Sprintf("foo update %d", i)
+		writeRepoFile(t, repoDir, "skills/foo/SKILL.md", subject+"\n")
+		commitAll(t, repoDir, subject)
+	}
+	newHead := gitIn(t, repoDir, "rev-parse", "HEAD")
+
+	got, err := GitDiff("example", repoDir, oldHead, newHead, []ItemRef{
+		{Type: "skills", Name: "foo", Dir: "skills/foo"},
+	}, []string{"skills"})
+	if err != nil {
+		t.Fatalf("GitDiff: %v", err)
+	}
+	want := []string{"foo update 4", "foo update 3", "foo update 2"}
+	if !reflect.DeepEqual(got.Changes[0].LogLines, want) {
+		t.Fatalf("LogLines = %#v; want %#v", got.Changes[0].LogLines, want)
+	}
+}
+
+func TestGitDiff_LogExcerptExcludesMergeCommits(t *testing.T) {
+	t.Parallel()
+	repoDir := buildGitRepo(t)
+
+	writeRepoFile(t, repoDir, "skills/foo/SKILL.md", "foo v1\n")
+	commitAll(t, repoDir, "initial")
+	oldHead := gitIn(t, repoDir, "rev-parse", "HEAD")
+	baseBranch := gitIn(t, repoDir, "branch", "--show-current")
+
+	gitIn(t, repoDir, "checkout", "-b", "feature")
+	writeRepoFile(t, repoDir, "skills/foo/SKILL.md", "foo feature\n")
+	commitAll(t, repoDir, "feature updates foo")
+	gitIn(t, repoDir, "checkout", baseBranch)
+	writeRepoFile(t, repoDir, "README.md", "mainline\n")
+	commitAll(t, repoDir, "mainline update")
+	gitIn(t, repoDir, "merge", "--no-ff", "feature", "-m", "merge feature branch")
+	newHead := gitIn(t, repoDir, "rev-parse", "HEAD")
+
+	got, err := GitDiff("example", repoDir, oldHead, newHead, []ItemRef{
+		{Type: "skills", Name: "foo", Dir: "skills/foo"},
+	}, []string{"skills"})
+	if err != nil {
+		t.Fatalf("GitDiff: %v", err)
+	}
+	want := []string{"feature updates foo"}
+	if !reflect.DeepEqual(got.Changes[0].LogLines, want) {
+		t.Fatalf("LogLines = %#v; want %#v", got.Changes[0].LogLines, want)
+	}
+}
+
+func TestGitDiff_RemovedItemGetsDeletingCommitSubject(t *testing.T) {
+	t.Parallel()
+	repoDir := buildGitRepo(t)
+
+	writeRepoFile(t, repoDir, "skills/foo/SKILL.md", "foo v1\n")
+	commitAll(t, repoDir, "initial")
+	oldHead := gitIn(t, repoDir, "rev-parse", "HEAD")
+
+	if err := os.RemoveAll(filepath.Join(repoDir, "skills", "foo")); err != nil {
+		t.Fatalf("remove foo: %v", err)
+	}
+	commitAll(t, repoDir, "remove foo skill")
+	newHead := gitIn(t, repoDir, "rev-parse", "HEAD")
+
+	got, err := GitDiff("example", repoDir, oldHead, newHead, nil, []string{"skills"})
+	if err != nil {
+		t.Fatalf("GitDiff: %v", err)
+	}
+	if len(got.Changes) != 1 {
+		t.Fatalf("Changes len = %d; want 1: %#v", len(got.Changes), got.Changes)
+	}
+	if got.Changes[0].Kind != KindRemoved {
+		t.Fatalf("Kind = %q; want %q", got.Changes[0].Kind, KindRemoved)
+	}
+	want := []string{"remove foo skill"}
+	if !reflect.DeepEqual(got.Changes[0].LogLines, want) {
+		t.Fatalf("LogLines = %#v; want %#v", got.Changes[0].LogLines, want)
+	}
+}
+
+func TestGitDiff_LogExcerptSkippedAboveItemLimit(t *testing.T) {
+	t.Parallel()
+	repoDir := buildGitRepo(t)
+
+	writeRepoFile(t, repoDir, "README.md", "initial\n")
+	commitAll(t, repoDir, "initial")
+	oldHead := gitIn(t, repoDir, "rev-parse", "HEAD")
+
+	var items []ItemRef
+	for i := 1; i <= 21; i++ {
+		name := fmt.Sprintf("item-%02d", i)
+		dir := "skills/" + name
+		writeRepoFile(t, repoDir, dir+"/SKILL.md", name+"\n")
+		items = append(items, ItemRef{Type: "skills", Name: name, Dir: dir})
+	}
+	commitAll(t, repoDir, "add many skills")
+	newHead := gitIn(t, repoDir, "rev-parse", "HEAD")
+
+	got, err := GitDiff("example", repoDir, oldHead, newHead, items, []string{"skills"})
+	if err != nil {
+		t.Fatalf("GitDiff: %v", err)
+	}
+	if len(got.Changes) != 21 {
+		t.Fatalf("Changes len = %d; want 21", len(got.Changes))
+	}
+	for _, change := range got.Changes {
+		if len(change.LogLines) != 0 {
+			t.Fatalf("%s/%s LogLines = %#v; want nil/empty", change.Type, change.Name, change.LogLines)
+		}
+	}
+}
+
 func buildGitScenario(t *testing.T) (repoDir, commit1, commit2 string) {
 	t.Helper()
-	repoDir = t.TempDir()
-	gitIn(t, repoDir, "init")
-	gitIn(t, repoDir, "config", "user.email", "test@example.com")
-	gitIn(t, repoDir, "config", "user.name", "Test User")
+	repoDir = buildGitRepo(t)
 
 	writeRepoFile(t, repoDir, "skills/alpha/SKILL.md", "alpha v1\n")
 	writeRepoFile(t, repoDir, "skills/beta/SKILL.md", "beta v1\n")
@@ -144,6 +290,15 @@ func buildGitScenario(t *testing.T) (repoDir, commit1, commit2 string) {
 	commit2 = gitIn(t, repoDir, "rev-parse", "HEAD")
 
 	return repoDir, commit1, commit2
+}
+
+func buildGitRepo(t *testing.T) string {
+	t.Helper()
+	repoDir := t.TempDir()
+	gitIn(t, repoDir, "init")
+	gitIn(t, repoDir, "config", "user.email", "test@example.com")
+	gitIn(t, repoDir, "config", "user.name", "Test User")
+	return repoDir
 }
 
 func writeRepoFile(t *testing.T, repoDir, rel, contents string) {

--- a/cli/internal/regdiff/regdiff.go
+++ b/cli/internal/regdiff/regdiff.go
@@ -11,10 +11,11 @@ const (
 
 // ItemChange is one content item's change between two registry states.
 type ItemChange struct {
-	Type  string // content type dir/slug, e.g. "skills", or MOAT type "skill"
-	Name  string // item name
-	Kind  Kind
-	Paths []string // changed file paths relative to repo root (git registries); nil for MOAT
+	Type     string // content type dir/slug, e.g. "skills", or MOAT type "skill"
+	Name     string // item name
+	Kind     Kind
+	Paths    []string // changed file paths relative to repo root (git registries); nil for MOAT
+	LogLines []string // upstream commit subjects touching this item, newest first, capped; git registries only, nil for MOAT
 }
 
 // Diff is the full change set for one registry between two refs.

--- a/cli/internal/registryops/gitdiff_test.go
+++ b/cli/internal/registryops/gitdiff_test.go
@@ -47,8 +47,8 @@ func TestGitSyncDiff(t *testing.T) {
 		t.Fatal("GitSyncDiff = nil; want diff")
 	}
 	wantChanges := []regdiff.ItemChange{
-		{Type: "skills", Name: "alpha", Kind: regdiff.KindModified, Paths: []string{"skills/alpha/SKILL.md"}},
-		{Type: "skills", Name: "beta", Kind: regdiff.KindAdded, Paths: []string{"skills/beta/SKILL.md"}},
+		{Type: "skills", Name: "alpha", Kind: regdiff.KindModified, Paths: []string{"skills/alpha/SKILL.md"}, LogLines: []string{"update content"}},
+		{Type: "skills", Name: "beta", Kind: regdiff.KindAdded, Paths: []string{"skills/beta/SKILL.md"}, LogLines: []string{"update content"}},
 	}
 	if !reflect.DeepEqual(got.Changes, wantChanges) {
 		t.Fatalf("Changes = %#v; want %#v", got.Changes, wantChanges)


### PR DESCRIPTION
## Summary

Chunk 6d of #542 item 6 (update visibility) — the final #542 chunk. Git-registry diff lines in `registry sync` and `registry status` now carry a short excerpt of the upstream git log per changed item:

```
Changes since last sync:
  ~ skills/foo
      · fix foo prompt wording
      · add usage examples
  + skills/bar
```

- **`regdiff.ItemChange.LogLines`** — populated in `GitDiff` via `git log --no-merges --format=%s -n 3 <old>..<new> -- <item dir>` (merge-commit noise excluded; removed items get the deleting commit's subject). Best-effort: a `git log` failure for one item leaves that item's excerpt nil without failing the diff.
- **Work cap** — excerpts are skipped entirely when the diff has more than 20 changed items (`logExcerptItemLimit`), so a large upstream reorganization doesn't spawn hundreds of git invocations.
- **Display** — `printRegistryDiffLines` renders `      · <subject>` under each change line, which covers both the sync path and the status path (status diffs against the fetched remote head, whose objects are already in the local object db). MOAT diffs are untouched (manifests carry no commit history); `registry status --json` output is unchanged.

## Testing

- New regdiff tests against real git fixtures: excerpt captured newest-first, cap at 3, merge commits excluded (`git merge --no-ff`), removed item gets the deleting commit's subject, >20 changed items → all excerpts skipped.
- New pure render test for `printRegistryDiffLines` with and without LogLines.
- Existing exact-output sync/status integration tests updated for the new excerpt lines (incidentally proving excerpts appear in both real paths).
- Full suite green locally: 40 packages ok, `gofmt -l cmd internal` clean.

Part of #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)