### PR TITLE
feat(installstore): pin + one-step rollback record fields (#542 item 7a)

### DIFF
--- a/cli/internal/installstore/record.go
+++ b/cli/internal/installstore/record.go
@@ -7,6 +7,9 @@ import (
 	"time"
 )
 
+// ErrPinned is returned when an update would overwrite a pinned record.
+var ErrPinned = errors.New("install record is pinned")
+
 // PlacementInput describes one installer action to record. Keys carries the
 // JSON keys touched by a merge install (one stored Placement per key); an
 // empty Keys means a single placement with no key (symlink/copy).
@@ -17,17 +20,30 @@ type PlacementInput struct {
 	Keys      []string
 }
 
+// InstallMeta carries optional install-time metadata.
+type InstallMeta struct {
+	MOAT      *MOATProvenance // nil preserves existing provenance
+	SourceSHA string          // "" preserves any existing SourceSHA
+}
+
 // RecordInstall loads the store at storePath, upserts the record for c, adds
 // one placement per key (or one keyless placement), and saves. contentHash
 // is computed from libraryPath via HashContent; a hash failure is returned
 // as an error without writing. now stamps InstalledAt/UpdatedAt.
 func RecordInstall(storePath string, c Coord, libraryPath string, p PlacementInput, now time.Time) error {
-	return RecordInstallMOAT(storePath, c, libraryPath, p, nil, now)
+	return RecordInstallMeta(storePath, c, libraryPath, p, InstallMeta{}, now)
 }
 
 // RecordInstallMOAT is RecordInstall plus MOAT provenance. A non-nil moatProv
 // replaces the record's MOAT field; nil preserves any existing provenance.
 func RecordInstallMOAT(storePath string, c Coord, libraryPath string, p PlacementInput, moatProv *MOATProvenance, now time.Time) error {
+	return RecordInstallMeta(storePath, c, libraryPath, p, InstallMeta{MOAT: moatProv}, now)
+}
+
+// RecordInstallMeta is RecordInstall plus optional install metadata. Non-nil
+// MOAT provenance replaces the record's MOAT field; nil preserves it. A
+// non-empty SourceSHA replaces the record's SourceSHA; empty preserves it.
+func RecordInstallMeta(storePath string, c Coord, libraryPath string, p PlacementInput, meta InstallMeta, now time.Time) error {
 	contentHash, err := HashContent(libraryPath)
 	if err != nil {
 		return fmt.Errorf("hashing install content: %w", err)
@@ -47,11 +63,18 @@ func RecordInstallMOAT(storePath string, c Coord, libraryPath string, p Placemen
 	if existing := s.Find(c); existing != nil {
 		rec.Placements = append([]Placement(nil), existing.Placements...)
 		rec.MOAT = cloneMOAT(existing.MOAT)
+		rec.SourceSHA = existing.SourceSHA
+		rec.Pinned = existing.Pinned
+		rec.PinnedAt = existing.PinnedAt
+		rec.Previous = clonePrevious(existing.Previous)
 	} else {
 		rec.InstalledAt = now
 	}
-	if moatProv != nil {
-		rec.MOAT = cloneMOAT(moatProv)
+	if meta.MOAT != nil {
+		rec.MOAT = cloneMOAT(meta.MOAT)
+	}
+	if meta.SourceSHA != "" {
+		rec.SourceSHA = meta.SourceSHA
 	}
 	s.Upsert(rec)
 
@@ -69,6 +92,108 @@ func RecordInstallMOAT(storePath string, c Coord, libraryPath string, p Placemen
 		}
 	}
 
+	if err := s.Save(); err != nil {
+		return fmt.Errorf("saving install store: %w", err)
+	}
+	return nil
+}
+
+// SetPinned records whether c is held at its current content.
+func SetPinned(storePath string, c Coord, pinned bool, now time.Time) error {
+	if err := requireStoreFile(storePath); err != nil {
+		return err
+	}
+
+	s, err := Load(storePath)
+	if err != nil {
+		return fmt.Errorf("loading install store: %w", err)
+	}
+	rec := s.Find(c)
+	if rec == nil {
+		return installRecordNotFound(c)
+	}
+	if rec.Pinned == pinned {
+		return nil
+	}
+
+	rec.Pinned = pinned
+	if pinned {
+		rec.PinnedAt = now
+	} else {
+		rec.PinnedAt = time.Time{}
+	}
+	rec.UpdatedAt = now
+	if err := s.Save(); err != nil {
+		return fmt.Errorf("saving install store: %w", err)
+	}
+	return nil
+}
+
+// RecordUpdate updates c after its library copy has been overwritten.
+func RecordUpdate(storePath string, c Coord, libraryPath string, newSourceSHA string, prevCopyPath string, now time.Time) error {
+	if err := requireStoreFile(storePath); err != nil {
+		return err
+	}
+
+	s, err := Load(storePath)
+	if err != nil {
+		return fmt.Errorf("loading install store: %w", err)
+	}
+	rec := s.Find(c)
+	if rec == nil {
+		return installRecordNotFound(c)
+	}
+	if rec.Pinned {
+		return fmt.Errorf("%w for coord registry=%q type=%q name=%q", ErrPinned, c.Registry, c.Type, c.Name)
+	}
+
+	contentHash, err := HashContent(libraryPath)
+	if err != nil {
+		return fmt.Errorf("hashing install content: %w", err)
+	}
+
+	rec.Previous = &PreviousVersion{
+		SourceSHA:   rec.SourceSHA,
+		ContentHash: rec.ContentHash,
+		CopyPath:    prevCopyPath,
+		ReplacedAt:  now,
+	}
+	rec.ContentHash = contentHash
+	rec.SourceSHA = newSourceSHA
+	rec.UpdatedAt = now
+	if err := s.Save(); err != nil {
+		return fmt.Errorf("saving install store: %w", err)
+	}
+	return nil
+}
+
+// RecordRollback updates c after its previous library content was restored.
+func RecordRollback(storePath string, c Coord, libraryPath string, now time.Time) error {
+	if err := requireStoreFile(storePath); err != nil {
+		return err
+	}
+
+	s, err := Load(storePath)
+	if err != nil {
+		return fmt.Errorf("loading install store: %w", err)
+	}
+	rec := s.Find(c)
+	if rec == nil {
+		return installRecordNotFound(c)
+	}
+	if rec.Previous == nil {
+		return fmt.Errorf("no rollback data for coord registry=%q type=%q name=%q", c.Registry, c.Type, c.Name)
+	}
+
+	contentHash, err := HashContent(libraryPath)
+	if err != nil {
+		return fmt.Errorf("hashing install content: %w", err)
+	}
+
+	rec.SourceSHA = rec.Previous.SourceSHA
+	rec.ContentHash = contentHash
+	rec.Previous = nil
+	rec.UpdatedAt = now
 	if err := s.Save(); err != nil {
 		return fmt.Errorf("saving install store: %w", err)
 	}
@@ -152,4 +277,18 @@ func cloneMOAT(m *MOATProvenance) *MOATProvenance {
 	}
 	clone := *m
 	return &clone
+}
+
+func requireStoreFile(storePath string) error {
+	if _, err := os.Stat(storePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("install store not found: %s", storePath)
+		}
+		return fmt.Errorf("stat install store: %w", err)
+	}
+	return nil
+}
+
+func installRecordNotFound(c Coord) error {
+	return fmt.Errorf("install record not found for coord registry=%q type=%q name=%q", c.Registry, c.Type, c.Name)
 }

--- a/cli/internal/installstore/record_test.go
+++ b/cli/internal/installstore/record_test.go
@@ -1,9 +1,11 @@
 package installstore
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -12,6 +14,15 @@ func writeContentFixture(t *testing.T, dir, name string) string {
 	path := filepath.Join(dir, name)
 	writeFile(t, path, []byte("# "+name+"\n"))
 	return path
+}
+
+func mustHashContent(t *testing.T, path string) string {
+	t.Helper()
+	hash, err := HashContent(path)
+	if err != nil {
+		t.Fatalf("HashContent(%s): %v", path, err)
+	}
+	return hash
 }
 
 func assertStoreFileMissing(t *testing.T, path string) {
@@ -163,6 +174,363 @@ func TestRecordInstallHashFailureLeavesStoreUntouched(t *testing.T) {
 		t.Fatal("RecordInstall missing libraryPath returned nil error")
 	}
 	assertStoreFileMissing(t, storePath)
+}
+
+func TestRecordInstallMetaSourceSHAAndPreservesExistingState(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "installs.json")
+	libraryPath := writeContentFixture(t, dir, "writer.md")
+	coord := testCoord("core", "skills", "writer")
+	input := PlacementInput{Provider: "codex", Mechanism: MechanismSymlink, Path: "/tmp/codex/writer"}
+
+	if err := RecordInstallMeta(storePath, coord, libraryPath, input, InstallMeta{SourceSHA: "sha-new"}, fixedTime(28)); err != nil {
+		t.Fatalf("RecordInstallMeta fresh: %v", err)
+	}
+	rec := mustLoadStore(t, storePath).Find(coord)
+	if rec == nil {
+		t.Fatal("record missing")
+	}
+	if rec.SourceSHA != "sha-new" {
+		t.Fatalf("SourceSHA = %q, want sha-new", rec.SourceSHA)
+	}
+
+	pinnedAt := fixedTime(29)
+	prev := &PreviousVersion{
+		SourceSHA:   "sha-prev",
+		ContentHash: rec.ContentHash,
+		CopyPath:    filepath.Join(dir, "rollback", "writer"),
+		ReplacedAt:  fixedTime(30),
+	}
+	s := mustLoadStore(t, storePath)
+	rec = s.Find(coord)
+	rec.SourceSHA = "sha-existing"
+	rec.Pinned = true
+	rec.PinnedAt = pinnedAt
+	rec.Previous = prev
+	mustSaveStore(t, s)
+
+	if err := RecordInstallMeta(storePath, coord, libraryPath, PlacementInput{
+		Provider:  "claude-code",
+		Mechanism: MechanismSymlink,
+		Path:      "/tmp/claude/writer",
+	}, InstallMeta{}, fixedTime(31)); err != nil {
+		t.Fatalf("RecordInstallMeta reinstall: %v", err)
+	}
+
+	got := mustLoadStore(t, storePath).Find(coord)
+	if got == nil {
+		t.Fatal("record missing after reinstall")
+	}
+	if got.SourceSHA != "sha-existing" {
+		t.Fatalf("SourceSHA = %q, want preserved sha-existing", got.SourceSHA)
+	}
+	if !got.Pinned || got.PinnedAt != pinnedAt {
+		t.Fatalf("pin state = pinned %v at %v, want true at %v", got.Pinned, got.PinnedAt, pinnedAt)
+	}
+	if !reflect.DeepEqual(got.Previous, prev) {
+		t.Fatalf("Previous = %#v, want preserved %#v", got.Previous, prev)
+	}
+}
+
+func TestRecordInstallMetaHashFailureLeavesStoreUntouched(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(t.TempDir(), "installs.json")
+	err := RecordInstallMeta(storePath, testCoord("core", "skills", "missing"), filepath.Join(t.TempDir(), "missing.md"), PlacementInput{
+		Provider:  "codex",
+		Mechanism: MechanismSymlink,
+		Path:      "/tmp/codex/missing",
+	}, InstallMeta{SourceSHA: "sha-new"}, fixedTime(32))
+	if err == nil {
+		t.Fatal("RecordInstallMeta missing libraryPath returned nil error")
+	}
+	assertStoreFileMissing(t, storePath)
+}
+
+func TestSetPinnedSetsClearsAndNoOps(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "installs.json")
+	libraryPath := writeContentFixture(t, dir, "writer.md")
+	coord := testCoord("core", "skills", "writer")
+	input := PlacementInput{Provider: "codex", Mechanism: MechanismSymlink, Path: "/tmp/codex/writer"}
+	if err := RecordInstall(storePath, coord, libraryPath, input, fixedTime(33)); err != nil {
+		t.Fatalf("RecordInstall: %v", err)
+	}
+
+	pinnedAt := fixedTime(34)
+	if err := SetPinned(storePath, coord, true, pinnedAt); err != nil {
+		t.Fatalf("SetPinned pin: %v", err)
+	}
+	rec := mustLoadStore(t, storePath).Find(coord)
+	if rec == nil {
+		t.Fatal("record missing")
+	}
+	if !rec.Pinned || rec.PinnedAt != pinnedAt || rec.UpdatedAt != pinnedAt {
+		t.Fatalf("pin fields = pinned %v at %v updated %v, want true at/updated %v", rec.Pinned, rec.PinnedAt, rec.UpdatedAt, pinnedAt)
+	}
+
+	pinnedBytes := mustReadFile(t, storePath)
+	if err := SetPinned(storePath, coord, true, fixedTime(35)); err != nil {
+		t.Fatalf("SetPinned already pinned: %v", err)
+	}
+	if after := mustReadFile(t, storePath); !reflect.DeepEqual(after, pinnedBytes) {
+		t.Fatalf("already-pinned no-op rewrote store\nbefore:\n%s\nafter:\n%s", pinnedBytes, after)
+	}
+
+	unpinnedAt := fixedTime(36)
+	if err := SetPinned(storePath, coord, false, unpinnedAt); err != nil {
+		t.Fatalf("SetPinned unpin: %v", err)
+	}
+	rec = mustLoadStore(t, storePath).Find(coord)
+	if rec == nil {
+		t.Fatal("record missing after unpin")
+	}
+	if rec.Pinned || !rec.PinnedAt.IsZero() || rec.UpdatedAt != unpinnedAt {
+		t.Fatalf("unpin fields = pinned %v at %v updated %v, want false zero updated %v", rec.Pinned, rec.PinnedAt, rec.UpdatedAt, unpinnedAt)
+	}
+}
+
+func TestSetPinnedMissingStoreAndRecordErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	coord := testCoord("core", "skills", "writer")
+	missingStore := filepath.Join(dir, "missing", "installs.json")
+	if err := SetPinned(missingStore, coord, true, fixedTime(37)); err == nil {
+		t.Fatal("SetPinned missing store returned nil error")
+	}
+	assertStoreFileMissing(t, missingStore)
+
+	storePath := filepath.Join(dir, "installs.json")
+	s := mustLoadStore(t, storePath)
+	s.Upsert(testRecord(testCoord("core", "skills", "other"), fixedTime(38)))
+	mustSaveStore(t, s)
+	if err := SetPinned(storePath, coord, true, fixedTime(39)); err == nil {
+		t.Fatal("SetPinned missing record returned nil error")
+	}
+}
+
+func TestRecordUpdateRotatesPreviousAndRehashes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "installs.json")
+	libraryPath := filepath.Join(dir, "writer.md")
+	writeFile(t, libraryPath, []byte("# writer\n"))
+	coord := testCoord("core", "skills", "writer")
+	input := PlacementInput{Provider: "codex", Mechanism: MechanismSymlink, Path: "/tmp/codex/writer"}
+	if err := RecordInstallMeta(storePath, coord, libraryPath, input, InstallMeta{SourceSHA: "sha-old"}, fixedTime(40)); err != nil {
+		t.Fatalf("RecordInstallMeta: %v", err)
+	}
+	oldHash := mustLoadStore(t, storePath).Find(coord).ContentHash
+
+	writeFile(t, libraryPath, []byte("# writer updated\n"))
+	firstUpdate := fixedTime(41)
+	if err := RecordUpdate(storePath, coord, libraryPath, "sha-new", filepath.Join(dir, "prev1"), firstUpdate); err != nil {
+		t.Fatalf("RecordUpdate first: %v", err)
+	}
+	rec := mustLoadStore(t, storePath).Find(coord)
+	if rec == nil {
+		t.Fatal("record missing")
+	}
+	firstUpdateHash := mustHashContent(t, libraryPath)
+	if rec.SourceSHA != "sha-new" || rec.ContentHash != firstUpdateHash || rec.UpdatedAt != firstUpdate {
+		t.Fatalf("updated record = %#v, want source sha-new hash %s updated %v", rec, firstUpdateHash, firstUpdate)
+	}
+	wantPrev := &PreviousVersion{
+		SourceSHA:   "sha-old",
+		ContentHash: oldHash,
+		CopyPath:    filepath.Join(dir, "prev1"),
+		ReplacedAt:  firstUpdate,
+	}
+	if !reflect.DeepEqual(rec.Previous, wantPrev) {
+		t.Fatalf("Previous after first update = %#v, want %#v", rec.Previous, wantPrev)
+	}
+
+	writeFile(t, libraryPath, []byte("# writer updated again\n"))
+	secondUpdate := fixedTime(42)
+	if err := RecordUpdate(storePath, coord, libraryPath, "sha-newer", filepath.Join(dir, "prev2"), secondUpdate); err != nil {
+		t.Fatalf("RecordUpdate second: %v", err)
+	}
+	rec = mustLoadStore(t, storePath).Find(coord)
+	if rec == nil {
+		t.Fatal("record missing after second update")
+	}
+	wantPrev = &PreviousVersion{
+		SourceSHA:   "sha-new",
+		ContentHash: firstUpdateHash,
+		CopyPath:    filepath.Join(dir, "prev2"),
+		ReplacedAt:  secondUpdate,
+	}
+	if !reflect.DeepEqual(rec.Previous, wantPrev) {
+		t.Fatalf("Previous after second update = %#v, want %#v", rec.Previous, wantPrev)
+	}
+	if rec.SourceSHA != "sha-newer" || rec.ContentHash != mustHashContent(t, libraryPath) {
+		t.Fatalf("record after second update = %#v", rec)
+	}
+}
+
+func TestRecordUpdateErrPinnedAndMissingErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	coord := testCoord("core", "skills", "writer")
+	missingStore := filepath.Join(dir, "missing", "installs.json")
+	if err := RecordUpdate(missingStore, coord, filepath.Join(dir, "writer.md"), "sha-new", "", fixedTime(43)); err == nil {
+		t.Fatal("RecordUpdate missing store returned nil error")
+	}
+
+	storePath := filepath.Join(dir, "installs.json")
+	s := mustLoadStore(t, storePath)
+	s.Upsert(testRecord(testCoord("core", "skills", "other"), fixedTime(44)))
+	mustSaveStore(t, s)
+	if err := RecordUpdate(storePath, coord, filepath.Join(dir, "writer.md"), "sha-new", "", fixedTime(45)); err == nil {
+		t.Fatal("RecordUpdate missing record returned nil error")
+	}
+
+	libraryPath := writeContentFixture(t, dir, "writer.md")
+	if err := RecordInstallMeta(storePath, coord, libraryPath, PlacementInput{
+		Provider:  "codex",
+		Mechanism: MechanismSymlink,
+		Path:      "/tmp/codex/writer",
+	}, InstallMeta{SourceSHA: "sha-old"}, fixedTime(46)); err != nil {
+		t.Fatalf("RecordInstallMeta: %v", err)
+	}
+	if err := SetPinned(storePath, coord, true, fixedTime(47)); err != nil {
+		t.Fatalf("SetPinned: %v", err)
+	}
+	beforePinned := mustReadFile(t, storePath)
+	err := RecordUpdate(storePath, coord, libraryPath, "sha-new", "", fixedTime(48))
+	if !errors.Is(err, ErrPinned) {
+		t.Fatalf("RecordUpdate pinned error = %v, want errors.Is ErrPinned", err)
+	}
+	if after := mustReadFile(t, storePath); !reflect.DeepEqual(after, beforePinned) {
+		t.Fatalf("pinned update rewrote store\nbefore:\n%s\nafter:\n%s", beforePinned, after)
+	}
+}
+
+func TestRecordUpdateHashFailureWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "installs.json")
+	libraryPath := writeContentFixture(t, dir, "writer.md")
+	coord := testCoord("core", "skills", "writer")
+	if err := RecordInstallMeta(storePath, coord, libraryPath, PlacementInput{
+		Provider:  "codex",
+		Mechanism: MechanismSymlink,
+		Path:      "/tmp/codex/writer",
+	}, InstallMeta{SourceSHA: "sha-old"}, fixedTime(49)); err != nil {
+		t.Fatalf("RecordInstallMeta: %v", err)
+	}
+	before := mustReadFile(t, storePath)
+
+	err := RecordUpdate(storePath, coord, filepath.Join(dir, "missing.md"), "sha-new", filepath.Join(dir, "prev"), fixedTime(50))
+	if err == nil {
+		t.Fatal("RecordUpdate missing libraryPath returned nil error")
+	}
+	if after := mustReadFile(t, storePath); !reflect.DeepEqual(after, before) {
+		t.Fatalf("hash failure rewrote store\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestRecordRollbackRestoresSourceSHAAndClearsPrevious(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "installs.json")
+	libraryPath := filepath.Join(dir, "writer.md")
+	oldContent := []byte("# writer\n")
+	writeFile(t, libraryPath, oldContent)
+	coord := testCoord("core", "skills", "writer")
+	if err := RecordInstallMeta(storePath, coord, libraryPath, PlacementInput{
+		Provider:  "codex",
+		Mechanism: MechanismSymlink,
+		Path:      "/tmp/codex/writer",
+	}, InstallMeta{SourceSHA: "sha-old"}, fixedTime(51)); err != nil {
+		t.Fatalf("RecordInstallMeta: %v", err)
+	}
+
+	writeFile(t, libraryPath, []byte("# writer updated\n"))
+	if err := RecordUpdate(storePath, coord, libraryPath, "sha-new", filepath.Join(dir, "prev"), fixedTime(52)); err != nil {
+		t.Fatalf("RecordUpdate: %v", err)
+	}
+
+	writeFile(t, libraryPath, oldContent)
+	rolledAt := fixedTime(53)
+	if err := RecordRollback(storePath, coord, libraryPath, rolledAt); err != nil {
+		t.Fatalf("RecordRollback: %v", err)
+	}
+	rec := mustLoadStore(t, storePath).Find(coord)
+	if rec == nil {
+		t.Fatal("record missing")
+	}
+	if rec.SourceSHA != "sha-old" {
+		t.Fatalf("SourceSHA = %q, want sha-old", rec.SourceSHA)
+	}
+	if rec.ContentHash != mustHashContent(t, libraryPath) {
+		t.Fatalf("ContentHash = %q, want current restored hash", rec.ContentHash)
+	}
+	if rec.Previous != nil {
+		t.Fatalf("Previous = %#v, want nil", rec.Previous)
+	}
+	if rec.UpdatedAt != rolledAt {
+		t.Fatalf("UpdatedAt = %v, want %v", rec.UpdatedAt, rolledAt)
+	}
+}
+
+func TestRecordRollbackErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	coord := testCoord("core", "skills", "writer")
+	missingStore := filepath.Join(dir, "missing", "installs.json")
+	if err := RecordRollback(missingStore, coord, filepath.Join(dir, "writer.md"), fixedTime(54)); err == nil {
+		t.Fatal("RecordRollback missing store returned nil error")
+	}
+
+	storePath := filepath.Join(dir, "installs.json")
+	libraryPath := writeContentFixture(t, dir, "writer.md")
+	s := mustLoadStore(t, storePath)
+	s.Upsert(testRecord(testCoord("core", "skills", "other"), fixedTime(55)))
+	mustSaveStore(t, s)
+	if err := RecordRollback(storePath, coord, libraryPath, fixedTime(56)); err == nil {
+		t.Fatal("RecordRollback missing record returned nil error")
+	}
+
+	if err := RecordInstallMeta(storePath, coord, libraryPath, PlacementInput{
+		Provider:  "codex",
+		Mechanism: MechanismSymlink,
+		Path:      "/tmp/codex/writer",
+	}, InstallMeta{SourceSHA: "sha-old"}, fixedTime(57)); err != nil {
+		t.Fatalf("RecordInstallMeta: %v", err)
+	}
+	err := RecordRollback(storePath, coord, libraryPath, fixedTime(58))
+	if err == nil || !strings.Contains(err.Error(), "no rollback data") {
+		t.Fatalf("RecordRollback no previous error = %v, want no rollback data", err)
+	}
+
+	s = mustLoadStore(t, storePath)
+	rec := s.Find(coord)
+	rec.Previous = &PreviousVersion{
+		SourceSHA:   "sha-prev",
+		ContentHash: rec.ContentHash,
+		CopyPath:    filepath.Join(dir, "prev"),
+		ReplacedAt:  fixedTime(59),
+	}
+	mustSaveStore(t, s)
+	before := mustReadFile(t, storePath)
+	err = RecordRollback(storePath, coord, filepath.Join(dir, "gone.md"), fixedTime(60))
+	if err == nil {
+		t.Fatal("RecordRollback missing libraryPath returned nil error")
+	}
+	if after := mustReadFile(t, storePath); !reflect.DeepEqual(after, before) {
+		t.Fatalf("rollback hash failure rewrote store\nbefore:\n%s\nafter:\n%s", before, after)
+	}
 }
 
 func TestRecordUninstallRemovesPlacementAndPrunesEmptyRecord(t *testing.T) {

--- a/cli/internal/installstore/store.go
+++ b/cli/internal/installstore/store.go
@@ -59,9 +59,29 @@ type Record struct {
 	ContentHash string          `json:"content_hash"`
 	LibraryPath string          `json:"library_path"`
 	MOAT        *MOATProvenance `json:"moat,omitempty"`
-	InstalledAt time.Time       `json:"installed_at"`
-	UpdatedAt   time.Time       `json:"updated_at"`
-	Placements  []Placement     `json:"placements,omitempty"`
+	// SourceSHA is the git-registry clone HEAD the library copy was taken from.
+	// Empty for MOAT, local, shared, and backfilled records ("no rollback data").
+	SourceSHA string `json:"source_sha,omitempty"`
+	// Pinned marks the item as held at its current content: update flows must
+	// refuse to overwrite it and drift reports annotate instead of hinting.
+	Pinned   bool      `json:"pinned,omitempty"`
+	PinnedAt time.Time `json:"pinned_at,omitzero"`
+	// Previous is the one-step rollback point, replaced on every update.
+	Previous    *PreviousVersion `json:"previous,omitempty"`
+	InstalledAt time.Time        `json:"installed_at"`
+	UpdatedAt   time.Time        `json:"updated_at"`
+	Placements  []Placement      `json:"placements,omitempty"`
+}
+
+// PreviousVersion captures the state replaced by the last update, enabling
+// one-step rollback. For git-registry items SourceSHA is the rollback
+// coordinate (content is re-extracted from the registry clone); for MOAT
+// items CopyPath points at a saved copy of the previous library content.
+type PreviousVersion struct {
+	SourceSHA   string    `json:"source_sha,omitempty"`
+	ContentHash string    `json:"content_hash"`
+	CopyPath    string    `json:"copy_path,omitempty"`
+	ReplacedAt  time.Time `json:"replaced_at"`
 }
 
 // Store is the on-disk install-record store.
@@ -314,8 +334,17 @@ func cloneRecord(rec Record) Record {
 		moat := *rec.MOAT
 		rec.MOAT = &moat
 	}
+	rec.Previous = clonePrevious(rec.Previous)
 	if rec.Placements != nil {
 		rec.Placements = append([]Placement(nil), rec.Placements...)
 	}
 	return rec
+}
+
+func clonePrevious(p *PreviousVersion) *PreviousVersion {
+	if p == nil {
+		return nil
+	}
+	clone := *p
+	return &clone
 }

--- a/cli/internal/installstore/store_test.go
+++ b/cli/internal/installstore/store_test.go
@@ -172,6 +172,80 @@ func TestStoreRoundTrip(t *testing.T) {
 	}
 }
 
+func TestStoreRoundTripPinRollbackFieldsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state", "installs.json")
+	coord := testCoord("core", "skills", "writer")
+	rec := testRecord(coord, fixedTime(1))
+	rec.SourceSHA = "abc123"
+	rec.Pinned = true
+	rec.PinnedAt = fixedTime(2)
+	rec.Previous = &PreviousVersion{
+		SourceSHA:   "def456",
+		ContentHash: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		CopyPath:    filepath.Join(t.TempDir(), "rollback", "writer"),
+		ReplacedAt:  fixedTime(3),
+	}
+
+	s := mustLoadStore(t, path)
+	s.Records = []Record{rec}
+	mustSaveStore(t, s)
+	firstBytes := mustReadFile(t, path)
+
+	loaded := mustLoadStore(t, path)
+	got := loaded.Find(coord)
+	if got == nil {
+		t.Fatal("record missing after load")
+	}
+	if !reflect.DeepEqual(got, &rec) {
+		t.Fatalf("new fields round-trip mismatch\n got: %#v\nwant: %#v", got, &rec)
+	}
+
+	mustSaveStore(t, loaded)
+	if secondBytes := mustReadFile(t, path); !bytes.Equal(secondBytes, firstBytes) {
+		t.Fatalf("second save changed bytes\nfirst:\n%s\nsecond:\n%s", firstBytes, secondBytes)
+	}
+}
+
+func TestLoadOldStoreCompatNewFieldsZero(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "installs.json")
+	writeFile(t, path, []byte(`{
+  "version": 1,
+  "records": [
+    {
+      "registry": "core",
+      "type": "skills",
+      "name": "writer",
+      "content_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "library_path": "skills/writer",
+      "installed_at": "2026-08-22T01:00:00Z",
+      "updated_at": "2026-08-22T02:00:00Z"
+    }
+  ]
+}`))
+
+	s := mustLoadStore(t, path)
+	rec := s.Find(testCoord("core", "skills", "writer"))
+	if rec == nil {
+		t.Fatal("record missing")
+	}
+	if rec.SourceSHA != "" {
+		t.Fatalf("SourceSHA = %q, want empty", rec.SourceSHA)
+	}
+	if rec.Pinned {
+		t.Fatal("Pinned = true, want false")
+	}
+	if !rec.PinnedAt.IsZero() {
+		t.Fatalf("PinnedAt = %v, want zero", rec.PinnedAt)
+	}
+	if rec.Previous != nil {
+		t.Fatalf("Previous = %#v, want nil", rec.Previous)
+	}
+}
+
 func TestStoreSaveDeterministic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Part of #542 item 7 (pin and rollback), chunk 7a — installstore package only.

- New `Record` fields: `SourceSHA` (git-registry clone HEAD the library copy came from), `Pinned`/`PinnedAt`, and `Previous *PreviousVersion` (the one-step rollback point: previous SourceSHA/ContentHash, optional saved-copy path for MOAT items).
- New APIs: `RecordInstallMeta` (existing `RecordInstall`/`RecordInstallMOAT` are now thin wrappers over it), `SetPinned`, `RecordUpdate` (rotates `Previous`, re-hashes, refuses pinned records with the `ErrPinned` sentinel), `RecordRollback` (restores `SourceSHA` from `Previous`, clears it).
- Pin and rollback state survive re-installs; store `Version` stays 1 (fields are additive); old stores load unchanged.
- Tests: save/load round-trip determinism, old-store compatibility, pin/unpin including no-op non-rewrite, update rotation, pinned enforcement, rollback, and error paths for every new function. Full suite: 40 packages ok, gofmt clean.

No CLI/TUI wiring in this chunk — command surfaces (pin/unpin/rollback) land in follow-up chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)