### PR TITLE
feat(add): stamp git-registry source SHA at add time (#542 item 7b-i)

### DIFF
--- a/cli/cmd/syllago/add_cmd.go
+++ b/cli/cmd/syllago/add_cmd.go
@@ -264,12 +264,14 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 	srcRegistry, _ := cmd.Flags().GetString("source-registry")
 	srcVisibility, _ := cmd.Flags().GetString("source-visibility")
+	sourceSHA := sourceSHAForConfiguredGitRegistry(mergedCfg, srcRegistry)
 
 	results := add.AddItems(items, add.AddOptions{
 		Force:            force,
 		DryRun:           dryRun,
 		Provider:         fromSlug,
 		SourceRegistry:   srcRegistry,
+		SourceSHA:        sourceSHA,
 		SourceVisibility: srcVisibility,
 	}, globalDir, canon, version)
 
@@ -327,6 +329,21 @@ func chainInstallAfterAdd(results []add.AddResult, toSlug, globalDir, projectRoo
 		}
 	}
 	return nil
+}
+
+func sourceSHAForConfiguredGitRegistry(cfg *config.Config, srcRegistry string) string {
+	if cfg == nil || srcRegistry == "" {
+		return ""
+	}
+	reg := findRegistryByName(cfg, srcRegistry)
+	if reg == nil || !reg.IsGit() {
+		return ""
+	}
+	head, err := registry.Head(reg.Name)
+	if err != nil {
+		return ""
+	}
+	return head
 }
 
 // filterDiscoveryItems filters a discovery list by content type and optional name.
@@ -1281,13 +1298,23 @@ func runAddFromRegistry(projectRoot string, args []string, fromSlug string, addA
 	if visibility == "" {
 		visibility = "unknown"
 	}
+	sourceSHA := ""
+	if reg.IsGit() {
+		if head, err := registry.Head(reg.Name); err == nil {
+			sourceSHA = head
+		}
+	}
 
 	results := add.AddItems(items, add.AddOptions{
 		Force:            force,
 		DryRun:           dryRun,
 		SourceRegistry:   reg.Name,
+		SourceSHA:        sourceSHA,
 		SourceVisibility: visibility,
 	}, globalDir, nil, version)
+	if !dryRun {
+		recordAddUpdateBookkeeping(results, reg.Name, sourceSHA)
+	}
 
 	telemetry.Enrich("from", fromSlug)
 	telemetry.Enrich("content_type", typeStr)

--- a/cli/cmd/syllago/add_cmd_registry_test.go
+++ b/cli/cmd/syllago/add_cmd_registry_test.go
@@ -3,12 +3,16 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/metadata"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/registry"
 )
@@ -35,6 +39,40 @@ func setupRegistryClone(t *testing.T, cacheDir, registryName string) string {
 	os.WriteFile(filepath.Join(cloneDir, "registry.yaml"), []byte("name: test-registry\n"), 0644)
 
 	return cloneDir
+}
+
+// setupGitRegistryClone creates a fake git-backed registry clone at
+// CacheDirOverride/<name> and returns the clone's initial HEAD.
+func setupGitRegistryClone(t *testing.T, cacheDir, registryName, skillContent string) (string, string) {
+	t.Helper()
+	cloneDir := setupRegistryClone(t, cacheDir, registryName)
+	if err := os.WriteFile(filepath.Join(cloneDir, "skills", "canary-skill", "SKILL.md"), []byte(skillContent), 0644); err != nil {
+		t.Fatalf("WriteFile canary skill: %v", err)
+	}
+	gitRunForRegistryAddTest(t, cloneDir, "init")
+	gitRunForRegistryAddTest(t, cloneDir, "config", "user.email", "test@example.com")
+	gitRunForRegistryAddTest(t, cloneDir, "config", "user.name", "Test User")
+	gitRunForRegistryAddTest(t, cloneDir, "add", "-A")
+	gitRunForRegistryAddTest(t, cloneDir, "commit", "-m", "initial")
+	return cloneDir, gitOutputForRegistryAddTest(t, cloneDir, "rev-parse", "HEAD")
+}
+
+func gitRunForRegistryAddTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	_ = gitOutputForRegistryAddTest(t, dir, args...)
+}
+
+func gitOutputForRegistryAddTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // setupProjectWithRegistry creates a temp project with a .syllago/config.json
@@ -369,6 +407,191 @@ func TestAddFromRegistry_MetadataSourceRegistry(t *testing.T) {
 	// Verify SourceRegistry is set in the metadata (YAML, check as string).
 	if !strings.Contains(string(data), regName) {
 		t.Errorf("expected metadata to contain registry name %q; got:\n%s", regName, string(data))
+	}
+}
+
+func TestAddFromRegistry_MetadataSourceSHA(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	const regName = "test-org/git-registry"
+	cacheDir := t.TempDir()
+	origCache := registry.CacheDirOverride
+	registry.CacheDirOverride = cacheDir
+	t.Cleanup(func() { registry.CacheDirOverride = origCache })
+
+	_, head := setupGitRegistryClone(t, cacheDir, regName, "# Canary skill\n")
+
+	root := setupProjectWithRegistry(t, regName)
+	withFakeRepoRoot(t, root)
+
+	globalDir := t.TempDir()
+	withGlobalLibrary(t, globalDir)
+
+	_, _ = output.SetForTest(t)
+
+	addCmd.Flags().Set("from", regName)
+	addCmd.Flags().Set("all", "false")
+	addCmd.Flags().Set("force", "false")
+	addCmd.Flags().Set("dry-run", "false")
+	t.Cleanup(func() {
+		addCmd.Flags().Set("from", "")
+		addCmd.Flags().Set("all", "false")
+		addCmd.Flags().Set("force", "false")
+		addCmd.Flags().Set("dry-run", "false")
+	})
+
+	if err := addCmd.RunE(addCmd, []string{"skills/canary-skill"}); err != nil {
+		t.Fatalf("add from registry: %v", err)
+	}
+
+	itemDir := filepath.Join(globalDir, "skills", "canary-skill")
+	meta, err := metadata.Load(itemDir)
+	if err != nil || meta == nil {
+		t.Fatalf("metadata load failed: %v", err)
+	}
+	if meta.SourceSHA != head {
+		t.Fatalf("SourceSHA = %q, want %q", meta.SourceSHA, head)
+	}
+}
+
+func TestAddFromRegistryForceRotatesInstallRecord(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	const regName = "test-org/git-registry-rotate"
+	cacheDir := t.TempDir()
+	origCache := registry.CacheDirOverride
+	registry.CacheDirOverride = cacheDir
+	t.Cleanup(func() { registry.CacheDirOverride = origCache })
+
+	cloneDir, oldHead := setupGitRegistryClone(t, cacheDir, regName, "# Canary skill\nold\n")
+
+	root := setupProjectWithRegistry(t, regName)
+	withFakeRepoRoot(t, root)
+
+	globalDir := t.TempDir()
+	withGlobalLibrary(t, globalDir)
+	configDir := withInstallRecordConfigDir(t)
+
+	stdout, _ := output.SetForTest(t)
+
+	addCmd.Flags().Set("from", regName)
+	addCmd.Flags().Set("all", "false")
+	addCmd.Flags().Set("force", "false")
+	addCmd.Flags().Set("dry-run", "false")
+	t.Cleanup(func() {
+		addCmd.Flags().Set("from", "")
+		addCmd.Flags().Set("all", "false")
+		addCmd.Flags().Set("force", "false")
+		addCmd.Flags().Set("dry-run", "false")
+	})
+
+	if err := addCmd.RunE(addCmd, []string{"skills/canary-skill"}); err != nil {
+		t.Fatalf("initial add from registry: %v", err)
+	}
+
+	libraryPath := filepath.Join(globalDir, "skills", "canary-skill")
+	coord := installstore.Coord{Registry: regName, Type: string(catalog.Skills), Name: "canary-skill"}
+	storePath := filepath.Join(configDir, "installs.json")
+	if err := installstore.RecordInstallMeta(storePath, coord, libraryPath, installstore.PlacementInput{
+		Provider:  "claude-code",
+		Mechanism: installstore.MechanismSymlink,
+		Path:      filepath.Join(t.TempDir(), "canary-skill"),
+	}, installstore.InstallMeta{SourceSHA: oldHead}, time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("seed RecordInstallMeta: %v", err)
+	}
+	oldContentHash, err := installstore.HashContent(libraryPath)
+	if err != nil {
+		t.Fatalf("HashContent old library: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(cloneDir, "skills", "canary-skill", "SKILL.md"), []byte("# Canary skill\nnew\n"), 0644); err != nil {
+		t.Fatalf("WriteFile updated skill: %v", err)
+	}
+	gitRunForRegistryAddTest(t, cloneDir, "add", "-A")
+	gitRunForRegistryAddTest(t, cloneDir, "commit", "-m", "update canary")
+	newHead := gitOutputForRegistryAddTest(t, cloneDir, "rev-parse", "HEAD")
+
+	stdout.Reset()
+	addCmd.Flags().Set("force", "true")
+	if err := addCmd.RunE(addCmd, []string{"skills/canary-skill"}); err != nil {
+		t.Fatalf("force add from registry: %v", err)
+	}
+
+	store := mustLoadInstallRecordStore(t, configDir)
+	rec := store.Find(coord)
+	if rec == nil {
+		t.Fatal("install record missing after force add")
+	}
+	if rec.SourceSHA != newHead {
+		t.Fatalf("SourceSHA = %q, want %q", rec.SourceSHA, newHead)
+	}
+	if rec.Previous == nil {
+		t.Fatal("Previous = nil, want rollback point")
+	}
+	if rec.Previous.SourceSHA != oldHead {
+		t.Fatalf("Previous.SourceSHA = %q, want %q", rec.Previous.SourceSHA, oldHead)
+	}
+	if rec.Previous.ContentHash != oldContentHash {
+		t.Fatalf("Previous.ContentHash = %q, want %q", rec.Previous.ContentHash, oldContentHash)
+	}
+}
+
+func TestAddFromRegistryForceWithoutInstallRecordSkipsBookkeeping(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	const regName = "test-org/git-registry-no-record"
+	cacheDir := t.TempDir()
+	origCache := registry.CacheDirOverride
+	registry.CacheDirOverride = cacheDir
+	t.Cleanup(func() { registry.CacheDirOverride = origCache })
+
+	cloneDir, _ := setupGitRegistryClone(t, cacheDir, regName, "# Canary skill\nold\n")
+
+	root := setupProjectWithRegistry(t, regName)
+	withFakeRepoRoot(t, root)
+
+	globalDir := t.TempDir()
+	withGlobalLibrary(t, globalDir)
+	configDir := withInstallRecordConfigDir(t)
+
+	_, _ = output.SetForTest(t)
+
+	addCmd.Flags().Set("from", regName)
+	addCmd.Flags().Set("all", "false")
+	addCmd.Flags().Set("force", "false")
+	addCmd.Flags().Set("dry-run", "false")
+	t.Cleanup(func() {
+		addCmd.Flags().Set("from", "")
+		addCmd.Flags().Set("all", "false")
+		addCmd.Flags().Set("force", "false")
+		addCmd.Flags().Set("dry-run", "false")
+	})
+
+	if err := addCmd.RunE(addCmd, []string{"skills/canary-skill"}); err != nil {
+		t.Fatalf("initial add from registry: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(cloneDir, "skills", "canary-skill", "SKILL.md"), []byte("# Canary skill\nnew\n"), 0644); err != nil {
+		t.Fatalf("WriteFile updated skill: %v", err)
+	}
+	gitRunForRegistryAddTest(t, cloneDir, "add", "-A")
+	gitRunForRegistryAddTest(t, cloneDir, "commit", "-m", "update canary")
+
+	addCmd.Flags().Set("force", "true")
+	if err := addCmd.RunE(addCmd, []string{"skills/canary-skill"}); err != nil {
+		t.Fatalf("force add from registry without record: %v", err)
+	}
+
+	store := mustLoadInstallRecordStore(t, configDir)
+	coord := installstore.Coord{Registry: regName, Type: string(catalog.Skills), Name: "canary-skill"}
+	if rec := store.Find(coord); rec != nil {
+		t.Fatalf("record was created unexpectedly: %#v", rec)
 	}
 }
 

--- a/cli/cmd/syllago/installrecord.go
+++ b/cli/cmd/syllago/installrecord.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/OpenScribbler/syllago/cli/internal/add"
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/installer"
 	"github.com/OpenScribbler/syllago/cli/internal/installstore"
@@ -18,7 +19,9 @@ func recordInstallBookkeeping(item catalog.ContentItem, provSlug string, pl inst
 		warnInstallRecord(err)
 		return
 	}
-	if err := installstore.RecordInstall(storePath, installRecordCoord(item), item.Path, installRecordPlacement(provSlug, pl), time.Now()); err != nil {
+	if err := installstore.RecordInstallMeta(storePath, installRecordCoord(item), item.Path, installRecordPlacement(provSlug, pl), installstore.InstallMeta{
+		SourceSHA: installRecordSourceSHA(item),
+	}, time.Now()); err != nil {
 		warnInstallRecord(err)
 	}
 }
@@ -31,8 +34,39 @@ func recordMOATInstallBookkeeping(item catalog.ContentItem, provSlug string, pl 
 		warnInstallRecord(err)
 		return
 	}
-	if err := installstore.RecordInstallMOAT(storePath, installRecordCoord(item), item.Path, installRecordPlacement(provSlug, pl), moatProv, time.Now()); err != nil {
+	if err := installstore.RecordInstallMeta(storePath, installRecordCoord(item), item.Path, installRecordPlacement(provSlug, pl), installstore.InstallMeta{
+		MOAT:      moatProv,
+		SourceSHA: installRecordSourceSHA(item),
+	}, time.Now()); err != nil {
 		warnInstallRecord(err)
+	}
+}
+
+// recordAddUpdateBookkeeping rotates install records for items that were
+// force-overwritten in the library, capturing the one-step rollback point.
+func recordAddUpdateBookkeeping(results []add.AddResult, regName, sourceSHA string) {
+	for _, r := range results {
+		if r.Status != add.AddStatusUpdated {
+			continue
+		}
+		storePath, err := installstore.DefaultPath()
+		if err != nil {
+			warnInstallRecord(err)
+			continue
+		}
+		coord := installstore.Coord{Registry: regName, Type: string(r.Type), Name: r.Name}
+		store, err := installstore.Load(storePath)
+		if err != nil {
+			warnInstallRecord(err)
+			continue
+		}
+		rec := store.Find(coord)
+		if rec == nil {
+			continue
+		}
+		if err := installstore.RecordUpdate(storePath, coord, rec.LibraryPath, sourceSHA, "", time.Now()); err != nil {
+			warnInstallRecord(err)
+		}
 	}
 }
 
@@ -79,6 +113,13 @@ func installRecordPlacement(provSlug string, pl installer.Placement) installstor
 		Path:      pl.Path,
 		Keys:      pl.Keys,
 	}
+}
+
+func installRecordSourceSHA(item catalog.ContentItem) string {
+	if item.Meta == nil {
+		return ""
+	}
+	return item.Meta.SourceSHA
 }
 
 func warnInstallRecord(err error) {

--- a/cli/cmd/syllago/installrecord_test.go
+++ b/cli/cmd/syllago/installrecord_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/installer"
 	"github.com/OpenScribbler/syllago/cli/internal/installstore"
 	"github.com/OpenScribbler/syllago/cli/internal/metadata"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
@@ -49,6 +50,46 @@ func TestInstallCommandRecordsInstallState(t *testing.T) {
 	wantPath := filepath.Join(installBase, "skills", "my-skill")
 	if got.Provider != "record-install-provider" || got.Mechanism != installstore.MechanismSymlink || got.Path != wantPath || got.Key != "" {
 		t.Fatalf("placement = %#v, want provider record-install-provider symlink path %s", got, wantPath)
+	}
+}
+
+func TestRecordInstallBookkeepingCarriesSourceSHA(t *testing.T) {
+	configDir := withInstallRecordConfigDir(t)
+	output.SetForTest(t)
+
+	libraryPath := filepath.Join(t.TempDir(), "skills", "writer")
+	if err := os.MkdirAll(libraryPath, 0755); err != nil {
+		t.Fatalf("MkdirAll library path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(libraryPath, "SKILL.md"), []byte("# Writer\n"), 0644); err != nil {
+		t.Fatalf("WriteFile library content: %v", err)
+	}
+
+	item := catalog.ContentItem{
+		Name: "writer",
+		Type: catalog.Skills,
+		Path: libraryPath,
+		Meta: &metadata.Meta{
+			SourceType:     "registry",
+			SourceRegistry: "acme/tools",
+			SourceSHA:      "sha-from-meta",
+		},
+	}
+	placement := installer.Placement{
+		Mechanism: installer.MechanismSymlink,
+		Path:      filepath.Join(t.TempDir(), "writer"),
+	}
+
+	recordInstallBookkeeping(item, "claude-code", placement)
+
+	store := mustLoadInstallRecordStore(t, configDir)
+	coord := installstore.Coord{Registry: "acme/tools", Type: string(catalog.Skills), Name: "writer"}
+	rec := store.Find(coord)
+	if rec == nil {
+		t.Fatal("install record missing")
+	}
+	if rec.SourceSHA != "sha-from-meta" {
+		t.Fatalf("SourceSHA = %q, want sha-from-meta", rec.SourceSHA)
 	}
 }
 

--- a/cli/internal/add/add.go
+++ b/cli/internal/add/add.go
@@ -90,6 +90,7 @@ type AddOptions struct {
 	DryRun           bool
 	Provider         string // provider slug, used for directory layout
 	SourceRegistry   string // registry name for taint propagation (e.g., "acme/internal-rules")
+	SourceSHA        string // registry clone HEAD the items are being copied from; empty for non-git sources
 	SourceVisibility string // visibility at import time: "public", "private", "unknown"
 }
 
@@ -332,6 +333,7 @@ func writeItem(item DiscoveryItem, opts AddOptions, globalDir string, canon Cano
 	// Taint propagation: if registry source is explicitly provided, use it.
 	if opts.SourceRegistry != "" {
 		meta.SourceRegistry = opts.SourceRegistry
+		meta.SourceSHA = opts.SourceSHA
 		meta.SourceVisibility = opts.SourceVisibility
 		meta.SourceType = "registry"
 	} else {

--- a/cli/internal/add/add_test.go
+++ b/cli/internal/add/add_test.go
@@ -214,6 +214,83 @@ func TestAddItems_NewItem(t *testing.T) {
 	}
 }
 
+func TestAddItems_SourceSHARequiresSourceRegistry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		sourceRegistry string
+		sourceSHA      string
+		wantSourceSHA  string
+		wantYAMLKey    bool
+	}{
+		{
+			name:           "registry and sha stamps source sha",
+			sourceRegistry: "acme/tools",
+			sourceSHA:      "abc123",
+			wantSourceSHA:  "abc123",
+			wantYAMLKey:    true,
+		},
+		{
+			name:           "registry without sha omits field",
+			sourceRegistry: "acme/tools",
+			sourceSHA:      "",
+			wantSourceSHA:  "",
+			wantYAMLKey:    false,
+		},
+		{
+			name:           "sha without registry omits field",
+			sourceRegistry: "",
+			sourceSHA:      "abc123",
+			wantSourceSHA:  "",
+			wantYAMLKey:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmp := t.TempDir()
+			globalDir := t.TempDir()
+			srcPath := filepath.Join(tmp, "rule.md")
+			if err := os.WriteFile(srcPath, []byte("# Rule"), 0644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			results := AddItems([]DiscoveryItem{
+				{Name: "rule", Type: catalog.Rules, Path: srcPath, Status: StatusNew},
+			}, AddOptions{
+				Provider:       "claude-code",
+				SourceRegistry: tt.sourceRegistry,
+				SourceSHA:      tt.sourceSHA,
+			}, globalDir, nil, "test")
+			if results[0].Status != AddStatusAdded {
+				t.Fatalf("Status = %v, want AddStatusAdded", results[0].Status)
+			}
+
+			destDir := filepath.Join(globalDir, "rules", "claude-code", "rule")
+			meta, err := metadata.Load(destDir)
+			if err != nil || meta == nil {
+				t.Fatalf("metadata load failed: %v", err)
+			}
+			if meta.SourceSHA != tt.wantSourceSHA {
+				t.Fatalf("SourceSHA = %q, want %q", meta.SourceSHA, tt.wantSourceSHA)
+			}
+
+			data, err := os.ReadFile(metadata.MetaPath(destDir))
+			if err != nil {
+				t.Fatalf("ReadFile metadata: %v", err)
+			}
+			hasYAMLKey := strings.Contains(string(data), "source_sha:")
+			if hasYAMLKey != tt.wantYAMLKey {
+				t.Fatalf("source_sha YAML presence = %v, want %v\n%s", hasYAMLKey, tt.wantYAMLKey, string(data))
+			}
+		})
+	}
+}
+
 func TestAddItems_UpToDate_Skipped(t *testing.T) {
 	t.Parallel()
 	globalDir := t.TempDir()

--- a/cli/internal/metadata/metadata.go
+++ b/cli/internal/metadata/metadata.go
@@ -58,6 +58,7 @@ type Meta struct {
 	HasSource        bool                `yaml:"has_source,omitempty"`        // whether .source/ directory exists
 	SourceHash       string              `yaml:"source_hash,omitempty"`       // SHA-256 of source content at import time
 	SourceRegistry   string              `yaml:"source_registry,omitempty"`   // registry name content was imported from (e.g. "acme/internal-rules")
+	SourceSHA        string              `yaml:"source_sha,omitempty"`        // git-registry clone HEAD at add time (rollback coordinate)
 	SourceVisibility string              `yaml:"source_visibility,omitempty"` // visibility at import time: "public", "private", "unknown"
 	AddedAt          *time.Time          `yaml:"added_at,omitempty"`          // when content was added to library
 	AddedBy          string              `yaml:"added_by,omitempty"`          // e.g. "syllago v0.1.0"

--- a/cli/internal/metadata/schemadoc.go
+++ b/cli/internal/metadata/schemadoc.go
@@ -64,6 +64,7 @@ var fieldGroups = map[string]string{
 	"SourceURL":      "source-provenance",
 	"HasSource":      "source-provenance",
 	"SourceHash":     "source-provenance",
+	"SourceSHA":      "source-provenance",
 	"AddedAt":        "source-provenance",
 	"AddedBy":        "source-provenance",
 

--- a/cli/syllago-yaml-schema.json
+++ b/cli/syllago-yaml-schema.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated_at": "2026-08-21T21:26:09Z",
+  "generated_at": "2026-08-24T17:50:16Z",
   "syllago_version": "0.14.0",
   "schema": {
     "struct_name": "Meta",
@@ -197,6 +197,15 @@
         "required": false,
         "comment": "registry name content was imported from (e.g. \"acme/internal-rules\")",
         "group": "registry"
+      },
+      {
+        "name": "SourceSHA",
+        "yaml_key": "source_sha",
+        "type": "string",
+        "omitempty": true,
+        "required": false,
+        "comment": "git-registry clone HEAD at add time (rollback coordinate)",
+        "group": "source-provenance"
       },
       {
         "name": "SourceVisibility",


### PR DESCRIPTION
Part of #542 item 7 (pin and rollback).

Git-registry rollback re-extracts content from the registry clone at a recorded commit — which means the clone HEAD must be captured at ADD time, when the content is actually copied out of the clone. This PR wires that provenance chain for the CLI paths:

- `metadata.Meta.SourceSHA` (`source_sha` in `.syllago.yaml`): the registry clone HEAD the item was copied from. Stamped only alongside `source_registry` — a SHA without a registry is meaningless. Schema docs regenerated.
- Registry adds (`syllago add <registry>/...`) resolve `registry.Head` best-effort: an error leaves the SHA empty rather than failing the add. Provider-source adds resolve it when `--source-registry` names a configured git registry.
- `add --force` over an installed item now rotates its install record via `installstore.RecordUpdate`, capturing the previous ContentHash/SourceSHA as the one-step rollback point. Items that were never installed skip silently.
- Install bookkeeping switches to `RecordInstallMeta`, carrying the library copy's `source_sha` into the install record. Empty SHA preserves existing record state, so non-registry content is unaffected.

Tests: metadata stamping matrix, registry add HEAD capture, force-overwrite rotation and no-record skip, install bookkeeping carry — local git fixtures, no network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)