### PR TITLE
feat(tui): carry source SHA + MOAT undo copy in TUI flows (#542 item 7b-iii)

### DIFF
--- a/cli/internal/tui/actions.go
+++ b/cli/internal/tui/actions.go
@@ -1121,7 +1121,7 @@ func (a App) doMOATInstallCmd(msg installResultMsg) tea.Cmd {
 			return done
 		}
 		now := time.Now()
-		staged, stageErr := moatinstall.StageIntoLibrary(cacheDir, entry, reg.Name, globalDir, now)
+		staged, prevCopy, stageErr := moatinstall.StageIntoLibraryKeepPrev(cacheDir, entry, reg.Name, globalDir, now)
 		if stageErr != nil {
 			done.err = stageErr
 			return done
@@ -1131,6 +1131,9 @@ func (a App) doMOATInstallCmd(msg installResultMsg) tea.Cmd {
 		if installErr != nil {
 			done.err = installErr
 			return done
+		}
+		if prevCopy != "" {
+			recordTUIMOATUpdateBookkeeping(staged, prevCopy)
 		}
 		recordTUIMOATInstallBookkeeping(staged, prov.Slug, placement, &installstore.MOATProvenance{
 			ManifestURI: reg.ManifestURI,
@@ -1361,9 +1364,17 @@ func (a App) handleLibraryAdd(item *catalog.ContentItem, installAfter bool) (tea
 			di.Description = itemCopy.Description
 		}
 
+		sourceSHA := ""
+		if itemCopy.Registry != "" {
+			if head, err := registry.Head(itemCopy.Registry); err == nil {
+				sourceSHA = head
+			}
+		}
+
 		opts := add.AddOptions{
 			Force:          false,
 			SourceRegistry: itemCopy.Registry,
+			SourceSHA:      sourceSHA,
 		}
 		results := add.AddItems([]add.DiscoveryItem{di}, opts, contentRoot, nil, "syllago")
 		if len(results) == 0 {

--- a/cli/internal/tui/add_wizard.go
+++ b/cli/internal/tui/add_wizard.go
@@ -22,6 +22,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/installer"
 	"github.com/OpenScribbler/syllago/cli/internal/metadata"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
 )
 
 // --- Step enum ---
@@ -120,9 +121,10 @@ type addDiscoveryDoneMsg struct {
 }
 
 type addExecItemDoneMsg struct {
-	seq    int
-	index  int
-	result addExecResult
+	seq       int
+	index     int
+	result    addExecResult
+	sourceSHA string
 }
 
 type addExecAllDoneMsg struct {
@@ -262,12 +264,14 @@ type addWizardModel struct {
 	renameDiscoveryIdx int // index into m.discoveredItems the modal is editing
 
 	// Execute step
-	executeResults   []addExecResult
-	executeCurrent   int
-	executeOffset    int
-	executeDone      bool
-	executeCancelled bool
-	executing        bool
+	executeResults    []addExecResult
+	executeCurrent    int
+	executeOffset     int
+	executeDone       bool
+	executeCancelled  bool
+	executing         bool
+	executeSourceSHA  string
+	executeResolveSHA bool
 
 	// Git source
 	gitTempDir string
@@ -1417,7 +1421,21 @@ func (m *addWizardModel) enterExecute() {
 	m.executeDone = false
 	m.executeCancelled = false
 	m.executing = true
+	m.executeSourceSHA = ""
+	m.executeResolveSHA = m.sourceRegistry != "" && addWizardRegistryIsGit(m.cfg, m.sourceRegistry)
 	m.updateMaxStep()
+}
+
+func addWizardRegistryIsGit(cfg *config.Config, name string) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, reg := range cfg.Registries {
+		if reg.Name == name {
+			return reg.IsGit()
+		}
+	}
+	return false
 }
 
 // startDiscoveryCmd creates an async tea.Cmd to discover content from the selected source.
@@ -1694,6 +1712,8 @@ func (m *addWizardModel) addItemCmd(index int) tea.Cmd {
 	contentRoot := m.contentRoot
 	sourceReg := m.sourceRegistry
 	sourceVis := m.sourceVisibility
+	sourceSHA := m.executeSourceSHA
+	resolveSHA := index == 0 && m.executeResolveSHA
 	source := m.source
 	provSlug := ""
 	if source == addSourceProvider && m.providerCursor < len(m.providers) {
@@ -1701,8 +1721,13 @@ func (m *addWizardModel) addItemCmd(index int) tea.Cmd {
 	}
 
 	return func() tea.Msg {
-		result := addSingleItem(item, contentRoot, sourceReg, sourceVis, provSlug)
-		return addExecItemDoneMsg{seq: seq, index: index, result: result}
+		if resolveSHA {
+			if head, err := registry.Head(sourceReg); err == nil {
+				sourceSHA = head
+			}
+		}
+		result := addSingleItem(item, contentRoot, sourceReg, sourceVis, provSlug, sourceSHA)
+		return addExecItemDoneMsg{seq: seq, index: index, result: result, sourceSHA: sourceSHA}
 	}
 }
 
@@ -2495,7 +2520,7 @@ func discoverFromGitURL(
 }
 
 // addSingleItem adds a single item to the library.
-func addSingleItem(item addDiscoveryItem, contentRoot, srcReg, srcVis, provSlug string) addExecResult {
+func addSingleItem(item addDiscoveryItem, contentRoot, srcReg, srcVis, provSlug, srcSHA string) addExecResult {
 	if item.underlying == nil {
 		return addExecResult{
 			name:   item.name,
@@ -2510,7 +2535,7 @@ func addSingleItem(item addDiscoveryItem, contentRoot, srcReg, srcVis, provSlug 
 	// hook.json. Instead, serialize the parsed HookData directly. Mirrors
 	// cli/cmd/syllago/add_cmd.go addHooksFromLocation.
 	if item.itemType == catalog.Hooks && item.hookData != nil {
-		return writeHookToLibrary(item, contentRoot, srcReg, srcVis, provSlug)
+		return writeHookToLibrary(item, contentRoot, srcReg, srcVis, provSlug, srcSHA)
 	}
 
 	// Auto-split branch (P4 of syllago-50wq4): a rule item whose source file
@@ -2525,6 +2550,7 @@ func addSingleItem(item addDiscoveryItem, contentRoot, srcReg, srcVis, provSlug 
 		Force:            item.overwrite,
 		Provider:         provSlug,
 		SourceRegistry:   srcReg,
+		SourceSHA:        srcSHA,
 		SourceVisibility: srcVis,
 	}
 
@@ -2547,6 +2573,7 @@ func addSingleItem(item addDiscoveryItem, contentRoot, srcReg, srcVis, provSlug 
 	case add.AddStatusAdded:
 		return addExecResult{name: item.name, status: "added"}
 	case add.AddStatusUpdated:
+		recordTUIAddUpdateBookkeeping(srcReg, string(item.itemType), item.name, "", srcSHA)
 		return addExecResult{name: item.name, status: "updated"}
 	case add.AddStatusUpToDate:
 		return addExecResult{name: item.name, status: "skipped"}
@@ -2562,7 +2589,7 @@ func addSingleItem(item addDiscoveryItem, contentRoot, srcReg, srcVis, provSlug 
 // writeHookToLibrary serializes a HookData to ~/.syllago/hooks/<provider>/<name>/hook.json,
 // bundles any referenced scripts into the same directory, and writes .syllago.yaml
 // metadata. Mirrors addHooksFromLocation in cli/cmd/syllago/add_cmd.go.
-func writeHookToLibrary(item addDiscoveryItem, contentRoot, srcReg, srcVis, provSlug string) addExecResult {
+func writeHookToLibrary(item addDiscoveryItem, contentRoot, srcReg, srcVis, provSlug, srcSHA string) addExecResult {
 	itemDir := filepath.Join(contentRoot, string(catalog.Hooks), provSlug, item.name)
 
 	if !item.overwrite {
@@ -2623,6 +2650,7 @@ func writeHookToLibrary(item addDiscoveryItem, contentRoot, srcReg, srcVis, prov
 	}
 	if srcReg != "" {
 		meta.SourceType = "registry"
+		meta.SourceSHA = srcSHA
 	}
 	if err := metadata.Save(itemDir, meta); err != nil {
 		return addExecResult{name: item.name, status: "error", err: fmt.Errorf("writing metadata: %w", err)}

--- a/cli/internal/tui/add_wizard_hook_write_test.go
+++ b/cli/internal/tui/add_wizard_hook_write_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/converter"
+	"github.com/OpenScribbler/syllago/cli/internal/metadata"
 )
 
 // TestWriteHookToLibrary_WritesManifestHookJSON is a regression test for the bug
@@ -34,7 +35,7 @@ func TestWriteHookToLibrary_WritesManifestHookJSON(t *testing.T) {
 		hookSourceDir: "",
 	}
 
-	result := writeHookToLibrary(item, contentRoot, "", "", "claude-code")
+	result := writeHookToLibrary(item, contentRoot, "", "", "claude-code", "")
 	if result.status != "added" {
 		t.Fatalf("expected status=added, got %q err=%v", result.status, result.err)
 	}
@@ -106,8 +107,38 @@ func TestWriteHookToLibrary_SkipsExisting(t *testing.T) {
 		overwrite: false,
 	}
 
-	result := writeHookToLibrary(item, contentRoot, "", "", "claude-code")
+	result := writeHookToLibrary(item, contentRoot, "", "", "claude-code", "")
 	if result.status != "skipped" {
 		t.Errorf("expected skipped for existing dir without overwrite, got %q", result.status)
+	}
+}
+
+func TestWriteHookToLibrary_StampsRegistrySourceSHA(t *testing.T) {
+	contentRoot := t.TempDir()
+	hook := converter.HookData{
+		Event: "before_tool_execute",
+		Hooks: []converter.HookEntry{{Type: "command", Command: "echo hi"}},
+	}
+	item := addDiscoveryItem{
+		name:     "my-hook",
+		itemType: catalog.Hooks,
+		scope:    "global",
+		hookData: &hook,
+	}
+
+	result := writeHookToLibrary(item, contentRoot, "acme/tools", "private", "claude-code", "sha-from-registry")
+	if result.status != "added" {
+		t.Fatalf("expected status=added, got %q err=%v", result.status, result.err)
+	}
+
+	meta, err := metadata.Load(filepath.Join(contentRoot, string(catalog.Hooks), "claude-code", "my-hook"))
+	if err != nil {
+		t.Fatalf("Load metadata: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("metadata missing")
+	}
+	if meta.SourceRegistry != "acme/tools" || meta.SourceSHA != "sha-from-registry" {
+		t.Fatalf("registry provenance = registry %q sha %q, want acme/tools sha-from-registry", meta.SourceRegistry, meta.SourceSHA)
 	}
 }

--- a/cli/internal/tui/add_wizard_rename_test.go
+++ b/cli/internal/tui/add_wizard_rename_test.go
@@ -611,7 +611,7 @@ func TestWriteHookToLibrary_HonorsDisplayNameAndDescription(t *testing.T) {
 		hookData:    &hook,
 	}
 
-	result := writeHookToLibrary(item, contentRoot, "", "", "claude-code")
+	result := writeHookToLibrary(item, contentRoot, "", "", "claude-code", "")
 	if result.status != "added" {
 		t.Fatalf("expected status=added, got %q err=%v", result.status, result.err)
 	}

--- a/cli/internal/tui/add_wizard_update.go
+++ b/cli/internal/tui/add_wizard_update.go
@@ -1334,6 +1334,9 @@ func (m *addWizardModel) handleExecItemDone(msg addExecItemDoneMsg) (*addWizardM
 	if msg.index < len(m.executeResults) {
 		m.executeResults[msg.index] = msg.result
 	}
+	if msg.index == 0 {
+		m.executeSourceSHA = msg.sourceSHA
+	}
 	m.executeCurrent = msg.index + 1
 
 	if next := m.nextPending(); next >= 0 && !m.executeCancelled {

--- a/cli/internal/tui/installrecord.go
+++ b/cli/internal/tui/installrecord.go
@@ -15,7 +15,9 @@ func recordTUIInstallBookkeeping(item catalog.ContentItem, provSlug string, pl i
 	}
 	// The TUI has no stable stderr surface mid-render; install-state
 	// bookkeeping is best-effort and must not disturb the Elm loop.
-	_ = installstore.RecordInstall(storePath, tuiInstallRecordCoord(item), item.Path, tuiInstallRecordPlacement(provSlug, pl), time.Now())
+	_ = installstore.RecordInstallMeta(storePath, tuiInstallRecordCoord(item), item.Path, tuiInstallRecordPlacement(provSlug, pl), installstore.InstallMeta{
+		SourceSHA: tuiInstallRecordSourceSHA(item),
+	}, time.Now())
 }
 
 func recordTUIMOATInstallBookkeeping(item catalog.ContentItem, provSlug string, pl installer.Placement, moatProv *installstore.MOATProvenance) {
@@ -25,7 +27,52 @@ func recordTUIMOATInstallBookkeeping(item catalog.ContentItem, provSlug string, 
 	}
 	// The TUI has no stable stderr surface mid-render; install-state
 	// bookkeeping is best-effort and must not disturb the Elm loop.
-	_ = installstore.RecordInstallMOAT(storePath, tuiInstallRecordCoord(item), item.Path, tuiInstallRecordPlacement(provSlug, pl), moatProv, time.Now())
+	_ = installstore.RecordInstallMeta(storePath, tuiInstallRecordCoord(item), item.Path, tuiInstallRecordPlacement(provSlug, pl), installstore.InstallMeta{
+		MOAT:      moatProv,
+		SourceSHA: tuiInstallRecordSourceSHA(item),
+	}, time.Now())
+}
+
+func recordTUIAddUpdateBookkeeping(regName, contentType, name, libraryFallbackPath, sourceSHA string) {
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		return
+	}
+	store, err := installstore.Load(storePath)
+	if err != nil {
+		return
+	}
+	coord := installstore.Coord{Registry: regName, Type: contentType, Name: name}
+	rec := store.Find(coord)
+	if rec == nil {
+		return
+	}
+	libraryPath := rec.LibraryPath
+	if libraryPath == "" {
+		libraryPath = libraryFallbackPath
+	}
+	// The TUI has no stable stderr surface mid-render; install-state
+	// bookkeeping is best-effort and must not disturb the Elm loop.
+	_ = installstore.RecordUpdate(storePath, coord, libraryPath, sourceSHA, "", time.Now())
+}
+
+func recordTUIMOATUpdateBookkeeping(item catalog.ContentItem, prevCopyPath string) {
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		return
+	}
+	store, err := installstore.Load(storePath)
+	if err != nil {
+		return
+	}
+	coord := tuiInstallRecordCoord(item)
+	rec := store.Find(coord)
+	if rec == nil {
+		return
+	}
+	// The TUI has no stable stderr surface mid-render; install-state
+	// bookkeeping is best-effort and must not disturb the Elm loop.
+	_ = installstore.RecordUpdate(storePath, coord, rec.LibraryPath, "", prevCopyPath, time.Now())
 }
 
 func recordTUIUninstallBookkeeping(item catalog.ContentItem, provSlug string, pl installer.Placement) {
@@ -67,4 +114,11 @@ func tuiInstallRecordPlacement(provSlug string, pl installer.Placement) installs
 		Path:      pl.Path,
 		Keys:      pl.Keys,
 	}
+}
+
+func tuiInstallRecordSourceSHA(item catalog.ContentItem) string {
+	if item.Meta == nil {
+		return ""
+	}
+	return item.Meta.SourceSHA
 }

--- a/cli/internal/tui/installrecord_test.go
+++ b/cli/internal/tui/installrecord_test.go
@@ -1,11 +1,193 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/OpenScribbler/syllago/cli/internal/add"
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
 	"github.com/OpenScribbler/syllago/cli/internal/metadata"
 )
+
+func TestRecordTUIInstallBookkeepingCarriesSourceSHA(t *testing.T) {
+	configDir := withTUIInstallRecordConfigDir(t)
+
+	libraryPath := filepath.Join(t.TempDir(), "skills", "writer")
+	writeTUITestFile(t, filepath.Join(libraryPath, "SKILL.md"), []byte("# Writer\n"))
+
+	item := catalog.ContentItem{
+		Name: "writer",
+		Type: catalog.Skills,
+		Path: libraryPath,
+		Meta: &metadata.Meta{
+			SourceType:     "registry",
+			SourceRegistry: "acme/tools",
+			SourceSHA:      "sha-from-meta",
+		},
+	}
+	placement := installer.Placement{
+		Mechanism: installer.MechanismSymlink,
+		Path:      filepath.Join(t.TempDir(), "writer"),
+	}
+
+	recordTUIInstallBookkeeping(item, "claude-code", placement)
+
+	store := mustLoadTUIInstallRecordStore(t, configDir)
+	coord := installstore.Coord{Registry: "acme/tools", Type: string(catalog.Skills), Name: "writer"}
+	rec := store.Find(coord)
+	if rec == nil {
+		t.Fatal("install record missing")
+	}
+	if rec.SourceSHA != "sha-from-meta" {
+		t.Fatalf("SourceSHA = %q, want sha-from-meta", rec.SourceSHA)
+	}
+}
+
+func TestRecordTUIAddUpdateBookkeepingRotatesExistingRecord(t *testing.T) {
+	configDir := withTUIInstallRecordConfigDir(t)
+	storePath := filepath.Join(configDir, "installs.json")
+	libraryPath := filepath.Join(t.TempDir(), "skills", "writer")
+	writeTUITestFile(t, filepath.Join(libraryPath, "SKILL.md"), []byte("# Writer\n"))
+
+	coord := installstore.Coord{Registry: "acme/tools", Type: string(catalog.Skills), Name: "writer"}
+	if err := installstore.RecordInstallMeta(storePath, coord, libraryPath, installstore.PlacementInput{
+		Provider:  "claude-code",
+		Mechanism: installstore.MechanismSymlink,
+		Path:      filepath.Join(t.TempDir(), "writer"),
+	}, installstore.InstallMeta{SourceSHA: "sha-old"}, time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("seed RecordInstallMeta: %v", err)
+	}
+	oldHash := mustHashTUIInstallContent(t, libraryPath)
+	writeTUITestFile(t, filepath.Join(libraryPath, "SKILL.md"), []byte("# Writer updated\n"))
+
+	recordTUIAddUpdateBookkeeping("acme/tools", string(catalog.Skills), "writer", "", "sha-new")
+
+	rec := mustLoadTUIInstallRecordStore(t, configDir).Find(coord)
+	if rec == nil {
+		t.Fatal("install record missing")
+	}
+	if rec.SourceSHA != "sha-new" {
+		t.Fatalf("SourceSHA = %q, want sha-new", rec.SourceSHA)
+	}
+	if rec.Previous == nil {
+		t.Fatal("Previous is nil")
+	}
+	if rec.Previous.SourceSHA != "sha-old" {
+		t.Fatalf("Previous.SourceSHA = %q, want sha-old", rec.Previous.SourceSHA)
+	}
+	if rec.Previous.ContentHash != oldHash {
+		t.Fatalf("Previous.ContentHash = %q, want %q", rec.Previous.ContentHash, oldHash)
+	}
+	if rec.Previous.CopyPath != "" {
+		t.Fatalf("Previous.CopyPath = %q, want empty", rec.Previous.CopyPath)
+	}
+}
+
+func TestRecordTUIAddUpdateBookkeepingMissingRecordDoesNotCreateStore(t *testing.T) {
+	configDir := withTUIInstallRecordConfigDir(t)
+	storePath := filepath.Join(configDir, "installs.json")
+
+	recordTUIAddUpdateBookkeeping("acme/tools", string(catalog.Skills), "writer", "", "sha-new")
+
+	if _, err := os.Stat(storePath); !os.IsNotExist(err) {
+		t.Fatalf("store file exists or stat failed: %v", err)
+	}
+}
+
+func TestRecordTUIMOATUpdateBookkeepingSetsPreviousCopyPath(t *testing.T) {
+	configDir := withTUIInstallRecordConfigDir(t)
+	storePath := filepath.Join(configDir, "installs.json")
+	libraryPath := filepath.Join(t.TempDir(), "skills", "writer")
+	writeTUITestFile(t, filepath.Join(libraryPath, "SKILL.md"), []byte("# Writer\n"))
+
+	coord := installstore.Coord{Registry: "acme/moat", Type: string(catalog.Skills), Name: "writer"}
+	if err := installstore.RecordInstallMeta(storePath, coord, libraryPath, installstore.PlacementInput{
+		Provider:  "claude-code",
+		Mechanism: installstore.MechanismSymlink,
+		Path:      filepath.Join(t.TempDir(), "writer"),
+	}, installstore.InstallMeta{}, time.Date(2026, 8, 24, 11, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("seed RecordInstallMeta: %v", err)
+	}
+	writeTUITestFile(t, filepath.Join(libraryPath, "SKILL.md"), []byte("# Writer updated\n"))
+	prevCopyPath := filepath.Join(t.TempDir(), "previous", "writer")
+
+	recordTUIMOATUpdateBookkeeping(catalog.ContentItem{
+		Name:     "writer",
+		Type:     catalog.Skills,
+		Path:     libraryPath,
+		Registry: "acme/moat",
+	}, prevCopyPath)
+
+	rec := mustLoadTUIInstallRecordStore(t, configDir).Find(coord)
+	if rec == nil {
+		t.Fatal("install record missing")
+	}
+	if rec.Previous == nil {
+		t.Fatal("Previous is nil")
+	}
+	if rec.Previous.CopyPath != prevCopyPath {
+		t.Fatalf("Previous.CopyPath = %q, want %q", rec.Previous.CopyPath, prevCopyPath)
+	}
+}
+
+func TestAddSingleItemOverwriteRotatesInstallRecord(t *testing.T) {
+	configDir := withTUIInstallRecordConfigDir(t)
+	storePath := filepath.Join(configDir, "installs.json")
+	contentRoot := t.TempDir()
+	libraryPath := filepath.Join(contentRoot, string(catalog.Skills), "writer")
+	writeTUITestFile(t, filepath.Join(libraryPath, "SKILL.md"), []byte("# Writer\n"))
+
+	coord := installstore.Coord{Registry: "acme/tools", Type: string(catalog.Skills), Name: "writer"}
+	if err := installstore.RecordInstallMeta(storePath, coord, libraryPath, installstore.PlacementInput{
+		Provider:  "claude-code",
+		Mechanism: installstore.MechanismSymlink,
+		Path:      filepath.Join(t.TempDir(), "writer"),
+	}, installstore.InstallMeta{SourceSHA: "sha-old"}, time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("seed RecordInstallMeta: %v", err)
+	}
+	oldHash := mustHashTUIInstallContent(t, libraryPath)
+
+	sourcePath := filepath.Join(t.TempDir(), "SKILL.md")
+	writeTUITestFile(t, sourcePath, []byte("# Writer updated\n"))
+	item := addDiscoveryItem{
+		name:      "writer",
+		itemType:  catalog.Skills,
+		overwrite: true,
+		underlying: &add.DiscoveryItem{
+			Name:   "writer",
+			Type:   catalog.Skills,
+			Path:   sourcePath,
+			Status: add.StatusOutdated,
+		},
+	}
+
+	result := addSingleItem(item, contentRoot, "acme/tools", "private", "", "sha-new")
+	if result.status != "updated" {
+		t.Fatalf("status = %q err=%v, want updated", result.status, result.err)
+	}
+
+	rec := mustLoadTUIInstallRecordStore(t, configDir).Find(coord)
+	if rec == nil {
+		t.Fatal("install record missing")
+	}
+	if rec.SourceSHA != "sha-new" {
+		t.Fatalf("SourceSHA = %q, want sha-new", rec.SourceSHA)
+	}
+	if rec.Previous == nil {
+		t.Fatal("Previous is nil")
+	}
+	if rec.Previous.SourceSHA != "sha-old" {
+		t.Fatalf("Previous.SourceSHA = %q, want sha-old", rec.Previous.SourceSHA)
+	}
+	if rec.Previous.ContentHash != oldHash {
+		t.Fatalf("Previous.ContentHash = %q, want %q", rec.Previous.ContentHash, oldHash)
+	}
+}
 
 func TestTUIInstallRecordCoordRegistryFallback(t *testing.T) {
 	t.Parallel()
@@ -55,4 +237,41 @@ func TestTUIInstallRecordCoordRegistryFallback(t *testing.T) {
 			}
 		})
 	}
+}
+
+func withTUIInstallRecordConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := config.GlobalDirOverride
+	config.GlobalDirOverride = dir
+	t.Cleanup(func() { config.GlobalDirOverride = orig })
+	return dir
+}
+
+func writeTUITestFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+}
+
+func mustLoadTUIInstallRecordStore(t *testing.T, configDir string) *installstore.Store {
+	t.Helper()
+	store, err := installstore.Load(filepath.Join(configDir, "installs.json"))
+	if err != nil {
+		t.Fatalf("Load install store: %v", err)
+	}
+	return store
+}
+
+func mustHashTUIInstallContent(t *testing.T, path string) string {
+	t.Helper()
+	hash, err := installstore.HashContent(path)
+	if err != nil {
+		t.Fatalf("HashContent(%s): %v", path, err)
+	}
+	return hash
 }


### PR DESCRIPTION
Part of #542 item 7 (pin and rollback) — TUI wiring chunk 7b-iii.

Brings the TUI install/add paths to parity with the CLI provenance chain:

- `recordTUIInstallBookkeeping` / `recordTUIMOATInstallBookkeeping` switch to `installstore.RecordInstallMeta`, carrying `item.Meta.SourceSHA` into install records.
- New silent best-effort helpers `recordTUIAddUpdateBookkeeping` and `recordTUIMOATUpdateBookkeeping` rotate `Record.Previous` on update paths.
- MOAT install (actions.go) switches to `moatinstall.StageIntoLibraryKeepPrev`; when a previous copy was saved, the record is rotated before re-recording (mirrors the CLI ordering in `install_moat.go`).
- The registry-clone library add stamps best-effort `registry.Head` as `SourceSHA`.
- The add wizard resolves git-registry HEAD once per batch in the execute flow, passes `SourceSHA` through `addSingleItem`/`writeHookToLibrary`, and rotates records on `AddStatusUpdated`.

Mechanical wiring only — no new UI, no keybinds, no visual changes; no golden diffs.

Tests: new unit tests in `installrecord_test.go` (SourceSHA carry, rotation, missing-record no-op, MOAT CopyPath, addSingleItem overwrite rotation) and `add_wizard_hook_write_test.go` (hook metadata SourceSHA stamp). Full suite green locally; wizard invariant suite passes with no golden updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)