### PR TITLE
feat(cli): one-step rollback command via git worktree + MOAT undo copy (#542 item 7e)

### DIFF
--- a/cli/cmd/syllago/rollback_cmd.go
+++ b/cli/cmd/syllago/rollback_cmd.go
@@ -1,0 +1,465 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/add"
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
+	"github.com/OpenScribbler/syllago/cli/internal/rulestore"
+	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+type rollbackResult struct {
+	Name                string `json:"name"`
+	Type                string `json:"type"`
+	Registry            string `json:"registry"`
+	RestoredSourceSHA   string `json:"restored_source_sha,omitempty"`
+	RestoredFromCopy    bool   `json:"restored_from_copy"`
+	PlacementsReapplied int    `json:"placements_reapplied"`
+}
+
+var rollbackCmd = &cobra.Command{
+	Use:   "rollback <name>",
+	Short: "Restore the previous installed library version",
+	Long: `Restores a registry-sourced library item to its one-step rollback point.
+
+Rollback is available after an update replaces an installed item. It works for
+pinned items because rollback is an explicit user action.`,
+	Example: `  # Roll back a skill to the previous version
+  syllago rollback my-skill
+
+  # Disambiguate by type
+  syllago rollback shared-context --type skills
+
+  # Preview the rollback source without changing files
+  syllago rollback my-skill --dry-run`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRollback,
+}
+
+func init() {
+	rollbackCmd.Flags().String("type", "", "Disambiguate when name exists in multiple types")
+	rollbackCmd.Flags().Bool("dry-run", false, "Show what would happen without making changes")
+	rootCmd.AddCommand(rollbackCmd)
+}
+
+func runRollback(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	typeFilter, _ := cmd.Flags().GetString("type")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+	item, err := resolveRollbackLibraryItem(name, typeFilter)
+	if err != nil {
+		return err
+	}
+	telemetry.Enrich("content_type", string(item.Type))
+	telemetry.Enrich("dry_run", dryRun)
+
+	if item.Meta == nil || item.Meta.SourceRegistry == "" {
+		return output.NewStructuredError(
+			output.ErrInputInvalid,
+			fmt.Sprintf("%s/%s is not registry-sourced", item.Type, item.Name),
+			"Rollback needs an item installed from a registry update.",
+		)
+	}
+
+	storePath, rec, coord, err := loadRollbackRecord(*item)
+	if err != nil {
+		return err
+	}
+	prev := rec.Previous
+	if prev == nil || prev.SourceSHA == "" && prev.CopyPath == "" {
+		return noRollbackDataError(coord)
+	}
+
+	result := rollbackResult{
+		Name:     item.Name,
+		Type:     string(item.Type),
+		Registry: coord.Registry,
+	}
+	if prev.CopyPath != "" {
+		result.RestoredFromCopy = true
+	} else {
+		result.RestoredSourceSHA = prev.SourceSHA
+	}
+
+	if dryRun {
+		if output.JSON {
+			output.Print(result)
+			return nil
+		}
+		printRollbackDryRunPlan(*item, prev)
+		return nil
+	}
+
+	placements := append([]installstore.Placement(nil), rec.Placements...)
+
+	if prev.CopyPath != "" {
+		if err := restoreFromPreviousCopy(rec.LibraryPath, prev.CopyPath); err != nil {
+			return err
+		}
+	} else {
+		if err := restoreFromGitPrevious(*item, rec.LibraryPath, coord.Registry, prev.SourceSHA); err != nil {
+			return err
+		}
+	}
+
+	if err := installstore.RecordRollback(storePath, coord, rec.LibraryPath, time.Now()); err != nil {
+		return output.NewStructuredErrorDetail(
+			output.ErrSystemIO,
+			"content was restored but install record rollback failed",
+			"Inspect the library item and install record before running another update.",
+			err.Error(),
+		)
+	}
+
+	var reappliedPlacements []installstore.Placement
+	restoredItem, err := resolveRollbackLibraryItem(item.Name, string(item.Type))
+	if err != nil {
+		fmt.Fprintf(output.ErrWriter, "warning: could not reload restored item for placement re-apply: %v\n", err)
+	} else {
+		reappliedPlacements = reapplyRollbackPlacements(*restoredItem, placements)
+		result.PlacementsReapplied = len(reappliedPlacements)
+	}
+
+	if output.JSON {
+		output.Print(result)
+		return nil
+	}
+	if output.Quiet {
+		return nil
+	}
+	if result.RestoredFromCopy {
+		fmt.Fprintf(output.Writer, "Rolled back %s/%s to previous version\n", item.Type, item.Name)
+	} else {
+		fmt.Fprintf(output.Writer, "Rolled back %s/%s to %s\n", item.Type, item.Name, shortSHA(prev.SourceSHA))
+	}
+	for _, pl := range reappliedPlacements {
+		fmt.Fprintf(output.Writer, "Re-applied %s placement for %s\n", pl.Mechanism, pl.Provider)
+	}
+	return nil
+}
+
+func resolveRollbackLibraryItem(name, typeFilter string) (*catalog.ContentItem, error) {
+	emptyRoot, err := os.MkdirTemp("", "syllago-rollback-*")
+	if err != nil {
+		return nil, output.NewStructuredErrorDetail(output.ErrSystemIO, "creating temp dir failed", "Check filesystem permissions and disk space", err.Error())
+	}
+	defer func() { _ = os.RemoveAll(emptyRoot) }()
+
+	cat, err := catalog.ScanWithGlobalAndRegistries(emptyRoot, emptyRoot, nil)
+	if err != nil {
+		return nil, output.NewStructuredErrorDetail(output.ErrCatalogScanFailed, "scanning library failed", "Check that ~/.syllago/content/ exists and is readable", err.Error())
+	}
+	return findLibraryItem(cat, name, typeFilter)
+}
+
+func loadRollbackRecord(item catalog.ContentItem) (string, *installstore.Record, installstore.Coord, error) {
+	coord := installstore.Coord{
+		Registry: item.Meta.SourceRegistry,
+		Type:     string(item.Type),
+		Name:     item.Name,
+	}
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		return "", nil, coord, output.NewStructuredErrorDetail(output.ErrSystemHomedir, "install record path unavailable", "Set the HOME environment variable", err.Error())
+	}
+	if _, err := os.Stat(storePath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil, coord, noInstallRecordError(coord)
+		}
+		return "", nil, coord, output.NewStructuredErrorDetail(output.ErrSystemIO, "checking install record store failed", "Check ~/.syllago/installs.json permissions", err.Error())
+	}
+	store, err := installstore.Load(storePath)
+	if err != nil {
+		return "", nil, coord, output.NewStructuredErrorDetail(output.ErrSystemIO, "loading install record store failed", "Check ~/.syllago/installs.json syntax and permissions", err.Error())
+	}
+	rec := store.Find(coord)
+	if rec == nil {
+		return "", nil, coord, noInstallRecordError(coord)
+	}
+	return storePath, rec, coord, nil
+}
+
+func noInstallRecordError(c installstore.Coord) error {
+	return output.NewStructuredError(
+		output.ErrInstallNotInstalled,
+		fmt.Sprintf("no install record for %s/%s", c.Type, c.Name),
+		"Rollback needs an installed item with update history.",
+	)
+}
+
+func noRollbackDataError(c installstore.Coord) error {
+	return output.NewStructuredError(
+		output.ErrInstallConflict,
+		fmt.Sprintf("no rollback data for %s/%s", c.Type, c.Name),
+		"Rollback is one-step: it becomes available after an update replaces the item.",
+	)
+}
+
+func printRollbackDryRunPlan(item catalog.ContentItem, prev *installstore.PreviousVersion) {
+	if output.Quiet && !output.JSON {
+		return
+	}
+	if prev.CopyPath != "" {
+		when := "unknown date"
+		if !prev.ReplacedAt.IsZero() {
+			when = prev.ReplacedAt.Format("2006-01-02")
+		}
+		fmt.Fprintf(output.Writer, "would roll back %s/%s to saved copy from %s\n", item.Type, item.Name, when)
+		return
+	}
+	fmt.Fprintf(output.Writer, "would roll back %s/%s to %s\n", item.Type, item.Name, shortSHA(prev.SourceSHA))
+}
+
+func restoreFromPreviousCopy(libraryPath, copyPath string) error {
+	info, err := os.Stat(copyPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return output.NewStructuredError(
+				output.ErrInstallConflict,
+				fmt.Sprintf("saved previous copy is gone: %s", copyPath),
+				"Rollback copy data is local and one-step; restore from backup or re-add the item from its registry.",
+			)
+		}
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, "checking saved previous copy failed", "Check filesystem permissions", err.Error())
+	}
+	if !info.IsDir() {
+		return output.NewStructuredError(output.ErrInstallConflict, fmt.Sprintf("saved previous copy is not a directory: %s", copyPath), "Rollback copy data must be an intact directory tree.")
+	}
+	if err := os.RemoveAll(libraryPath); err != nil {
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, "removing current library item failed", "Check permissions in ~/.syllago/content/", err.Error())
+	}
+	if err := copyTree(copyPath, libraryPath); err != nil {
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, "restoring saved previous copy failed", "Check permissions in ~/.syllago/content/ and the saved rollback copy.", err.Error())
+	}
+	return nil
+}
+
+func restoreFromGitPrevious(item catalog.ContentItem, libraryPath, regName, sha string) error {
+	globalDir := catalog.GlobalContentDir()
+	if globalDir == "" {
+		return output.NewStructuredError(output.ErrSystemHomedir, "cannot determine home directory", "Set the HOME environment variable")
+	}
+	worktreeDir, cleanup, err := registry.WorktreeAt(regName, sha)
+	if err != nil {
+		return output.NewStructuredErrorDetail(
+			output.ErrRegistrySyncFailed,
+			fmt.Sprintf("could not materialize rollback source %s", shortSHA(sha)),
+			"Run 'syllago registry sync "+regName+"' or restore the registry clone with full history.",
+			err.Error(),
+		)
+	}
+	defer cleanup()
+
+	items, err := add.DiscoverFromRegistry(regName, worktreeDir, globalDir)
+	if err != nil {
+		return output.NewStructuredErrorDetail(output.ErrCatalogScanFailed, "scanning rollback registry checkout failed", "Check registry contents at the rollback commit.", err.Error())
+	}
+	var match *add.DiscoveryItem
+	for i := range items {
+		if items[i].Type == item.Type && items[i].Name == item.Name {
+			match = &items[i]
+			break
+		}
+	}
+	if match == nil {
+		return output.NewStructuredError(
+			output.ErrItemNotFound,
+			fmt.Sprintf("item did not exist at %s", shortSHA(sha)),
+			"Rollback can only restore items present at the recorded previous registry commit.",
+		)
+	}
+
+	sourceProvider := item.Provider
+	sourceVisibility := ""
+	if item.Meta != nil {
+		if sourceProvider == "" {
+			sourceProvider = item.Meta.SourceProvider
+		}
+		sourceVisibility = item.Meta.SourceVisibility
+	}
+	results := add.AddItems([]add.DiscoveryItem{*match}, add.AddOptions{
+		Force:            true,
+		Provider:         sourceProvider,
+		SourceRegistry:   regName,
+		SourceSHA:        sha,
+		SourceVisibility: sourceVisibility,
+	}, globalDir, nil, version)
+	if len(results) != 1 {
+		return output.NewStructuredError(output.ErrSystemIO, fmt.Sprintf("restoring %s/%s failed", item.Type, item.Name), "The rollback restore did not produce a result.")
+	}
+	if results[0].Status == add.AddStatusError {
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, fmt.Sprintf("restoring %s/%s failed", item.Type, item.Name), "Check registry item contents and library permissions.", results[0].Error.Error())
+	}
+	if _, err := os.Stat(libraryPath); err != nil {
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, "restored library item is missing", "The registry restore completed but the expected library path was not found.", err.Error())
+	}
+	return nil
+}
+
+func reapplyRollbackPlacements(item catalog.ContentItem, placements []installstore.Placement) []installstore.Placement {
+	projectRoot, projectErr := findProjectRoot()
+	var reapplied []installstore.Placement
+	for _, pl := range placements {
+		if !shouldReapplyPlacement(pl.Mechanism) {
+			continue
+		}
+		if projectErr != nil {
+			warnRollbackPlacement(pl, projectErr)
+			continue
+		}
+		prov := findProviderBySlug(pl.Provider)
+		if prov == nil {
+			warnRollbackPlacement(pl, fmt.Errorf("unknown provider"))
+			continue
+		}
+		var err error
+		switch pl.Mechanism {
+		case installstore.MechanismHookMerge, installstore.MechanismMCPMerge:
+			err = reapplyJSONMergePlacement(item, *prov, projectRoot)
+		case installstore.MechanismRuleAppend:
+			err = reapplyRuleAppendPlacement(item, pl, projectRoot)
+		}
+		if err != nil {
+			warnRollbackPlacement(pl, err)
+			continue
+		}
+		reapplied = append(reapplied, pl)
+	}
+	return reapplied
+}
+
+func shouldReapplyPlacement(m installstore.Mechanism) bool {
+	switch m {
+	case installstore.MechanismHookMerge, installstore.MechanismMCPMerge, installstore.MechanismRuleAppend:
+		return true
+	default:
+		return false
+	}
+}
+
+func reapplyJSONMergePlacement(item catalog.ContentItem, prov provider.Provider, projectRoot string) error {
+	if _, err := installer.Uninstall(item, prov, projectRoot); err != nil {
+		return fmt.Errorf("remove current merge before re-apply: %w", err)
+	}
+	if _, err := installer.Install(item, prov, projectRoot, installer.MethodSymlink, ""); err != nil {
+		return fmt.Errorf("install restored merge: %w", err)
+	}
+	return nil
+}
+
+func reapplyRuleAppendPlacement(item catalog.ContentItem, pl installstore.Placement, projectRoot string) error {
+	if item.Type != catalog.Rules {
+		return fmt.Errorf("rule_append placement recorded for %s item", item.Type)
+	}
+	globalDir := catalog.GlobalContentDir()
+	if globalDir == "" {
+		return fmt.Errorf("cannot determine home directory")
+	}
+	ruleDir, err := findLibraryRuleDir(filepath.Join(globalDir, string(catalog.Rules)), item.Name)
+	if err != nil {
+		return err
+	}
+	loaded, err := rulestore.LoadRule(ruleDir)
+	if err != nil {
+		return err
+	}
+	body := loaded.History[loaded.Meta.CurrentVersion]
+	if body == nil {
+		return fmt.Errorf("no history entry for current_version %s", loaded.Meta.CurrentVersion)
+	}
+	inst, err := installer.LoadInstalled(projectRoot)
+	if err != nil {
+		return err
+	}
+	libraryID := loaded.Meta.ID
+	for _, r := range inst.RuleAppends {
+		if r.Name == item.Name && r.Provider == pl.Provider && r.TargetFile == pl.Path {
+			libraryID = r.LibraryID
+			break
+		}
+	}
+	library := map[string]*rulestore.Loaded{
+		libraryID:      loaded,
+		loaded.Meta.ID: loaded,
+	}
+	return installer.ReplaceRuleAppend(projectRoot, libraryID, pl.Path, body, library)
+}
+
+func warnRollbackPlacement(pl installstore.Placement, err error) {
+	fmt.Fprintf(output.ErrWriter, "warning: could not re-apply %s placement for %s: %v\n", pl.Mechanism, pl.Provider, err)
+}
+
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		return copyTreeFile(path, target)
+	})
+}
+
+func copyTreeFile(src, dst string) (err error) {
+	if info, err := os.Lstat(dst); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("destination is a symlink: %s", dst)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.CreateTemp(filepath.Dir(dst), ".syllago-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := out.Name()
+	defer func() {
+		if err != nil {
+			_ = out.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+	if err = out.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, dst)
+}
+
+func shortSHA(sha string) string {
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
+}

--- a/cli/cmd/syllago/rollback_cmd_test.go
+++ b/cli/cmd/syllago/rollback_cmd_test.go
@@ -1,0 +1,631 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/add"
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/metadata"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
+)
+
+func TestRollbackGitHappyPath(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	env := setupGitRollbackState(t, false)
+	stdout, _ := output.SetForTest(t)
+	resetRollbackFlags(t)
+
+	if err := rollbackCmd.RunE(rollbackCmd, []string{"canary-skill"}); err != nil {
+		t.Fatalf("rollback RunE: %v", err)
+	}
+
+	assertFileContains(t, filepath.Join(env.libraryPath, "SKILL.md"), "v1")
+	meta, err := metadata.Load(env.libraryPath)
+	if err != nil || meta == nil {
+		t.Fatalf("metadata.Load: %v", err)
+	}
+	if meta.SourceSHA != env.shaA {
+		t.Fatalf("metadata SourceSHA = %q, want %q", meta.SourceSHA, env.shaA)
+	}
+	store := mustLoadInstallRecordStore(t, env.configDir)
+	rec := store.Find(env.coord)
+	if rec == nil {
+		t.Fatal("record missing after rollback")
+	}
+	if rec.SourceSHA != env.shaA {
+		t.Fatalf("record SourceSHA = %q, want %q", rec.SourceSHA, env.shaA)
+	}
+	if rec.Previous != nil {
+		t.Fatalf("record Previous = %#v, want nil", rec.Previous)
+	}
+	if !strings.Contains(stdout.String(), "Rolled back skills/canary-skill to "+shortSHA(env.shaA)) {
+		t.Fatalf("stdout = %q, want rollback summary", stdout.String())
+	}
+}
+
+func TestRollbackMOATCopyHappyPath(t *testing.T) {
+	env := setupMOATRollbackState(t, "canary-skill", catalog.Skills)
+	output.SetForTest(t)
+	resetRollbackFlags(t)
+
+	if err := rollbackCmd.RunE(rollbackCmd, []string{"canary-skill"}); err != nil {
+		t.Fatalf("rollback RunE: %v", err)
+	}
+
+	assertFileContains(t, filepath.Join(env.libraryPath, "SKILL.md"), "v1")
+	store := mustLoadInstallRecordStore(t, env.configDir)
+	rec := store.Find(env.coord)
+	if rec == nil {
+		t.Fatal("record missing after rollback")
+	}
+	if rec.Previous != nil {
+		t.Fatalf("record Previous = %#v, want nil", rec.Previous)
+	}
+}
+
+func TestRollbackStructuredErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) string
+		wantError string
+	}{
+		{
+			name: "no record",
+			setup: func(t *testing.T) string {
+				globalDir, configDir := setupRollbackGlobals(t)
+				writeLibrarySkill(t, globalDir, "canary-skill", "v2", &metadata.Meta{
+					ID:             "skill-no-record",
+					Name:           "canary-skill",
+					Type:           string(catalog.Skills),
+					SourceType:     "registry",
+					SourceRegistry: "test-reg",
+				})
+				_ = configDir
+				return "canary-skill"
+			},
+			wantError: "no install record",
+		},
+		{
+			name: "previous nil",
+			setup: func(t *testing.T) string {
+				globalDir, configDir := setupRollbackGlobals(t)
+				libraryPath := writeLibrarySkill(t, globalDir, "canary-skill", "v2", &metadata.Meta{
+					ID:             "skill-no-prev",
+					Name:           "canary-skill",
+					Type:           string(catalog.Skills),
+					SourceType:     "registry",
+					SourceRegistry: "test-reg",
+				})
+				storePath := filepath.Join(configDir, "installs.json")
+				coord := installstore.Coord{Registry: "test-reg", Type: string(catalog.Skills), Name: "canary-skill"}
+				if err := installstore.RecordInstallMeta(storePath, coord, libraryPath, installstore.PlacementInput{
+					Provider:  "claude-code",
+					Mechanism: installstore.MechanismSymlink,
+					Path:      filepath.Join(t.TempDir(), "canary-skill"),
+				}, installstore.InstallMeta{}, time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)); err != nil {
+					t.Fatalf("RecordInstallMeta: %v", err)
+				}
+				return "canary-skill"
+			},
+			wantError: "no rollback data for skills/canary-skill",
+		},
+		{
+			name: "copy path missing",
+			setup: func(t *testing.T) string {
+				env := setupMOATRollbackState(t, "canary-skill", catalog.Skills)
+				store := mustLoadInstallRecordStore(t, env.configDir)
+				rec := store.Find(env.coord)
+				rec.Previous.CopyPath = filepath.Join(t.TempDir(), "gone")
+				if err := store.Save(); err != nil {
+					t.Fatalf("Save store: %v", err)
+				}
+				return "canary-skill"
+			},
+			wantError: "saved previous copy is gone",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output.SetForTest(t)
+			resetRollbackFlags(t)
+			arg := tt.setup(t)
+
+			err := rollbackCmd.RunE(rollbackCmd, []string{arg})
+			if err == nil {
+				t.Fatal("rollback returned nil error")
+			}
+			if !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestRollbackItemAbsentAtOldSHA(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	env := setupGitRollbackStateMissingAtPreviousSHA(t)
+	output.SetForTest(t)
+	resetRollbackFlags(t)
+
+	err := rollbackCmd.RunE(rollbackCmd, []string{"canary-skill"})
+	if err == nil {
+		t.Fatal("rollback returned nil error")
+	}
+	want := "item did not exist at " + shortSHA(env.shaA)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want substring %q", err, want)
+	}
+	assertFileContains(t, filepath.Join(env.libraryPath, "SKILL.md"), "v2")
+}
+
+func TestRollbackDryRunLeavesLibraryAndRecordUntouched(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	env := setupGitRollbackState(t, false)
+	storePath := filepath.Join(env.configDir, "installs.json")
+	beforeStore, err := os.ReadFile(storePath)
+	if err != nil {
+		t.Fatalf("ReadFile store before: %v", err)
+	}
+	stdout, _ := output.SetForTest(t)
+	resetRollbackFlags(t)
+	rollbackCmd.Flags().Set("dry-run", "true")
+
+	if err := rollbackCmd.RunE(rollbackCmd, []string{"canary-skill"}); err != nil {
+		t.Fatalf("rollback dry-run: %v", err)
+	}
+
+	assertFileContains(t, filepath.Join(env.libraryPath, "SKILL.md"), "v2")
+	afterStore, err := os.ReadFile(storePath)
+	if err != nil {
+		t.Fatalf("ReadFile store after: %v", err)
+	}
+	if string(afterStore) != string(beforeStore) {
+		t.Fatalf("dry-run changed install store\nbefore:\n%s\nafter:\n%s", beforeStore, afterStore)
+	}
+	if !strings.Contains(stdout.String(), "would roll back skills/canary-skill to "+shortSHA(env.shaA)) {
+		t.Fatalf("stdout = %q, want dry-run plan", stdout.String())
+	}
+}
+
+func TestRollbackPinnedRecordSucceeds(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	env := setupGitRollbackState(t, true)
+	output.SetForTest(t)
+	resetRollbackFlags(t)
+
+	if err := rollbackCmd.RunE(rollbackCmd, []string{"canary-skill"}); err != nil {
+		t.Fatalf("rollback pinned record: %v", err)
+	}
+	assertFileContains(t, filepath.Join(env.libraryPath, "SKILL.md"), "v1")
+	store := mustLoadInstallRecordStore(t, env.configDir)
+	rec := store.Find(env.coord)
+	if rec == nil {
+		t.Fatal("record missing after rollback")
+	}
+	if !rec.Pinned {
+		t.Fatal("record Pinned = false, want true")
+	}
+}
+
+func TestRollbackReappliesHookMergePlacement(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	projectRoot := t.TempDir()
+	withFakeRepoRoot(t, projectRoot)
+	env := setupMOATHookRollbackState(t, homeDir, projectRoot)
+	stdout, _ := output.SetForTest(t)
+	resetRollbackFlags(t)
+
+	if err := rollbackCmd.RunE(rollbackCmd, []string{"rollback-hook"}); err != nil {
+		t.Fatalf("rollback hook: %v", err)
+	}
+
+	assertFileContains(t, filepath.Join(env.libraryPath, "hook.json"), "echo v1")
+	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
+	assertFileContains(t, settingsPath, "echo v1")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile settings: %v", err)
+	}
+	if strings.Contains(string(data), "echo v2") {
+		t.Fatalf("settings still contain v2 hook: %s", data)
+	}
+	if !strings.Contains(stdout.String(), "Re-applied hook_merge placement for claude-code") {
+		t.Fatalf("stdout = %q, want reapply line", stdout.String())
+	}
+}
+
+func TestRollbackJSONOutput(t *testing.T) {
+	env := setupMOATRollbackState(t, "canary-skill", catalog.Skills)
+	stdout, _ := output.SetForTest(t)
+	output.JSON = true
+	resetRollbackFlags(t)
+
+	if err := rollbackCmd.RunE(rollbackCmd, []string{"canary-skill"}); err != nil {
+		t.Fatalf("rollback RunE: %v", err)
+	}
+
+	var got struct {
+		Name                string `json:"name"`
+		Type                string `json:"type"`
+		Registry            string `json:"registry"`
+		RestoredFromCopy    bool   `json:"restored_from_copy"`
+		PlacementsReapplied int    `json:"placements_reapplied"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v\n%s", err, stdout.String())
+	}
+	if got.Name != "canary-skill" || got.Type != string(catalog.Skills) || got.Registry != env.coord.Registry || !got.RestoredFromCopy {
+		t.Fatalf("unexpected JSON output: %+v", got)
+	}
+}
+
+type rollbackGitEnv struct {
+	globalDir   string
+	configDir   string
+	regName     string
+	shaA        string
+	shaB        string
+	libraryPath string
+	coord       installstore.Coord
+}
+
+type rollbackMOATEnv struct {
+	globalDir   string
+	configDir   string
+	libraryPath string
+	coord       installstore.Coord
+}
+
+func setupRollbackGlobals(t *testing.T) (globalDir, configDir string) {
+	t.Helper()
+	globalDir = t.TempDir()
+	withGlobalLibrary(t, globalDir)
+	configDir = withInstallRecordConfigDir(t)
+	withFakeRepoRoot(t, t.TempDir())
+	return globalDir, configDir
+}
+
+func setupRollbackCache(t *testing.T) string {
+	t.Helper()
+	cacheDir := t.TempDir()
+	origCache := registry.CacheDirOverride
+	registry.CacheDirOverride = cacheDir
+	t.Cleanup(func() { registry.CacheDirOverride = origCache })
+	return cacheDir
+}
+
+func setupGitRollbackState(t *testing.T, pinned bool) rollbackGitEnv {
+	t.Helper()
+	globalDir, configDir := setupRollbackGlobals(t)
+	cacheDir := setupRollbackCache(t)
+	const regName = "test-org/rollback-reg"
+	cloneDir := filepath.Join(cacheDir, filepath.FromSlash(regName))
+	if err := os.MkdirAll(cloneDir, 0755); err != nil {
+		t.Fatalf("MkdirAll clone: %v", err)
+	}
+	gitRunForRegistryAddTest(t, cloneDir, "init")
+	gitRunForRegistryAddTest(t, cloneDir, "config", "user.email", "test@example.com")
+	gitRunForRegistryAddTest(t, cloneDir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(cloneDir, "registry.yaml"), []byte("name: rollback-reg\n"), 0644); err != nil {
+		t.Fatalf("WriteFile registry.yaml: %v", err)
+	}
+	writeGitRegistrySkill(t, cloneDir, "v1")
+	gitRunForRegistryAddTest(t, cloneDir, "add", "-A")
+	gitRunForRegistryAddTest(t, cloneDir, "commit", "-m", "v1")
+	shaA := gitOutputForRegistryAddTest(t, cloneDir, "rev-parse", "HEAD")
+	addRegistrySkillToLibrary(t, regName, cloneDir, globalDir, shaA)
+
+	libraryPath := filepath.Join(globalDir, "skills", "canary-skill")
+	coord := installstore.Coord{Registry: regName, Type: string(catalog.Skills), Name: "canary-skill"}
+	storePath := filepath.Join(configDir, "installs.json")
+	if err := installstore.RecordInstallMeta(storePath, coord, libraryPath, installstore.PlacementInput{
+		Provider:  "claude-code",
+		Mechanism: installstore.MechanismSymlink,
+		Path:      filepath.Join(t.TempDir(), "canary-skill"),
+	}, installstore.InstallMeta{SourceSHA: shaA}, time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("RecordInstallMeta: %v", err)
+	}
+
+	writeGitRegistrySkill(t, cloneDir, "v2")
+	gitRunForRegistryAddTest(t, cloneDir, "add", "-A")
+	gitRunForRegistryAddTest(t, cloneDir, "commit", "-m", "v2")
+	shaB := gitOutputForRegistryAddTest(t, cloneDir, "rev-parse", "HEAD")
+	addRegistrySkillToLibrary(t, regName, cloneDir, globalDir, shaB)
+	if err := installstore.RecordUpdate(storePath, coord, libraryPath, shaB, "", time.Date(2026, 8, 24, 13, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("RecordUpdate: %v", err)
+	}
+	if pinned {
+		if err := installstore.SetPinned(storePath, coord, true, time.Date(2026, 8, 24, 14, 0, 0, 0, time.UTC)); err != nil {
+			t.Fatalf("SetPinned: %v", err)
+		}
+	}
+	return rollbackGitEnv{
+		globalDir:   globalDir,
+		configDir:   configDir,
+		regName:     regName,
+		shaA:        shaA,
+		shaB:        shaB,
+		libraryPath: libraryPath,
+		coord:       coord,
+	}
+}
+
+func setupGitRollbackStateMissingAtPreviousSHA(t *testing.T) rollbackGitEnv {
+	t.Helper()
+	globalDir, configDir := setupRollbackGlobals(t)
+	cacheDir := setupRollbackCache(t)
+	const regName = "test-org/rollback-missing"
+	cloneDir := filepath.Join(cacheDir, filepath.FromSlash(regName))
+	if err := os.MkdirAll(cloneDir, 0755); err != nil {
+		t.Fatalf("MkdirAll clone: %v", err)
+	}
+	gitRunForRegistryAddTest(t, cloneDir, "init")
+	gitRunForRegistryAddTest(t, cloneDir, "config", "user.email", "test@example.com")
+	gitRunForRegistryAddTest(t, cloneDir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(cloneDir, "registry.yaml"), []byte("name: rollback-missing\n"), 0644); err != nil {
+		t.Fatalf("WriteFile registry.yaml: %v", err)
+	}
+	gitRunForRegistryAddTest(t, cloneDir, "add", "-A")
+	gitRunForRegistryAddTest(t, cloneDir, "commit", "-m", "empty")
+	shaA := gitOutputForRegistryAddTest(t, cloneDir, "rev-parse", "HEAD")
+
+	writeGitRegistrySkill(t, cloneDir, "v2")
+	gitRunForRegistryAddTest(t, cloneDir, "add", "-A")
+	gitRunForRegistryAddTest(t, cloneDir, "commit", "-m", "add skill")
+	shaB := gitOutputForRegistryAddTest(t, cloneDir, "rev-parse", "HEAD")
+	addRegistrySkillToLibrary(t, regName, cloneDir, globalDir, shaB)
+
+	libraryPath := filepath.Join(globalDir, "skills", "canary-skill")
+	coord := installstore.Coord{Registry: regName, Type: string(catalog.Skills), Name: "canary-skill"}
+	storePath := filepath.Join(configDir, "installs.json")
+	if err := installstore.RecordInstallMeta(storePath, coord, libraryPath, installstore.PlacementInput{
+		Provider:  "claude-code",
+		Mechanism: installstore.MechanismSymlink,
+		Path:      filepath.Join(t.TempDir(), "canary-skill"),
+	}, installstore.InstallMeta{SourceSHA: shaA}, time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("RecordInstallMeta: %v", err)
+	}
+	if err := installstore.RecordUpdate(storePath, coord, libraryPath, shaB, "", time.Date(2026, 8, 24, 13, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("RecordUpdate: %v", err)
+	}
+	return rollbackGitEnv{
+		globalDir:   globalDir,
+		configDir:   configDir,
+		regName:     regName,
+		shaA:        shaA,
+		shaB:        shaB,
+		libraryPath: libraryPath,
+		coord:       coord,
+	}
+}
+
+func setupMOATRollbackState(t *testing.T, name string, ct catalog.ContentType) rollbackMOATEnv {
+	t.Helper()
+	globalDir, configDir := setupRollbackGlobals(t)
+	libraryPath := writeLibrarySkill(t, globalDir, name, "v1", &metadata.Meta{
+		ID:             "skill-" + name,
+		Name:           name,
+		Type:           string(ct),
+		SourceType:     "registry",
+		SourceRegistry: "moat-reg",
+	})
+	prevCopy := filepath.Join(t.TempDir(), "prev-copy")
+	copyTreeForRollbackTest(t, libraryPath, prevCopy)
+	_ = writeLibrarySkill(t, globalDir, name, "v2", &metadata.Meta{
+		ID:             "skill-" + name,
+		Name:           name,
+		Type:           string(ct),
+		SourceType:     "registry",
+		SourceRegistry: "moat-reg",
+	})
+
+	coord := installstore.Coord{Registry: "moat-reg", Type: string(ct), Name: name}
+	storePath := filepath.Join(configDir, "installs.json")
+	if err := installstore.RecordInstallMeta(storePath, coord, libraryPath, installstore.PlacementInput{
+		Provider:  "claude-code",
+		Mechanism: installstore.MechanismSymlink,
+		Path:      filepath.Join(t.TempDir(), name),
+	}, installstore.InstallMeta{}, time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("RecordInstallMeta: %v", err)
+	}
+	if err := installstore.RecordUpdate(storePath, coord, libraryPath, "", prevCopy, time.Date(2026, 8, 24, 13, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("RecordUpdate: %v", err)
+	}
+	return rollbackMOATEnv{globalDir: globalDir, configDir: configDir, libraryPath: libraryPath, coord: coord}
+}
+
+func setupMOATHookRollbackState(t *testing.T, homeDir, projectRoot string) rollbackMOATEnv {
+	t.Helper()
+	globalDir, configDir := setupRollbackGlobals(t)
+	withFakeRepoRoot(t, projectRoot)
+	hookPath := writeLibraryHook(t, globalDir, "rollback-hook", "echo v1")
+	prevCopy := filepath.Join(t.TempDir(), "prev-hook")
+	copyTreeForRollbackTest(t, hookPath, prevCopy)
+	hookPath = writeLibraryHook(t, globalDir, "rollback-hook", "echo v2")
+
+	coord := installstore.Coord{Registry: "moat-reg", Type: string(catalog.Hooks), Name: "rollback-hook"}
+	storePath := filepath.Join(configDir, "installs.json")
+	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
+	if err := installstore.RecordInstallMeta(storePath, coord, hookPath, installstore.PlacementInput{
+		Provider:  "claude-code",
+		Mechanism: installstore.MechanismHookMerge,
+		Path:      settingsPath,
+		Keys:      []string{"hooks.PreToolUse"},
+	}, installstore.InstallMeta{}, time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("RecordInstallMeta: %v", err)
+	}
+	if err := installstore.RecordUpdate(storePath, coord, hookPath, "", prevCopy, time.Date(2026, 8, 24, 13, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("RecordUpdate: %v", err)
+	}
+
+	item := scanRollbackTestItem(t, "rollback-hook", string(catalog.Hooks))
+	if _, err := installer.Install(*item, provider.ClaudeCode, projectRoot, installer.MethodSymlink, ""); err != nil {
+		t.Fatalf("install v2 hook: %v", err)
+	}
+	assertFileContains(t, settingsPath, "echo v2")
+	return rollbackMOATEnv{globalDir: globalDir, configDir: configDir, libraryPath: hookPath, coord: coord}
+}
+
+func addRegistrySkillToLibrary(t *testing.T, regName, cloneDir, globalDir, sourceSHA string) {
+	t.Helper()
+	items, err := add.DiscoverFromRegistry(regName, cloneDir, globalDir)
+	if err != nil {
+		t.Fatalf("DiscoverFromRegistry: %v", err)
+	}
+	var match *add.DiscoveryItem
+	for i := range items {
+		if items[i].Type == catalog.Skills && items[i].Name == "canary-skill" {
+			match = &items[i]
+			break
+		}
+	}
+	if match == nil {
+		t.Fatalf("canary-skill not discovered in %s", cloneDir)
+	}
+	results := add.AddItems([]add.DiscoveryItem{*match}, add.AddOptions{
+		Force:            true,
+		SourceRegistry:   regName,
+		SourceSHA:        sourceSHA,
+		SourceVisibility: "public",
+	}, globalDir, nil, version)
+	if len(results) != 1 || results[0].Status == add.AddStatusError {
+		t.Fatalf("AddItems results = %#v", results)
+	}
+}
+
+func writeGitRegistrySkill(t *testing.T, cloneDir, versionLabel string) {
+	t.Helper()
+	skillDir := filepath.Join(cloneDir, "skills", "canary-skill")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("MkdirAll skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Canary skill\n"+versionLabel+"\n"), 0644); err != nil {
+		t.Fatalf("WriteFile skill: %v", err)
+	}
+}
+
+func writeLibrarySkill(t *testing.T, globalDir, name, versionLabel string, meta *metadata.Meta) string {
+	t.Helper()
+	skillDir := filepath.Join(globalDir, "skills", name)
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("MkdirAll skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Canary skill\n"+versionLabel+"\n"), 0644); err != nil {
+		t.Fatalf("WriteFile skill: %v", err)
+	}
+	if meta != nil {
+		if err := metadata.Save(skillDir, meta); err != nil {
+			t.Fatalf("metadata.Save: %v", err)
+		}
+	}
+	return skillDir
+}
+
+func writeLibraryHook(t *testing.T, globalDir, name, command string) string {
+	t.Helper()
+	hookDir := filepath.Join(globalDir, "hooks", "claude-code", name)
+	if err := os.MkdirAll(hookDir, 0755); err != nil {
+		t.Fatalf("MkdirAll hook dir: %v", err)
+	}
+	hookJSON := `{"spec":"hooks/0.1","hooks":[{"name":"` + name + `","event":"PreToolUse","matcher":"Bash","handler":{"type":"command","command":"` + command + `"}}]}`
+	if err := os.WriteFile(filepath.Join(hookDir, "hook.json"), []byte(hookJSON), 0644); err != nil {
+		t.Fatalf("WriteFile hook: %v", err)
+	}
+	if err := metadata.Save(hookDir, &metadata.Meta{
+		ID:             "hook-" + name,
+		Name:           name,
+		Type:           string(catalog.Hooks),
+		SourceProvider: "claude-code",
+		SourceType:     "registry",
+		SourceRegistry: "moat-reg",
+	}); err != nil {
+		t.Fatalf("metadata.Save hook: %v", err)
+	}
+	return hookDir
+}
+
+func scanRollbackTestItem(t *testing.T, name, typeFilter string) *catalog.ContentItem {
+	t.Helper()
+	emptyRoot := t.TempDir()
+	cat, err := catalog.ScanWithGlobalAndRegistries(emptyRoot, emptyRoot, nil)
+	if err != nil {
+		t.Fatalf("ScanWithGlobalAndRegistries: %v", err)
+	}
+	item, err := findLibraryItem(cat, name, typeFilter)
+	if err != nil {
+		t.Fatalf("findLibraryItem: %v", err)
+	}
+	return item
+}
+
+func resetRollbackFlags(t *testing.T) {
+	t.Helper()
+	rollbackCmd.Flags().Set("type", "")
+	rollbackCmd.Flags().Set("dry-run", "false")
+	t.Cleanup(func() {
+		rollbackCmd.Flags().Set("type", "")
+		rollbackCmd.Flags().Set("dry-run", "false")
+	})
+}
+
+func copyTreeForRollbackTest(t *testing.T, src, dst string) {
+	t.Helper()
+	if err := filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return os.MkdirAll(dst, 0755)
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0644)
+	}); err != nil {
+		t.Fatalf("copyTree %s -> %s: %v", src, dst, err)
+	}
+}
+
+func assertFileContains(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", path, err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("%s = %q, want substring %q", path, data, want)
+	}
+}

--- a/cli/commands.json
+++ b/cli/commands.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
-  "generatedAt": "2026-08-24T17:32:29Z",
-  "syllagoVersion": "dev",
+  "generatedAt": "2026-08-24T18:46:23Z",
+  "syllagoVersion": "0.14.0",
   "commands": [
     {
       "name": "add",
@@ -3258,6 +3258,72 @@
       "seeAlso": [],
       "examples": "  # Remove a skill from library and all providers\n  syllago remove my-skill\n\n  # Disambiguate by type when name exists in multiple types\n  syllago remove my-rule --type rules\n\n  # Skip confirmation prompt\n  syllago remove my-skill --force\n\n  # Preview what would happen\n  syllago remove my-skill --dry-run",
       "source": "cli/cmd/syllago/remove.go"
+    },
+    {
+      "name": "rollback",
+      "displayName": "Rollback",
+      "slug": "rollback",
+      "parent": null,
+      "synopsis": "syllago rollback \u003cname\u003e [flags]",
+      "description": "Restore the previous installed library version",
+      "longDescription": "Restores a registry-sourced library item to its one-step rollback point.\n\nRollback is available after an update replaces an installed item. It works for\npinned items because rollback is an explicit user action.",
+      "aliases": [],
+      "flags": [
+        {
+          "name": "--dry-run",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Show what would happen without making changes"
+        },
+        {
+          "name": "--type",
+          "shorthand": null,
+          "type": "string",
+          "default": null,
+          "required": false,
+          "description": "Disambiguate when name exists in multiple types"
+        }
+      ],
+      "inheritedFlags": [
+        {
+          "name": "--json",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Output in JSON format"
+        },
+        {
+          "name": "--no-color",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Disable color output"
+        },
+        {
+          "name": "--quiet",
+          "shorthand": "-q",
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Suppress non-essential output"
+        },
+        {
+          "name": "--verbose",
+          "shorthand": "-v",
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Verbose output"
+        }
+      ],
+      "subcommands": [],
+      "seeAlso": [],
+      "examples": "  # Roll back a skill to the previous version\n  syllago rollback my-skill\n\n  # Disambiguate by type\n  syllago rollback shared-context --type skills\n\n  # Preview the rollback source without changing files\n  syllago rollback my-skill --dry-run",
+      "source": "cli/cmd/syllago/rollback.go"
     },
     {
       "name": "sandbox",

--- a/cli/internal/registry/worktree.go
+++ b/cli/internal/registry/worktree.go
@@ -1,0 +1,66 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// WorktreeAt materializes the registry clone's tree at sha in a temporary
+// directory using `git worktree add --detach`. The returned cleanup removes
+// the worktree (best-effort) and must always be called.
+func WorktreeAt(name, sha string) (dir string, cleanup func(), err error) {
+	if err := checkGit(); err != nil {
+		return "", nil, err
+	}
+	cloneDir, err := CloneDir(name)
+	if err != nil {
+		return "", nil, err
+	}
+	if _, err := os.Stat(cloneDir); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil, fmt.Errorf("registry clone %q does not exist at %s", name, cloneDir)
+		}
+		return "", nil, fmt.Errorf("checking registry clone %q at %s: %w", name, cloneDir, err)
+	}
+
+	tmp, err := os.MkdirTemp("", "syllago-rollback-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating rollback temp dir: %w", err)
+	}
+	worktreeDir := filepath.Join(tmp, "tree")
+	cleanup = func() {
+		_ = runGitWorktreeCommand(cloneDir, "worktree", "remove", "--force", worktreeDir)
+		_ = runGitWorktreeCommand(cloneDir, "worktree", "prune")
+		_ = os.RemoveAll(tmp)
+	}
+
+	out, err := runGitWorktreeCommandOutput(cloneDir,
+		"worktree", "add", "--detach", "--quiet", worktreeDir, sha,
+	)
+	if err != nil {
+		cleanup()
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			return "", nil, fmt.Errorf("git worktree add failed for %q at %s: %s", sha, cloneDir, msg)
+		}
+		return "", nil, fmt.Errorf("git worktree add failed for %q at %s: %w", sha, cloneDir, err)
+	}
+	return worktreeDir, cleanup, nil
+}
+
+func runGitWorktreeCommand(cloneDir string, args ...string) error {
+	_, err := runGitWorktreeCommandOutput(cloneDir, args...)
+	return err
+}
+
+func runGitWorktreeCommandOutput(cloneDir string, args ...string) ([]byte, error) {
+	fullArgs := append([]string{"-C", cloneDir, "-c", "core.hooksPath=/dev/null"}, args...)
+	cmd := exec.Command("git", fullArgs...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	return cmd.CombinedOutput()
+}

--- a/cli/internal/registry/worktree_test.go
+++ b/cli/internal/registry/worktree_test.go
@@ -1,0 +1,118 @@
+package registry
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWorktreeAtMaterializesHistoricalTreeAndCleansUp(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	cacheDir := t.TempDir()
+	origCache := CacheDirOverride
+	CacheDirOverride = cacheDir
+	t.Cleanup(func() { CacheDirOverride = origCache })
+
+	const regName = "acme/tools"
+	cloneDir, err := CloneDir(regName)
+	if err != nil {
+		t.Fatalf("CloneDir: %v", err)
+	}
+	if err := os.MkdirAll(cloneDir, 0755); err != nil {
+		t.Fatalf("MkdirAll clone: %v", err)
+	}
+	gitRunForWorktreeTest(t, cloneDir, "init")
+	gitRunForWorktreeTest(t, cloneDir, "config", "user.email", "test@example.com")
+	gitRunForWorktreeTest(t, cloneDir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(cloneDir, "item.txt"), []byte("old\n"), 0644); err != nil {
+		t.Fatalf("WriteFile old: %v", err)
+	}
+	gitRunForWorktreeTest(t, cloneDir, "add", "-A")
+	gitRunForWorktreeTest(t, cloneDir, "commit", "-m", "old")
+	oldSHA := gitOutputForWorktreeTest(t, cloneDir, "rev-parse", "HEAD")
+
+	if err := os.WriteFile(filepath.Join(cloneDir, "item.txt"), []byte("new\n"), 0644); err != nil {
+		t.Fatalf("WriteFile new: %v", err)
+	}
+	gitRunForWorktreeTest(t, cloneDir, "add", "-A")
+	gitRunForWorktreeTest(t, cloneDir, "commit", "-m", "new")
+
+	dir, cleanup, err := WorktreeAt(regName, oldSHA)
+	if err != nil {
+		t.Fatalf("WorktreeAt: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "item.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile materialized item: %v", err)
+	}
+	if string(data) != "old\n" {
+		t.Fatalf("materialized content = %q, want old", data)
+	}
+
+	cleanup()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("worktree dir still exists after cleanup, stat err = %v", err)
+	}
+}
+
+func TestWorktreeAtBogusSHAErrors(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	cacheDir := t.TempDir()
+	origCache := CacheDirOverride
+	CacheDirOverride = cacheDir
+	t.Cleanup(func() { CacheDirOverride = origCache })
+
+	const regName = "acme/bogus"
+	cloneDir, err := CloneDir(regName)
+	if err != nil {
+		t.Fatalf("CloneDir: %v", err)
+	}
+	if err := os.MkdirAll(cloneDir, 0755); err != nil {
+		t.Fatalf("MkdirAll clone: %v", err)
+	}
+	gitRunForWorktreeTest(t, cloneDir, "init")
+	gitRunForWorktreeTest(t, cloneDir, "config", "user.email", "test@example.com")
+	gitRunForWorktreeTest(t, cloneDir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(cloneDir, "item.txt"), []byte("content\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	gitRunForWorktreeTest(t, cloneDir, "add", "-A")
+	gitRunForWorktreeTest(t, cloneDir, "commit", "-m", "initial")
+
+	_, cleanup, err := WorktreeAt(regName, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if cleanup != nil {
+		cleanup()
+	}
+	if err == nil {
+		t.Fatal("WorktreeAt bogus SHA returned nil error")
+	}
+	if !strings.Contains(err.Error(), "aaaaaaaaaaaa") {
+		t.Fatalf("error = %v, want it to name the missing sha", err)
+	}
+}
+
+func gitRunForWorktreeTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	_ = gitOutputForWorktreeTest(t, dir, args...)
+}
+
+func gitOutputForWorktreeTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/cli/internal/telemetry/catalog.go
+++ b/cli/internal/telemetry/catalog.go
@@ -51,7 +51,7 @@ func EventCatalog() []EventDef {
 					Type:        "string",
 					Description: "Content type filter or specific type",
 					Example:     "rules",
-					Commands:    []string{"install", "add", "convert", "create", "uninstall", "remove", "list", "share", "sync-and-export", "registry_items"},
+					Commands:    []string{"install", "add", "convert", "create", "uninstall", "remove", "list", "share", "rollback", "sync-and-export", "registry_items"},
 				},
 				{
 					Name:        "content_count",
@@ -65,7 +65,7 @@ func EventCatalog() []EventDef {
 					Type:        "bool",
 					Description: "Whether --dry-run flag was used",
 					Example:     false,
-					Commands:    []string{"install", "add", "uninstall", "remove", "sync-and-export"},
+					Commands:    []string{"install", "add", "uninstall", "remove", "rollback", "sync-and-export"},
 				},
 				{
 					Name:        "from",

--- a/cli/telemetry.json
+++ b/cli/telemetry.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generatedAt": "2026-08-23T01:52:59Z",
+  "generatedAt": "2026-08-24T18:46:24Z",
   "syllagoVersion": "0.14.0",
   "events": [
     {
@@ -44,6 +44,7 @@
             "remove",
             "list",
             "share",
+            "rollback",
             "sync-and-export",
             "registry_items"
           ]
@@ -68,6 +69,7 @@
             "add",
             "uninstall",
             "remove",
+            "rollback",
             "sync-and-export"
           ]
         },


### PR DESCRIPTION
Part of #542 item 7 (pin and rollback) — rollback command chunk 7e.

Adds `syllago rollback <name>` (`--type`, `--dry-run`), restoring a registry-sourced library item to its one-step rollback point recorded in `installs.json`:

- **Git-registry items**: new `registry.WorktreeAt(name, sha)` materializes the registry clone at `Previous.SourceSHA` in a temporary detached git worktree (hardened invocation: `core.hooksPath=/dev/null`, `GIT_CONFIG_NOSYSTEM=1`), then `add.DiscoverFromRegistry` + `add.AddItems{Force: true, SourceSHA: <prev sha>}` re-writes the item through the normal add path, preserving source visibility.
- **MOAT items**: restores the saved previous library copy (`Previous.CopyPath`, written by `StageIntoLibraryKeepPrev`) with an atomic-per-file tree copy.
- Record math via `installstore.RecordRollback` after content restore; a record failure after successful restore is reported as exactly that.
- `hook_merge` / `mcp_merge` / `rule_append` placements are re-applied best-effort with per-placement warnings; symlink placements need nothing.
- Rollback works on pinned items: pinning guards upstream-driven updates, rollback is an explicit user action — the pin then holds at the rolled-back content.
- Structured errors for: not registry-sourced, no install record, no rollback data, saved copy missing, item absent at the old SHA.
- Telemetry: `content_type` + `dry_run` enrichment; catalog + telemetry.json/commands.json regenerated (commands.json also picks up the canonical `syllagoVersion` stamp, matching telemetry.json).

Tests: `worktree_test.go` (historical tree materialization + cleanup, bogus SHA) and `rollback_cmd_test.go` (git happy path, MOAT copy path, structured errors, item absent at old SHA, dry-run no-op, pinned rollback succeeds, hook_merge re-apply, JSON output). Full suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)