### PR TITLE
feat(moat): save previous library copy before overwrite (#542 item 7b-ii)

### DIFF
--- a/cli/cmd/syllago/install_moat.go
+++ b/cli/cmd/syllago/install_moat.go
@@ -353,7 +353,7 @@ func runInstallFromRegistry(
 	// Provider-side install: stage the verified source tree into the
 	// library first, then place it from the library with the regular
 	// installer so symlinks and install records share the normal path model.
-	item, stageErr := moatinstall.StageIntoLibrary(cacheDir, entry, reg.Name, globalDir, now)
+	item, prevCopy, stageErr := moatinstall.StageIntoLibraryKeepPrev(cacheDir, entry, reg.Name, globalDir, now)
 	if stageErr != nil {
 		return output.NewStructuredErrorDetail(
 			output.ErrInstallNotWritable,
@@ -371,6 +371,9 @@ func runInstallFromRegistry(
 			"The source artifact was fetched and verified but the provider-side install failed. Check filesystem permissions, that the target directory is writable, and that the provider supports this content type.",
 			installErr.Error(),
 		)
+	}
+	if prevCopy != "" {
+		recordMOATUpdateBookkeeping(item, prevCopy)
 	}
 	recordMOATInstallBookkeeping(item, targetProv.Slug, placement, &installstore.MOATProvenance{
 		ManifestURI: reg.ManifestURI,

--- a/cli/cmd/syllago/install_moat_integration_test.go
+++ b/cli/cmd/syllago/install_moat_integration_test.go
@@ -459,3 +459,241 @@ func TestInstallIntegration_TierBelowPolicyRefuses(t *testing.T) {
 	)
 	assertStructuredCode(t, err, output.ErrMoatTierBelowPolicy)
 }
+
+func TestInstallIntegration_ReplaceWithRecord(t *testing.T) {
+	// Setup environment
+	env := setupIntegrationEnv(t)
+	globalDir := t.TempDir()
+	withGlobalLibrary(t, globalDir)
+	configDir := withInstallRecordConfigDir(t)
+	output.SetForTest(t)
+
+	// Enable PreviousRootOverride for testing
+	origOverride := moatinstall.PreviousRootOverride
+	prevOverride := t.TempDir()
+	moatinstall.PreviousRootOverride = prevOverride
+	t.Cleanup(func() { moatinstall.PreviousRootOverride = origOverride })
+
+	t.Setenv("HOME", env.projectRoot)
+
+	// 1. Install v1 first
+	fixtureRoot1 := t.TempDir()
+	contentHash1 := makeRepoFixture(t, fixtureRoot1, "skills", "my-skill", map[string]string{
+		"SKILL.md": "# from registry v1\n",
+	})
+	stubCloneFromFixture(t, fixtureRoot1)
+	now := time.Date(2026, 8, 22, 14, 0, 0, 0, time.UTC)
+
+	env.syncResultFn = func() (moat.SyncResult, error) {
+		return moat.SyncResult{
+			ManifestURL: "https://example.com/m",
+			Manifest: &moat.Manifest{Content: []moat.ContentEntry{{
+				Name:        "my-skill",
+				Type:        "skill",
+				ContentHash: contentHash1,
+				SourceURI:   "https://github.com/example/repo",
+				AttestedAt:  now,
+			}}},
+			IncomingProfile: incomingProfile(),
+			Staleness:       moat.StalenessFresh,
+		}, nil
+	}
+
+	prov := integrationTestProvider()
+	err := runInstallFromRegistry(
+		context.Background(),
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		cfgWithPinnedMOATRegistry(),
+		env.projectRoot,
+		globalDir,
+		"example",
+		"my-skill",
+		&prov,
+		installer.MethodSymlink,
+		"",
+		false,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("first install failed: %v", err)
+	}
+
+	// Verify v1 install record exists
+	storePath := filepath.Join(configDir, "installs.json")
+	store, err := installstore.Load(storePath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	rec := store.Find(installstore.Coord{Registry: "example", Type: string(catalog.Skills), Name: "my-skill"})
+	if rec == nil {
+		t.Fatal("v1 record missing")
+	}
+	if rec.Previous != nil {
+		t.Fatal("v1 record should have no Previous")
+	}
+	v1Hash := rec.ContentHash
+
+	// 2. Install v2 (different content hash)
+	fixtureRoot2 := t.TempDir()
+	contentHash2 := makeRepoFixture(t, fixtureRoot2, "skills", "my-skill", map[string]string{
+		"SKILL.md": "# from registry v2\n",
+	})
+	stubCloneFromFixture(t, fixtureRoot2)
+
+	env.syncResultFn = func() (moat.SyncResult, error) {
+		return moat.SyncResult{
+			ManifestURL: "https://example.com/m2",
+			Manifest: &moat.Manifest{Content: []moat.ContentEntry{{
+				Name:        "my-skill",
+				Type:        "skill",
+				ContentHash: contentHash2,
+				SourceURI:   "https://github.com/example/repo",
+				AttestedAt:  now.Add(time.Hour),
+			}}},
+			IncomingProfile: incomingProfile(),
+			Staleness:       moat.StalenessFresh,
+		}, nil
+	}
+
+	err = runInstallFromRegistry(
+		context.Background(),
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		cfgWithPinnedMOATRegistry(),
+		env.projectRoot,
+		globalDir,
+		"example",
+		"my-skill",
+		&prov,
+		installer.MethodSymlink,
+		"",
+		false,
+		now.Add(time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("second install failed: %v", err)
+	}
+
+	// 3. Verify record's Previous is populated correctly
+	store, err = installstore.Load(storePath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	rec = store.Find(installstore.Coord{Registry: "example", Type: string(catalog.Skills), Name: "my-skill"})
+	if rec == nil {
+		t.Fatal("v2 record missing")
+	}
+	if rec.Previous == nil {
+		t.Fatal("v2 record Previous is nil, want populated previous version copy")
+	}
+
+	expectedPrevDir, _ := moatinstall.PreviousDirFor("example", catalog.Skills, "my-skill")
+	if rec.Previous.CopyPath != expectedPrevDir {
+		t.Errorf("Previous.CopyPath = %q, want %q", rec.Previous.CopyPath, expectedPrevDir)
+	}
+	if rec.Previous.ContentHash != v1Hash {
+		t.Errorf("Previous.ContentHash = %q, want %q", rec.Previous.ContentHash, v1Hash)
+	}
+	expectedV2Hash, err := installstore.HashContent(filepath.Join(globalDir, "skills", "my-skill"))
+	if err != nil {
+		t.Fatalf("HashContent: %v", err)
+	}
+	if rec.ContentHash != expectedV2Hash {
+		t.Errorf("ContentHash = %q, want %q", rec.ContentHash, expectedV2Hash)
+	}
+	if rec.MOAT == nil {
+		t.Fatal("MOAT provenance missing after replace")
+	}
+}
+
+func TestInstallIntegration_ReplaceWithoutRecord(t *testing.T) {
+	env := setupIntegrationEnv(t)
+	globalDir := t.TempDir()
+	withGlobalLibrary(t, globalDir)
+	configDir := withInstallRecordConfigDir(t)
+	output.SetForTest(t)
+
+	origOverride := moatinstall.PreviousRootOverride
+	prevOverride := t.TempDir()
+	moatinstall.PreviousRootOverride = prevOverride
+	t.Cleanup(func() { moatinstall.PreviousRootOverride = origOverride })
+
+	t.Setenv("HOME", env.projectRoot)
+
+	// Stage a v1 item directly into library so there is no install record for it.
+	libraryPath := filepath.Join(globalDir, "skills", "my-skill")
+	if err := os.MkdirAll(libraryPath, 0755); err != nil {
+		t.Fatalf("mkdir library: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(libraryPath, "SKILL.md"), []byte("# v1 directly staged\n"), 0644); err != nil {
+		t.Fatalf("write library file: %v", err)
+	}
+	if err := metadata.Save(libraryPath, &metadata.Meta{
+		Name:           "my-skill",
+		Type:           "skills",
+		SourceType:     "registry",
+		SourceRegistry: "example",
+		SourceHash:     "sha256:oldhash",
+	}); err != nil {
+		t.Fatalf("save meta: %v", err)
+	}
+
+	// Install v2
+	fixtureRoot := t.TempDir()
+	contentHash := makeRepoFixture(t, fixtureRoot, "skills", "my-skill", map[string]string{
+		"SKILL.md": "# from registry v2\n",
+	})
+	stubCloneFromFixture(t, fixtureRoot)
+	now := time.Date(2026, 8, 22, 14, 0, 0, 0, time.UTC)
+
+	env.syncResultFn = func() (moat.SyncResult, error) {
+		return moat.SyncResult{
+			ManifestURL: "https://example.com/m",
+			Manifest: &moat.Manifest{Content: []moat.ContentEntry{{
+				Name:        "my-skill",
+				Type:        "skill",
+				ContentHash: contentHash,
+				SourceURI:   "https://github.com/example/repo",
+				AttestedAt:  now,
+			}}},
+			IncomingProfile: incomingProfile(),
+			Staleness:       moat.StalenessFresh,
+		}, nil
+	}
+
+	prov := integrationTestProvider()
+	err := runInstallFromRegistry(
+		context.Background(),
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		cfgWithPinnedMOATRegistry(),
+		env.projectRoot,
+		globalDir,
+		"example",
+		"my-skill",
+		&prov,
+		installer.MethodSymlink,
+		"",
+		false,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	// Verify that a record was created for the new install, but since there was no
+	// record before, its Previous field is nil.
+	storePath := filepath.Join(configDir, "installs.json")
+	store, err := installstore.Load(storePath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	rec := store.Find(installstore.Coord{Registry: "example", Type: string(catalog.Skills), Name: "my-skill"})
+	if rec == nil {
+		t.Fatal("record missing after first install")
+	}
+	if rec.Previous != nil {
+		t.Errorf("record Previous = %+v, want nil", rec.Previous)
+	}
+}

--- a/cli/cmd/syllago/installrecord.go
+++ b/cli/cmd/syllago/installrecord.go
@@ -42,6 +42,30 @@ func recordMOATInstallBookkeeping(item catalog.ContentItem, provSlug string, pl 
 	}
 }
 
+// recordMOATUpdateBookkeeping rotates the install record for a MOAT item whose
+// library copy was just replaced, capturing the saved previous copy for
+// one-step rollback. Best-effort; items without records skip silently.
+func recordMOATUpdateBookkeeping(item catalog.ContentItem, prevCopyPath string) {
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		warnInstallRecord(err)
+		return
+	}
+	coord := installRecordCoord(item)
+	store, err := installstore.Load(storePath)
+	if err != nil {
+		warnInstallRecord(err)
+		return
+	}
+	rec := store.Find(coord)
+	if rec == nil {
+		return
+	}
+	if err := installstore.RecordUpdate(storePath, coord, item.Path, "", prevCopyPath, time.Now()); err != nil {
+		warnInstallRecord(err)
+	}
+}
+
 // recordAddUpdateBookkeeping rotates install records for items that were
 // force-overwritten in the library, capturing the one-step rollback point.
 func recordAddUpdateBookkeeping(results []add.AddResult, regName, sourceSHA string) {

--- a/cli/internal/moatinstall/stage.go
+++ b/cli/internal/moatinstall/stage.go
@@ -9,31 +9,55 @@ import (
 	"time"
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/metadata"
 	"github.com/OpenScribbler/syllago/cli/internal/moat"
 )
 
-// StageIntoLibrary copies a verified MOAT source-cache tree into the global
-// library and writes item metadata attributing it to the registry. Returns a
-// ContentItem rooted at the library dir with Registry set.
-func StageIntoLibrary(cacheDir string, entry *moat.ContentEntry, regName, globalDir string, now time.Time) (catalog.ContentItem, error) {
+// PreviousRootOverride redirects saved previous-version copies (tests).
+var PreviousRootOverride string
+
+// PreviousDirFor returns the directory where the previous library copy of a
+// registry item is kept for one-step rollback. It lives under the syllago
+// global dir, NOT the content root, so the catalog never scans it.
+func PreviousDirFor(regName string, ct catalog.ContentType, name string) (string, error) {
+	baseDir := PreviousRootOverride
+	if baseDir == "" {
+		var err error
+		baseDir, err = config.GlobalDirPath()
+		if err != nil {
+			return "", err
+		}
+	}
+	return filepath.Join(baseDir, "previous", regName, string(ct), name), nil
+}
+
+// StageIntoLibraryKeepPrev copies a verified MOAT source-cache tree into the global
+// library, saves a copy of the previous library content for rollback (if it was
+// replaced), and writes item metadata. Returns the ContentItem and the path to
+// the saved previous copy, if any.
+func StageIntoLibraryKeepPrev(cacheDir string, entry *moat.ContentEntry, regName, globalDir string, now time.Time) (catalog.ContentItem, string, error) {
+	return stageIntoLibrary(cacheDir, entry, regName, globalDir, true, now)
+}
+
+func stageIntoLibrary(cacheDir string, entry *moat.ContentEntry, regName, globalDir string, keepPrev bool, now time.Time) (catalog.ContentItem, string, error) {
 	if entry == nil {
-		return catalog.ContentItem{}, fmt.Errorf("StageIntoLibrary: entry is nil")
+		return catalog.ContentItem{}, "", fmt.Errorf("StageIntoLibrary: entry is nil")
 	}
 	if cacheDir == "" {
-		return catalog.ContentItem{}, fmt.Errorf("StageIntoLibrary: cacheDir is empty")
+		return catalog.ContentItem{}, "", fmt.Errorf("StageIntoLibrary: cacheDir is empty")
 	}
 	info, err := os.Stat(cacheDir)
 	if err != nil {
-		return catalog.ContentItem{}, fmt.Errorf("StageIntoLibrary: cacheDir %q: %w", cacheDir, err)
+		return catalog.ContentItem{}, "", fmt.Errorf("StageIntoLibrary: cacheDir %q: %w", cacheDir, err)
 	}
 	if !info.IsDir() {
-		return catalog.ContentItem{}, fmt.Errorf("StageIntoLibrary: cacheDir %q is not a directory", cacheDir)
+		return catalog.ContentItem{}, "", fmt.Errorf("StageIntoLibrary: cacheDir %q is not a directory", cacheDir)
 	}
 
 	ct, ok := moat.FromMOATType(entry.Type)
 	if !ok {
-		return catalog.ContentItem{}, fmt.Errorf("StageIntoLibrary: unknown MOAT type %q", entry.Type)
+		return catalog.ContentItem{}, "", fmt.Errorf("StageIntoLibrary: unknown MOAT type %q", entry.Type)
 	}
 
 	destDir := filepath.Join(globalDir, string(ct), entry.Name)
@@ -47,28 +71,42 @@ func StageIntoLibrary(cacheDir string, entry *moat.ContentEntry, regName, global
 
 	meta, err := metadata.Load(destDir)
 	if err != nil {
-		return catalog.ContentItem{}, fmt.Errorf("load library metadata: %w", err)
+		return catalog.ContentItem{}, "", fmt.Errorf("load library metadata: %w", err)
 	}
 	exists, err := pathExists(destDir)
 	if err != nil {
-		return catalog.ContentItem{}, fmt.Errorf("stat library destination: %w", err)
+		return catalog.ContentItem{}, "", fmt.Errorf("stat library destination: %w", err)
 	}
 
+	var prevCopyPath string
 	if exists {
 		if meta != nil && meta.SourceRegistry == regName {
 			if meta.SourceHash == entry.ContentHash {
-				return item, nil
+				return item, "", nil
+			}
+			if keepPrev {
+				prevDir, err := PreviousDirFor(regName, ct, entry.Name)
+				if err != nil {
+					return catalog.ContentItem{}, "", fmt.Errorf("resolve previous dir: %w", err)
+				}
+				if err := os.RemoveAll(prevDir); err != nil {
+					return catalog.ContentItem{}, "", fmt.Errorf("clear existing previous copy: %w", err)
+				}
+				if err := copyDir(destDir, prevDir); err != nil {
+					return catalog.ContentItem{}, "", fmt.Errorf("save previous copy: %w", err)
+				}
+				prevCopyPath = prevDir
 			}
 			if err := os.RemoveAll(destDir); err != nil {
-				return catalog.ContentItem{}, fmt.Errorf("remove existing registry content: %w", err)
+				return catalog.ContentItem{}, "", fmt.Errorf("remove existing registry content: %w", err)
 			}
 		} else {
-			return catalog.ContentItem{}, fmt.Errorf("library already contains %s/%s not sourced from registry %q", string(ct), entry.Name, regName)
+			return catalog.ContentItem{}, "", fmt.Errorf("library already contains %s/%s not sourced from registry %q", string(ct), entry.Name, regName)
 		}
 	}
 
 	if err := copyDir(cacheDir, destDir); err != nil {
-		return catalog.ContentItem{}, fmt.Errorf("stage registry content into library: %w", err)
+		return catalog.ContentItem{}, "", fmt.Errorf("stage registry content into library: %w", err)
 	}
 
 	m := &metadata.Meta{
@@ -82,10 +120,18 @@ func StageIntoLibrary(cacheDir string, entry *moat.ContentEntry, regName, global
 		AddedBy:        "syllago moat install",
 	}
 	if err := metadata.Save(destDir, m); err != nil {
-		return catalog.ContentItem{}, fmt.Errorf("save library metadata: %w", err)
+		return catalog.ContentItem{}, "", fmt.Errorf("save library metadata: %w", err)
 	}
 
-	return item, nil
+	return item, prevCopyPath, nil
+}
+
+// StageIntoLibrary copies a verified MOAT source-cache tree into the global
+// library and writes item metadata attributing it to the registry. Returns a
+// ContentItem rooted at the library dir with Registry set.
+func StageIntoLibrary(cacheDir string, entry *moat.ContentEntry, regName, globalDir string, now time.Time) (catalog.ContentItem, error) {
+	item, _, err := stageIntoLibrary(cacheDir, entry, regName, globalDir, false, now)
+	return item, err
 }
 
 func pathExists(path string) (bool, error) {

--- a/cli/internal/moatinstall/stage_test.go
+++ b/cli/internal/moatinstall/stage_test.go
@@ -277,3 +277,132 @@ func assertFileContent(t *testing.T, path, want string) {
 		t.Fatalf("%s = %q, want %q", path, data, want)
 	}
 }
+
+func TestPreviousDirFor(t *testing.T) {
+	t.Cleanup(func() { PreviousRootOverride = "" })
+
+	// Test with override
+	overrideDir := t.TempDir()
+	PreviousRootOverride = overrideDir
+	path, err := PreviousDirFor("example-reg", catalog.Skills, "test-skill")
+	if err != nil {
+		t.Fatalf("PreviousDirFor failed: %v", err)
+	}
+	wantPath := filepath.Join(overrideDir, "previous", "example-reg", "skills", "test-skill")
+	if path != wantPath {
+		t.Errorf("PreviousDirFor = %q, want %q", path, wantPath)
+	}
+
+	// Test without override
+	PreviousRootOverride = ""
+	path, err = PreviousDirFor("example-reg", catalog.Skills, "test-skill")
+	if err != nil {
+		t.Fatalf("PreviousDirFor failed: %v", err)
+	}
+	suffix := filepath.Join("previous", "example-reg", "skills", "test-skill")
+	if !strings.HasSuffix(path, suffix) {
+		t.Errorf("PreviousDirFor = %q, want suffix %q", path, suffix)
+	}
+}
+
+func TestStageIntoLibraryKeepPrev(t *testing.T) {
+	t.Cleanup(func() { PreviousRootOverride = "" })
+	PreviousRootOverride = t.TempDir()
+
+	globalDir := t.TempDir()
+	now := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+
+	// 1. Fresh install should return prev path "" and no previous dir should be created.
+	cacheV1 := writeStageCache(t, map[string]string{
+		"SKILL.md": "# v1\n",
+	})
+	entry := stageEntry("my-skill", "skill", "sha256:aaaaaaaa", "https://github.com/example/repo")
+	item, prevPath, err := StageIntoLibraryKeepPrev(cacheV1, entry, "example", globalDir, now)
+	if err != nil {
+		t.Fatalf("Fresh install failed: %v", err)
+	}
+	if prevPath != "" {
+		t.Errorf("Fresh install returned non-empty prev path: %q", prevPath)
+	}
+	destDir := filepath.Join(globalDir, "skills", "my-skill")
+	if item.Path != destDir {
+		t.Errorf("staged item path = %q, want %q", item.Path, destDir)
+	}
+	assertFileContent(t, filepath.Join(destDir, "SKILL.md"), "# v1\n")
+
+	// Verify no previous dir exists under our override root yet.
+	if _, err := os.Stat(filepath.Join(PreviousRootOverride, "previous")); !os.IsNotExist(err) {
+		t.Errorf("expected previous/ to not exist, got err: %v", err)
+	}
+
+	// 2. Idempotent same-hash stage should return prev path "" and not create previous dir.
+	_, prevPath, err = StageIntoLibraryKeepPrev(cacheV1, entry, "example", globalDir, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Idempotent stage failed: %v", err)
+	}
+	if prevPath != "" {
+		t.Errorf("Idempotent stage returned non-empty prev path: %q", prevPath)
+	}
+
+	// 3. Replace (v2) with different ContentHash should return a valid prevPath,
+	// which contains v1 files and metadata.
+	cacheV2 := writeStageCache(t, map[string]string{
+		"SKILL.md": "# v2\n",
+	})
+	entry.ContentHash = "sha256:bbbbbbbb"
+	_, prevPath, err = StageIntoLibraryKeepPrev(cacheV2, entry, "example", globalDir, now.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("Replace v2 failed: %v", err)
+	}
+
+	expectedPrevDir, _ := PreviousDirFor("example", catalog.Skills, "my-skill")
+	if prevPath != expectedPrevDir {
+		t.Errorf("Replace v2 returned prevPath = %q, want %q", prevPath, expectedPrevDir)
+	}
+	assertFileContent(t, filepath.Join(prevPath, "SKILL.md"), "# v1\n")
+	assertFileContent(t, filepath.Join(destDir, "SKILL.md"), "# v2\n")
+	// Check that v1 metadata also exists in the saved previous copy
+	meta, err := metadata.Load(prevPath)
+	if err != nil {
+		t.Fatalf("Failed to load metadata from prevPath: %v", err)
+	}
+	if meta == nil || meta.SourceHash != "sha256:aaaaaaaa" {
+		t.Errorf("Metadata in prevPath = %+v, want SourceHash sha256:aaaaaaaa", meta)
+	}
+
+	// 4. Second replace (v3) should overwrite the prev copy with v2, not accumulate.
+	cacheV3 := writeStageCache(t, map[string]string{
+		"SKILL.md":  "# v3\n",
+		"extra.txt": "extra\n",
+	})
+	entry.ContentHash = "sha256:cccccccc"
+	_, prevPath, err = StageIntoLibraryKeepPrev(cacheV3, entry, "example", globalDir, now.Add(3*time.Hour))
+	if err != nil {
+		t.Fatalf("Replace v3 failed: %v", err)
+	}
+	if prevPath != expectedPrevDir {
+		t.Errorf("Replace v3 returned prevPath = %q, want %q", prevPath, expectedPrevDir)
+	}
+	assertFileContent(t, filepath.Join(prevPath, "SKILL.md"), "# v2\n")
+	assertFileContent(t, filepath.Join(destDir, "SKILL.md"), "# v3\n")
+	assertFileContent(t, filepath.Join(destDir, "extra.txt"), "extra\n")
+	// Make sure v1 file from first previous copy is NOT in the second previous copy
+	if _, err := os.Stat(filepath.Join(prevPath, "extra.txt")); !os.IsNotExist(err) {
+		t.Errorf("extra.txt should not exist in prevPath for v2 copy, got err: %v", err)
+	}
+
+	// 5. Normal StageIntoLibrary (the wrapper) replacing a path should NOT create a previous dir.
+	// Clean up PreviousRootOverride to isolate.
+	PreviousRootOverride = t.TempDir()
+	cacheV4 := writeStageCache(t, map[string]string{
+		"SKILL.md": "# v4\n",
+	})
+	entry.ContentHash = "sha256:dddddddd"
+	_, err = StageIntoLibrary(cacheV4, entry, "example", globalDir, now.Add(4*time.Hour))
+	if err != nil {
+		t.Fatalf("Wrapper StageIntoLibrary failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(PreviousRootOverride, "previous")); !os.IsNotExist(err) {
+		t.Errorf("expected wrapper StageIntoLibrary to not create previous/, got err: %v", err)
+	}
+}


### PR DESCRIPTION
Part of #542 item 7 (pin and rollback).

Git-registry items roll back by re-extracting old content from the full-history registry clone. MOAT items have no local history — their staging flow (`StageIntoLibrary`) destroys the outgoing library copy with `os.RemoveAll` when a changed item is re-installed. This PR captures that copy first:

- `moatinstall.StageIntoLibraryKeepPrev` saves the replaced library tree (including `.syllago.yaml`) to `~/.syllago/previous/<registry>/<type>/<name>` before the destructive removal. The location is outside the content root, so the catalog never scans it. Retention is one-step: each save replaces the previous one. A failed save aborts the stage — better to fail the install than silently lose the rollback point.
- `StageIntoLibrary` keeps its exact previous behavior as a thin wrapper over the shared implementation; the TUI still uses it until the TUI wiring chunk.
- The MOAT CLI install path rotates the install record (`installstore.RecordUpdate` with `Previous.CopyPath`) before the normal install bookkeeping, which preserves `Previous` across re-installs. Items that were never installed skip silently.
- `PreviousDirFor` + `PreviousRootOverride` expose the saved-copy location for later chunks (the rollback command) and tests.

Tests: previous-copy save/replace/no-accumulate matrix, fresh-install and same-hash no-ops, wrapper behavior unchanged, end-to-end record rotation with and without an existing install record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)