### PR TITLE
feat(registry): fix --ref for tags and commit SHAs; pinned fetch-only sync (#542 item 7c)

### DIFF
--- a/cli/cmd/syllago/registry_cmd.go
+++ b/cli/cmd/syllago/registry_cmd.go
@@ -581,6 +581,13 @@ func syncGitOrMOATRegistry(ctx context.Context, cfg *config.Config, r *config.Re
 			return 0, output.NewStructuredErrorDetail(output.ErrRegistrySyncFailed, fmt.Sprintf("sync failed for %q", r.Name), "Check network connectivity and git credentials", err.Error())
 		}
 		outcome.NewHead = head
+
+		if pinned, errPinned := registry.IsPinned(r.Name); errPinned == nil && pinned {
+			outcome.Pinned = true
+			if remoteHead, errRemote := registry.RemoteDefaultHead(r.Name); errRemote == nil {
+				outcome.RemoteHead = remoteHead
+			}
+		}
 	} else {
 		var err error
 		outcome, err = registry.Sync(r.Name)
@@ -592,10 +599,28 @@ func syncGitOrMOATRegistry(ctx context.Context, cfg *config.Config, r *config.Re
 		return 0, output.NewStructuredErrorDetail(output.ErrRegistrySyncFailed, fmt.Sprintf("sync failed for %q", r.Name), "Could not save registry sync bookkeeping", err.Error())
 	}
 	reprobeRegistryVisibility(cfg, r.Name)
-	fmt.Fprintf(output.Writer, "Synced: %s\n", r.Name)
-	if !justCloned && outcome.OldHead != "" && outcome.OldHead != outcome.NewHead {
-		if d := registryops.GitSyncDiff(r.Name, outcome.OldHead, outcome.NewHead); d != nil {
-			printRegistryDiff(output.Writer, d)
+	if outcome.Pinned {
+		shortHead := outcome.NewHead
+		if len(shortHead) > 12 {
+			shortHead = shortHead[:12]
+		}
+		fmt.Fprintf(output.Writer, "Synced (pinned): %s — checkout held at %s\n", r.Name, shortHead)
+		if outcome.RemoteHead != outcome.NewHead {
+			shortRemote := outcome.RemoteHead
+			if len(shortRemote) > 12 {
+				shortRemote = shortRemote[:12]
+			}
+			fmt.Fprintf(output.Writer, "Upstream has moved to %s — changes below are NOT applied while pinned:\n", shortRemote)
+			if d := registryops.GitSyncDiff(r.Name, outcome.NewHead, outcome.RemoteHead); d != nil {
+				printRegistryDiff(output.Writer, d)
+			}
+		}
+	} else {
+		fmt.Fprintf(output.Writer, "Synced: %s\n", r.Name)
+		if !justCloned && outcome.OldHead != "" && outcome.OldHead != outcome.NewHead {
+			if d := registryops.GitSyncDiff(r.Name, outcome.OldHead, outcome.NewHead); d != nil {
+				printRegistryDiff(output.Writer, d)
+			}
 		}
 	}
 	drifts := registryops.InstalledGitDrift(r.Name)
@@ -929,7 +954,7 @@ func tryUpgradeToMOAT(r *config.Registry, cfg *config.Config, out io.Writer) (bo
 
 func init() {
 	registryAddCmd.Flags().String("name", "", "Override the registry name (default: derived from URL)")
-	registryAddCmd.Flags().String("ref", "", "Branch, tag, or commit to checkout (default: repo default branch)")
+	registryAddCmd.Flags().String("ref", "", "Branch, tag, or commit to checkout (default: repo default branch). Tag and commit refs pin the registry: sync fetches but never moves the checkout.")
 	registryAddCmd.Flags().Bool("sync", false, "Clone and sync immediately after registering (default: register only, sync later with 'registry sync')")
 	registryAddCmd.Flags().Bool("moat", false, "Add as a MOAT-signed registry (required when URL is not in the bundled allowlist and no --signing-identity is passed)")
 	registryAddCmd.Flags().String("signing-identity", "", "Workflow subject SAN (e.g. https://github.com/OWNER/REPO/.github/workflows/moat.yml@refs/heads/main) — implies --moat")

--- a/cli/cmd/syllago/registry_pinned_cmd_test.go
+++ b/cli/cmd/syllago/registry_pinned_cmd_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
+)
+
+func TestRegistryPinnedCommandFlow(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	// 1. Setup bare repository with custom tagging
+	bare, work, branch := createBareGitRegistryForSyncTest(t)
+
+	// Create tag "v2.0.0" at initial commit
+	gitRunForSyncTest(t, work, "tag", "v2.0.0")
+	// Push tag to bare
+	gitRunForSyncTest(t, work, "push", bare, "v2.0.0")
+
+	// Get the SHA of v2.0.0
+	tagSHA := gitOutputForSyncTest(t, work, "rev-parse", "v2.0.0")
+	shortTagSHA := tagSHA
+	if len(shortTagSHA) > 12 {
+		shortTagSHA = shortTagSHA[:12]
+	}
+
+	cfg := &config.Config{
+		Providers: []string{"claude-code"},
+		Registries: []config.Registry{
+			{
+				Name: "git-pinned",
+				URL:  bare,
+				Ref:  "v2.0.0",
+			},
+		},
+	}
+	withRegistryProjectAndCache(t, nil, cfg)
+	stdout, _ := output.SetForTest(t)
+	overrideProbe(t, func(url string) (string, error) {
+		return registry.VisibilityPublic, nil
+	})
+
+	// 2. Run sync to perform the initial checkout at v2.0.0
+	registrySyncCmd.SilenceUsage = true
+	registrySyncCmd.SilenceErrors = true
+	if err := registrySyncCmd.RunE(registrySyncCmd, []string{"git-pinned"}); err != nil {
+		t.Fatalf("initial registry sync failed: %v", err)
+	}
+
+	gotOut := stdout.String()
+	// Pinned initial sync should print Sync (pinned) output
+	expectedSyncedLine := "Synced (pinned): git-pinned — checkout held at " + shortTagSHA + "\n"
+	if !strings.Contains(gotOut, expectedSyncedLine) {
+		t.Errorf("stdout = %q; want to contain %q", gotOut, expectedSyncedLine)
+	}
+
+	// 3. Status on pinned registry before upstream moves (should be up to date)
+	stdout.Reset()
+	registryStatusCmd.SilenceUsage = true
+	registryStatusCmd.SilenceErrors = true
+	if err := registryStatusCmd.RunE(registryStatusCmd, []string{"git-pinned"}); err != nil {
+		t.Fatalf("registry status failed: %v", err)
+	}
+	gotStatusOut := stdout.String()
+	expectedStatusLine := "git-pinned (git, pinned): up to date\n"
+	if gotStatusOut != expectedStatusLine {
+		t.Errorf("status stdout = %q; want %q", gotStatusOut, expectedStatusLine)
+	}
+
+	// 4. Update upstream bare repository to force a diff
+	updateBareGitRegistryForSyncDiffTest(t, work, bare, branch)
+	upstreamSHA := gitOutputForSyncTest(t, work, "rev-parse", "HEAD")
+	shortUpstreamSHA := upstreamSHA
+	if len(shortUpstreamSHA) > 12 {
+		shortUpstreamSHA = shortUpstreamSHA[:12]
+	}
+
+	// 5. Run status again to see changes without applying them
+	stdout.Reset()
+	if err := registryStatusCmd.RunE(registryStatusCmd, []string{"git-pinned"}); err != nil {
+		t.Fatalf("registry status after upstream update failed: %v", err)
+	}
+	gotStatusDiffOut := stdout.String()
+	expectedStatusDiffLine := "git-pinned (git, pinned): 3 upstream change(s)\n"
+	if !strings.Contains(gotStatusDiffOut, expectedStatusDiffLine) {
+		t.Errorf("status diff stdout = %q; want to contain %q", gotStatusDiffOut, expectedStatusDiffLine)
+	}
+
+	// 6. Run sync to fetch but hold the checkout
+	stdout.Reset()
+	if err := registrySyncCmd.RunE(registrySyncCmd, []string{"git-pinned"}); err != nil {
+		t.Fatalf("registry sync after upstream update failed: %v", err)
+	}
+	gotSyncDiffOut := stdout.String()
+	expectedHeldLine := "Synced (pinned): git-pinned — checkout held at " + shortTagSHA + "\n"
+	expectedMovedLine := "Upstream has moved to " + shortUpstreamSHA + " — changes below are NOT applied while pinned:\n"
+	if !strings.Contains(gotSyncDiffOut, expectedHeldLine) {
+		t.Errorf("sync diff stdout = %q; want to contain %q", gotSyncDiffOut, expectedHeldLine)
+	}
+	if !strings.Contains(gotSyncDiffOut, expectedMovedLine) {
+		t.Errorf("sync diff stdout = %q; want to contain %q", gotSyncDiffOut, expectedMovedLine)
+	}
+
+	// 7. Test JSON output of status command to verify pinned attribute
+	stdout.Reset()
+	output.JSON = true
+	t.Cleanup(func() { output.JSON = false })
+
+	if err := registryStatusCmd.RunE(registryStatusCmd, []string{"git-pinned"}); err != nil {
+		t.Fatalf("registry status JSON failed: %v", err)
+	}
+
+	var rows []struct {
+		Name     string `json:"name"`
+		Kind     string `json:"kind"`
+		State    string `json:"state"`
+		Pinned   bool   `json:"pinned"`
+		Added    int    `json:"added"`
+		Modified int    `json:"modified"`
+		Removed  int    `json:"removed"`
+	}
+
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("unmarshal registry status JSON failed: %v\nOutput: %s", err, stdout.String())
+	}
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 status row, got %d", len(rows))
+	}
+
+	if rows[0].Name != "git-pinned" {
+		t.Errorf("row name = %q, want 'git-pinned'", rows[0].Name)
+	}
+	if !rows[0].Pinned {
+		t.Error("expected row to have Pinned = true")
+	}
+}

--- a/cli/cmd/syllago/registry_status.go
+++ b/cli/cmd/syllago/registry_status.go
@@ -26,6 +26,7 @@ type registryStatusJSON struct {
 	Modified int    `json:"modified"`
 	Removed  int    `json:"removed"`
 	Error    string `json:"error,omitempty"`
+	Pinned   bool   `json:"pinned"`
 }
 
 var registryStatusCmd = &cobra.Command{
@@ -155,9 +156,16 @@ func registryStatusGit(reg *config.Registry) (registryStatusJSON, error) {
 	if err != nil {
 		return row, output.NewStructuredErrorDetail(output.ErrRegistrySyncFailed, fmt.Sprintf("status failed for %q", reg.Name), "Check network connectivity and git credentials", err.Error())
 	}
+	row.Pinned = outcome.Pinned
+
+	kind := "git"
+	if outcome.Pinned {
+		kind = "git, pinned"
+	}
+
 	if outcome.Head == outcome.RemoteHead {
 		row.State = "up_to_date"
-		registryStatusPrintLine("%s (git): up to date\n", reg.Name)
+		registryStatusPrintLine("%s (%s): up to date\n", reg.Name, kind)
 		return row, nil
 	}
 
@@ -165,25 +173,25 @@ func registryStatusGit(reg *config.Registry) (registryStatusJSON, error) {
 	if d == nil {
 		row.State = "error"
 		row.Error = "could not compare"
-		registryStatusPrintLine("%s (git): could not compare — run 'syllago registry sync %s'\n", reg.Name, reg.Name)
+		registryStatusPrintLine("%s (%s): could not compare — run 'syllago registry sync %s'\n", reg.Name, kind, reg.Name)
 		return row, nil
 	}
 	cloneDir, err := registry.CloneDir(reg.Name)
 	if err != nil {
 		row.State = "error"
 		row.Error = "could not compare"
-		registryStatusPrintLine("%s (git): could not compare — run 'syllago registry sync %s'\n", reg.Name, reg.Name)
+		registryStatusPrintLine("%s (%s): could not compare — run 'syllago registry sync %s'\n", reg.Name, kind, reg.Name)
 		return row, nil
 	}
 	refineRegistryStatusGitKinds(cloneDir, outcome.Head, outcome.RemoteHead, d)
 	if registryStatusHasChanges(d) {
 		registryStatusSetChangeCounts(&row, d)
-		registryStatusPrintDiff(reg.Name, "git", d)
+		registryStatusPrintDiff(reg.Name, kind, d)
 		return row, nil
 	}
 
 	row.State = "up_to_date"
-	registryStatusPrintLine("%s (git): up to date\n", reg.Name)
+	registryStatusPrintLine("%s (%s): up to date\n", reg.Name, kind)
 	return row, nil
 }
 

--- a/cli/commands.json
+++ b/cli/commands.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
-  "generatedAt": "2026-08-23T01:52:59Z",
-  "syllagoVersion": "0.14.0",
+  "generatedAt": "2026-08-24T17:32:29Z",
+  "syllagoVersion": "dev",
   "commands": [
     {
       "name": "add",
@@ -2686,7 +2686,7 @@
           "type": "string",
           "default": null,
           "required": false,
-          "description": "Branch, tag, or commit to checkout (default: repo default branch)"
+          "description": "Branch, tag, or commit to checkout (default: repo default branch). Tag and commit refs pin the registry: sync fetches but never moves the checkout."
         },
         {
           "name": "--signing-identity",

--- a/cli/internal/registry/registry.go
+++ b/cli/internal/registry/registry.go
@@ -133,7 +133,7 @@ func Clone(url, name, ref string) error {
 		return fmt.Errorf("creating registry cache: %w", err)
 	}
 
-	args := cloneArgs(url, dir, ref)
+	args := cloneArgs(url, dir)
 	cmd := exec.Command("git", args...)
 	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
 	out, err := cmd.CombinedOutput()
@@ -144,29 +144,61 @@ func Clone(url, name, ref string) error {
 		_ = os.RemoveAll(dir)
 		return fmt.Errorf("git clone failed: %s", strings.TrimSpace(string(out)))
 	}
+
+	if ref != "" {
+		cmdVerify := exec.Command("git", "-C", dir, "rev-parse", "--verify", "--quiet", "refs/remotes/origin/"+ref)
+		cmdVerify.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+		errVerify := cmdVerify.Run()
+		isBranch := errVerify == nil
+
+		cArgs := checkoutArgs(dir, ref, isBranch)
+		cmdCheckout := exec.Command("git", cArgs...)
+		cmdCheckout.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+		outCheckout, errCheckout := cmdCheckout.CombinedOutput()
+		if errCheckout != nil {
+			_ = os.RemoveAll(dir)
+			return fmt.Errorf("git checkout %q failed: %s", ref, strings.TrimSpace(string(outCheckout)))
+		}
+	}
+
 	return nil
 }
 
 // cloneArgs builds the git argument list for a secure clone.
 // It disables hooks via core.hooksPath and prevents submodule recursion.
 // GIT_CONFIG_NOSYSTEM=1 must also be set on the command's Env by the caller.
-func cloneArgs(url, dir, ref string) []string {
-	args := []string{
+func cloneArgs(url, dir string) []string {
+	return []string{
 		"-c", "core.hooksPath=/dev/null",
 		"clone",
 		"--no-recurse-submodules",
 		url, dir,
 	}
-	if ref != "" {
-		args = append(args, "--branch", ref)
+}
+
+func checkoutArgs(dir, ref string, isBranch bool) []string {
+	if isBranch {
+		return []string{
+			"-C", dir,
+			"-c", "core.hooksPath=/dev/null",
+			"checkout", "--quiet",
+			ref,
+		}
 	}
-	return args
+	return []string{
+		"-C", dir,
+		"-c", "core.hooksPath=/dev/null",
+		"checkout", "--quiet", "--detach",
+		ref,
+	}
 }
 
 // GitSyncOutcome reports the commit movement of one git-registry sync.
 type GitSyncOutcome struct {
-	OldHead string // HEAD sha before the pull; "" if unreadable (e.g. empty repo)
-	NewHead string // HEAD sha after the pull
+	OldHead    string // HEAD sha before the pull; "" if unreadable (e.g. empty repo)
+	NewHead    string // HEAD sha after the pull
+	Pinned     bool   // True if the checkout is pinned (detached HEAD) and fetch-only
+	RemoteHead string // FETCH_HEAD sha after the fetch (pinned path only)
 }
 
 // GitStatusOutcome reports the local and upstream heads of a registry clone
@@ -174,6 +206,7 @@ type GitSyncOutcome struct {
 type GitStatusOutcome struct {
 	Head       string
 	RemoteHead string
+	Pinned     bool // True if the checkout is pinned (detached HEAD)
 }
 
 // Head returns the current HEAD sha for a git registry clone.
@@ -192,6 +225,36 @@ func Head(name string) (string, error) {
 	return head, nil
 }
 
+func isDetachedHead(dir string) bool {
+	cmdSym := exec.Command("git", "-C", dir, "symbolic-ref", "--quiet", "HEAD")
+	cmdSym.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	return cmdSym.Run() != nil
+}
+
+// IsPinned checks if the registry clone at name has a detached HEAD.
+func IsPinned(name string) (bool, error) {
+	if err := checkGit(); err != nil {
+		return false, err
+	}
+	dir, err := CloneDir(name)
+	if err != nil {
+		return false, err
+	}
+	return isDetachedHead(dir), nil
+}
+
+// RemoteDefaultHead returns the commit SHA of refs/remotes/origin/HEAD.
+func RemoteDefaultHead(name string) (string, error) {
+	if err := checkGit(); err != nil {
+		return "", err
+	}
+	dir, err := CloneDir(name)
+	if err != nil {
+		return "", err
+	}
+	return gitRevParse(dir, "refs/remotes/origin/HEAD")
+}
+
 // Status fetches the registry clone's upstream refs without moving the
 // checkout, then returns local HEAD vs FETCH_HEAD.
 func Status(name string) (GitStatusOutcome, error) {
@@ -203,6 +266,9 @@ func Status(name string) (GitStatusOutcome, error) {
 	if err != nil {
 		return outcome, err
 	}
+
+	isDetached := isDetachedHead(dir)
+
 	cmd := exec.Command("git",
 		"-C", dir,
 		"-c", "core.hooksPath=/dev/null",
@@ -211,18 +277,23 @@ func Status(name string) (GitStatusOutcome, error) {
 	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return outcome, fmt.Errorf("git fetch failed for %q: %s\n(Hint: delete the clone at ~/.syllago/registries/%s and re-run `syllago registry sync %s`)", name, strings.TrimSpace(string(out)), name, name)
+		return outcome, fmt.Errorf("git fetch failed for %q: %s\n(Hint: delete the clone at ~/.syllago/registries/%s and re-run `syllago registry sync %s` (deleting the clone also discards local history used for item rollback))", name, strings.TrimSpace(string(out)), name, name)
 	}
 	head, err := gitHead(dir)
 	if err != nil {
 		return outcome, fmt.Errorf("reading HEAD after git fetch for %q: %w", name, err)
 	}
-	remoteHead, err := gitRevParse(dir, "FETCH_HEAD")
+	remoteRef := "FETCH_HEAD"
+	if isDetached {
+		remoteRef = "refs/remotes/origin/HEAD"
+	}
+	remoteHead, err := gitRevParse(dir, remoteRef)
 	if err != nil {
-		return outcome, fmt.Errorf("reading FETCH_HEAD after git fetch for %q: %w", name, err)
+		return outcome, fmt.Errorf("reading %s after git fetch for %q: %w", remoteRef, name, err)
 	}
 	outcome.Head = head
 	outcome.RemoteHead = remoteHead
+	outcome.Pinned = isDetached
 	return outcome, nil
 }
 
@@ -240,6 +311,34 @@ func Sync(name string) (GitSyncOutcome, error) {
 	if oldHead, err := gitHead(dir); err == nil {
 		outcome.OldHead = oldHead
 	}
+
+	isDetached := isDetachedHead(dir)
+
+	if isDetached {
+		cmdFetch := exec.Command("git",
+			"-C", dir,
+			"-c", "core.hooksPath=/dev/null",
+			"fetch", "--quiet", "--no-recurse-submodules",
+		)
+		cmdFetch.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+		outFetch, errFetch := cmdFetch.CombinedOutput()
+		if errFetch != nil {
+			return outcome, fmt.Errorf("git fetch failed for %q: %s\n(Hint: delete the clone at ~/.syllago/registries/%s and re-run `syllago registry sync %s` (deleting the clone also discards local history used for item rollback))", name, strings.TrimSpace(string(outFetch)), name, name)
+		}
+		currHead, errHead := gitHead(dir)
+		if errHead != nil {
+			return outcome, fmt.Errorf("reading HEAD after git fetch for %q: %w", name, errHead)
+		}
+		remoteHead, errRemote := gitRevParse(dir, "refs/remotes/origin/HEAD")
+		if errRemote != nil {
+			return outcome, fmt.Errorf("reading refs/remotes/origin/HEAD after git fetch for %q: %w", name, errRemote)
+		}
+		outcome.NewHead = currHead
+		outcome.Pinned = true
+		outcome.RemoteHead = remoteHead
+		return outcome, nil
+	}
+
 	cmd := exec.Command("git",
 		"-C", dir,
 		"-c", "core.hooksPath=/dev/null",
@@ -248,13 +347,14 @@ func Sync(name string) (GitSyncOutcome, error) {
 	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return outcome, fmt.Errorf("git pull failed for %q: %s\n(Hint: delete the clone at ~/.syllago/registries/%s and re-run `syllago registry sync %s`)", name, strings.TrimSpace(string(out)), name, name)
+		return outcome, fmt.Errorf("git pull failed for %q: %s\n(Hint: delete the clone at ~/.syllago/registries/%s and re-run `syllago registry sync %s` (deleting the clone also discards local history used for item rollback))", name, strings.TrimSpace(string(out)), name, name)
 	}
 	newHead, err := gitHead(dir)
 	if err != nil {
 		return outcome, fmt.Errorf("reading HEAD after git pull for %q: %w", name, err)
 	}
 	outcome.NewHead = newHead
+	outcome.Pinned = false
 	return outcome, nil
 }
 

--- a/cli/internal/registry/registry_pinned_test.go
+++ b/cli/internal/registry/registry_pinned_test.go
@@ -1,0 +1,336 @@
+package registry
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func createTestUpstreamRepo(t *testing.T) (string, string) {
+	t.Helper()
+	workDir := filepath.Join(t.TempDir(), "upstream_work")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Helper to run git
+	gitRun := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = workDir
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	gitRun("init", "-b", "main")
+	gitRun("config", "user.email", "test@example.com")
+	gitRun("config", "user.name", "Test User")
+
+	// Write initial file and commit
+	if err := os.WriteFile(filepath.Join(workDir, "registry.yaml"), []byte("name: test-reg\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	gitRun("add", "registry.yaml")
+	gitRun("commit", "-m", "initial commit")
+
+	// Get initial SHA
+	initialSHA := gitRun("rev-parse", "HEAD")
+
+	// Create tag "v1.0.0" at initial commit
+	gitRun("tag", "v1.0.0")
+
+	// Create a branch "feature-branch"
+	gitRun("checkout", "-b", "feature-branch")
+	if err := os.WriteFile(filepath.Join(workDir, "feature.txt"), []byte("feature"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	gitRun("add", "feature.txt")
+	gitRun("commit", "-m", "feature commit")
+
+	// Go back to main
+	gitRun("checkout", "main")
+
+	// Clone bare
+	bareDir := filepath.Join(t.TempDir(), "bare.git")
+	cmdClone := exec.Command("git", "clone", "--bare", workDir, bareDir)
+	cmdClone.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	if out, err := cmdClone.CombinedOutput(); err != nil {
+		t.Fatalf("failed to create bare repo: %v\n%s", err, out)
+	}
+
+	return bareDir, initialSHA
+}
+
+func TestCloneAndSync_BranchRef(t *testing.T) {
+	requireGit(t)
+	setupCacheOverride(t)
+	bare, _ := createTestUpstreamRepo(t)
+
+	// Clone with branch ref
+	err := Clone(bare, "my-reg", "feature-branch")
+	if err != nil {
+		t.Fatalf("Clone with branch ref failed: %v", err)
+	}
+
+	dir, _ := CloneDir("my-reg")
+
+	// Check if we are on feature-branch
+	cmdSym := exec.Command("git", "-C", dir, "symbolic-ref", "--quiet", "HEAD")
+	cmdSym.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	out, err := cmdSym.CombinedOutput()
+	if err != nil {
+		t.Fatalf("symbolic-ref HEAD failed: %v\n%s", err, out)
+	}
+	symRef := strings.TrimSpace(string(out))
+	if !strings.HasSuffix(symRef, "refs/heads/feature-branch") {
+		t.Errorf("expected symbolic-ref to end with refs/heads/feature-branch, got %s", symRef)
+	}
+
+	// Status on branch clone
+	statusOutcome, err := Status("my-reg")
+	if err != nil {
+		t.Fatalf("Status failed: %v", err)
+	}
+	if statusOutcome.Pinned {
+		t.Error("expected Status on branch clone to not be Pinned")
+	}
+
+	// Sync on branch clone
+	outcome, err := Sync("my-reg")
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+	if outcome.Pinned {
+		t.Error("expected Sync on branch clone to not be Pinned")
+	}
+}
+
+func TestCloneAndSync_TagRef(t *testing.T) {
+	requireGit(t)
+	setupCacheOverride(t)
+	bare, initialSHA := createTestUpstreamRepo(t)
+
+	// Clone with tag ref
+	err := Clone(bare, "my-reg", "v1.0.0")
+	if err != nil {
+		t.Fatalf("Clone with tag ref failed: %v", err)
+	}
+
+	dir, _ := CloneDir("my-reg")
+
+	// symbolic-ref HEAD should fail (detached HEAD)
+	cmdSym := exec.Command("git", "-C", dir, "symbolic-ref", "--quiet", "HEAD")
+	cmdSym.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	if err := cmdSym.Run(); err == nil {
+		t.Error("expected symbolic-ref to fail on detached tag HEAD, but it succeeded")
+	}
+
+	// HEAD should be at initialSHA
+	currHead, err := gitHead(dir)
+	if err != nil {
+		t.Fatalf("gitHead failed: %v", err)
+	}
+	if currHead != initialSHA {
+		t.Errorf("expected HEAD to be %s, got %s", initialSHA, currHead)
+	}
+
+	// Status on tag clone
+	statusOutcome, err := Status("my-reg")
+	if err != nil {
+		t.Fatalf("Status failed: %v", err)
+	}
+	if !statusOutcome.Pinned {
+		t.Error("expected Status on tag clone to be Pinned")
+	}
+
+	// Sync on detached clone
+	outcome, err := Sync("my-reg")
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+	if !outcome.Pinned {
+		t.Error("expected Sync on tag clone to be Pinned")
+	}
+	if outcome.NewHead != initialSHA {
+		t.Errorf("expected Sync on pinned clone to keep HEAD at %s, got %s", initialSHA, outcome.NewHead)
+	}
+}
+
+func TestCloneAndSync_CommitRef(t *testing.T) {
+	requireGit(t)
+	setupCacheOverride(t)
+	bare, initialSHA := createTestUpstreamRepo(t)
+
+	// Clone with commit SHA
+	err := Clone(bare, "my-reg", initialSHA)
+	if err != nil {
+		t.Fatalf("Clone with commit SHA failed: %v", err)
+	}
+
+	dir, _ := CloneDir("my-reg")
+
+	// symbolic-ref HEAD should fail
+	cmdSym := exec.Command("git", "-C", dir, "symbolic-ref", "--quiet", "HEAD")
+	cmdSym.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	if err := cmdSym.Run(); err == nil {
+		t.Error("expected symbolic-ref to fail on detached commit HEAD")
+	}
+
+	// HEAD should be at initialSHA
+	currHead, err := gitHead(dir)
+	if err != nil {
+		t.Fatalf("gitHead failed: %v", err)
+	}
+	if currHead != initialSHA {
+		t.Errorf("expected HEAD to be %s, got %s", initialSHA, currHead)
+	}
+}
+
+func TestClone_BogusRef(t *testing.T) {
+	requireGit(t)
+	setupCacheOverride(t)
+	bare, _ := createTestUpstreamRepo(t)
+
+	// Clone with bogus ref
+	err := Clone(bare, "my-reg", "bogus-ref")
+	if err == nil {
+		t.Fatal("expected Clone with bogus ref to fail, but it succeeded")
+	}
+
+	if !strings.Contains(err.Error(), `git checkout "bogus-ref" failed`) {
+		t.Errorf("expected error message to mention the bad ref, got: %v", err)
+	}
+
+	// Clone dir should be removed
+	if IsCloned("my-reg") {
+		t.Error("expected clone directory to be removed on checkout failure")
+	}
+}
+
+func TestSync_DetachedRemoteHead(t *testing.T) {
+	requireGit(t)
+	setupCacheOverride(t)
+	bare, initialSHA := createTestUpstreamRepo(t)
+
+	// Clone with tag ref
+	err := Clone(bare, "my-reg", "v1.0.0")
+	if err != nil {
+		t.Fatalf("Clone failed: %v", err)
+	}
+
+	// Add a commit to bare repository
+	workDir := filepath.Join(t.TempDir(), "upstream_work_more")
+	cmdClone := exec.Command("git", "clone", bare, workDir)
+	cmdClone.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	if out, err := cmdClone.CombinedOutput(); err != nil {
+		t.Fatalf("git clone bare failed: %v\n%s", err, out)
+	}
+
+	cmdConfig1 := exec.Command("git", "config", "user.email", "test@example.com")
+	cmdConfig1.Dir = workDir
+	cmdConfig1.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	cmdConfig1.Run()
+
+	cmdConfig2 := exec.Command("git", "config", "user.name", "Test User")
+	cmdConfig2.Dir = workDir
+	cmdConfig2.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	cmdConfig2.Run()
+
+	if err := os.WriteFile(filepath.Join(workDir, "newfile.txt"), []byte("new"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmdAdd := exec.Command("git", "add", "newfile.txt")
+	cmdAdd.Dir = workDir
+	cmdAdd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	cmdAdd.Run()
+
+	cmdCommit := exec.Command("git", "commit", "-m", "new commit")
+	cmdCommit.Dir = workDir
+	cmdCommit.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	cmdCommit.Run()
+
+	cmdPush := exec.Command("git", "push", "origin", "main")
+	cmdPush.Dir = workDir
+	cmdPush.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	if out, err := cmdPush.CombinedOutput(); err != nil {
+		t.Fatalf("git push failed: %v\n%s", err, out)
+	}
+
+	newUpstreamSHA := gitOutput(t, workDir, "rev-parse", "HEAD")
+
+	// Status on detached clone
+	statusOutcome, err := Status("my-reg")
+	if err != nil {
+		t.Fatalf("Status failed: %v", err)
+	}
+	if !statusOutcome.Pinned {
+		t.Error("expected Status to be pinned")
+	}
+	if statusOutcome.Head != initialSHA {
+		t.Errorf("expected local status HEAD to be %s, got %s", initialSHA, statusOutcome.Head)
+	}
+	if statusOutcome.RemoteHead != newUpstreamSHA {
+		t.Errorf("expected remote status HEAD to be %s, got %s", newUpstreamSHA, statusOutcome.RemoteHead)
+	}
+
+	// Sync on detached clone
+	outcome, err := Sync("my-reg")
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	if !outcome.Pinned {
+		t.Error("expected Sync outcome to have Pinned = true")
+	}
+	if outcome.NewHead != initialSHA {
+		t.Errorf("expected HEAD to remain unmoved at %s, got %s", initialSHA, outcome.NewHead)
+	}
+	if outcome.RemoteHead != newUpstreamSHA {
+		t.Errorf("expected RemoteHead in Sync outcome to be %s, got %s", newUpstreamSHA, outcome.RemoteHead)
+	}
+}
+
+func TestFailureHint_RollbackWarning(t *testing.T) {
+	requireGit(t)
+	setupCacheOverride(t)
+	bare, _ := createTestUpstreamRepo(t)
+
+	err := Clone(bare, "my-reg", "")
+	if err != nil {
+		t.Fatalf("Clone failed: %v", err)
+	}
+
+	dir, _ := CloneDir("my-reg")
+
+	cmdRemote := exec.Command("git", "-C", dir, "remote", "set-url", "origin", "file:///nonexistent/repo.git")
+	cmdRemote.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	if out, err := cmdRemote.CombinedOutput(); err != nil {
+		t.Fatalf("set-url failed: %v\n%s", err, out)
+	}
+
+	// Status should fail and error message must contain rollback-data warning
+	_, errStatus := Status("my-reg")
+	if errStatus == nil {
+		t.Fatal("expected Status to fail due to invalid remote URL")
+	}
+	expectedWarning := "(deleting the clone also discards local history used for item rollback)"
+	if !strings.Contains(errStatus.Error(), expectedWarning) {
+		t.Errorf("expected Status error to contain warning %q, got: %v", expectedWarning, errStatus)
+	}
+
+	// Sync should fail and error message must contain rollback-data warning
+	_, errSync := Sync("my-reg")
+	if errSync == nil {
+		t.Fatal("expected Sync to fail due to invalid remote URL")
+	}
+	if !strings.Contains(errSync.Error(), expectedWarning) {
+		t.Errorf("expected Sync error to contain warning %q, got: %v", expectedWarning, errSync)
+	}
+}

--- a/cli/internal/registry/registry_test.go
+++ b/cli/internal/registry/registry_test.go
@@ -82,15 +82,13 @@ func TestCloneArgs_SecurityProtections(t *testing.T) {
 		name string
 		url  string
 		dir  string
-		ref  string
 	}{
-		{"no ref", "https://github.com/acme/tools.git", "/tmp/clone", ""},
-		{"with ref", "https://github.com/acme/tools.git", "/tmp/clone", "main"},
+		{"no ref", "https://github.com/acme/tools.git", "/tmp/clone"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			args := cloneArgs(tt.url, tt.dir, tt.ref)
+			args := cloneArgs(tt.url, tt.dir)
 
 			// Must contain -c core.hooksPath=/dev/null to disable git hooks
 			foundHooksPath := false
@@ -126,20 +124,6 @@ func TestCloneArgs_SecurityProtections(t *testing.T) {
 			}
 			if !foundClone {
 				t.Errorf("cloneArgs missing 'clone' subcommand, got %v", args)
-			}
-
-			// If ref is set, must contain --branch ref
-			if tt.ref != "" {
-				foundBranch := false
-				for i, a := range args {
-					if a == "--branch" && i+1 < len(args) && args[i+1] == tt.ref {
-						foundBranch = true
-						break
-					}
-				}
-				if !foundBranch {
-					t.Errorf("cloneArgs with ref=%q missing --branch flag, got %v", tt.ref, args)
-				}
 			}
 		})
 	}
@@ -223,7 +207,7 @@ func TestClone_SetsGitConfigNoSystem(t *testing.T) {
 	// The actual env var is set in Clone() — we verify it indirectly by
 	// confirming cloneArgs is the only path and checking the source.
 	t.Parallel()
-	args := cloneArgs("https://example.com/repo.git", "/tmp/test", "")
+	args := cloneArgs("https://example.com/repo.git", "/tmp/test")
 
 	// The -c flag must come BEFORE clone to be a global git option
 	cloneIdx := -1


### PR DESCRIPTION
Part of #542 item 7 (pin and rollback).

`registry add --ref` promised "Branch, tag, or commit" but a commit SHA failed outright (`git clone --branch <sha>` → "Remote branch not found") and a tag cloned detached, after which every `registry sync` failed (`git pull --ff-only` cannot run on a detached HEAD).

- **Clone**: always clone without `--branch`, then check out the ref — branches get a local tracking branch (pull behavior preserved), tags/SHAs get a detached checkout. Bad refs clean up the partial clone and name the ref in the error.
- **Sync**: a detached HEAD (self-describing — no ref-kind stored) means the registry is pinned: fetch-only, checkout never moves. `GitSyncOutcome` gains `Pinned`/`RemoteHead`; the CLI prints `Synced (pinned)` and, when upstream moved, the not-applied item diff.
- **Status**: `GitStatusOutcome.Pinned` + "git, pinned" kind in `registry status` (JSON gains `pinned`).
- New exported helpers `registry.IsPinned` / `registry.RemoteDefaultHead`.
- Both delete-the-clone failure hints now warn that deleting the clone discards local history used for item rollback.
- `--ref` flag help documents the pinning behavior (commands.json regenerated).

Tests: clone matrix (branch/tag/SHA/bogus ref), detached-HEAD sync/status, hint text, pinned sync display — all local git fixtures, no network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)