### PR TITLE
feat(cli): pin/unpin commands, --frozen flag, pinned drift display (#542 item 7d)

### DIFF
--- a/cli/cmd/syllago/add_cmd.go
+++ b/cli/cmd/syllago/add_cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/converter"
 	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
 	"github.com/OpenScribbler/syllago/cli/internal/metadata"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
@@ -72,6 +73,7 @@ func init() {
 	addCmd.Flags().String("trusted-root", "", "Path to Sigstore trusted_root.json (overrides registry config and the bundled default)")
 	addCmd.Flags().Bool("install", false, "Install added items immediately after adding (requires --to)")
 	addCmd.Flags().String("to", "", "Target provider for --install")
+	addCmd.Flags().Bool("frozen", false, "Pin the install record created by this command")
 	rootCmd.AddCommand(addCmd)
 }
 
@@ -94,6 +96,23 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return output.NewStructuredError(output.ErrInputMissing, "missing --from flag", "Usage: syllago add [type] --from <provider>")
 	}
 
+	// --frozen only makes sense for the provider-import path with a chained
+	// install (--install --to). The monolithic, shared, and registry branches
+	// below never chain an install, so reject the flag up front instead of
+	// silently dropping it.
+	frozenFlag, _ := cmd.Flags().GetBool("frozen")
+	if frozenFlag {
+		installFlagEarly, _ := cmd.Flags().GetBool("install")
+		installToEarly, _ := cmd.Flags().GetString("to")
+		if !installFlagEarly || installToEarly == "" {
+			return output.NewStructuredError(
+				output.ErrInputConflict,
+				"--frozen requires --install and --to: pinning applies to the chained install's record",
+				"Use --install --to <provider> along with --frozen",
+			)
+		}
+	}
+
 	// Monolithic-file mode: any --from value that resolves to an existing file
 	// is treated as a monolithic source path. Per D18, the CLI requires all
 	// --from entries to resolve consistently (either all files or all slugs).
@@ -112,6 +131,11 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			"Pass either all file paths or a single provider slug")
 	}
 	if len(monolithicPaths) > 0 {
+		if frozenFlag {
+			return output.NewStructuredError(output.ErrInputConflict,
+				"--frozen is not supported with monolithic file imports",
+				"Pin after installing: syllago pin <name>")
+		}
 		return runAddFromMonolithicFiles(cmd, root, monolithicPaths)
 	}
 
@@ -123,6 +147,11 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 	// Handle --from shared: add content from the project's shared content directory.
 	if fromSlug == "shared" {
+		if frozenFlag {
+			return output.NewStructuredError(output.ErrInputConflict,
+				"--frozen is not supported with --from shared",
+				"Pin after installing: syllago pin <name>")
+		}
 		addAll, _ := cmd.Flags().GetBool("all")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		force, _ := cmd.Flags().GetBool("force")
@@ -146,11 +175,18 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		if globalDir == "" {
 			return output.NewStructuredError(output.ErrSystemHomedir, "cannot determine home directory", "Set the HOME environment variable")
 		}
+		if frozenFlag {
+			return output.NewStructuredError(output.ErrInputConflict,
+				"--frozen is not supported when adding from a registry",
+				"Pin at install time instead: syllago install "+fromSlug+"/<item> --to <provider> --frozen")
+		}
 		return runAddFromRegistry(root, args, fromSlug, addAll, dryRun, force, globalDir, trustedRootOverride)
 	}
 
 	installFlag, _ := cmd.Flags().GetBool("install")
 	installTo, _ := cmd.Flags().GetString("to")
+	frozen := frozenFlag
+	telemetry.Enrich("frozen", frozen)
 	if installFlag && installTo == "" {
 		slugs := providerSlugs()
 		return output.NewStructuredError(output.ErrInputMissing, "--to is required with --install", "Available providers: "+strings.Join(slugs, ", "))
@@ -282,7 +318,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	telemetry.Enrich("install", installFlag)
 
 	if installFlag && installTo != "" && !dryRun {
-		if err := chainInstallAfterAdd(results, installTo, globalDir, root); err != nil {
+		if err := chainInstallAfterAdd(results, installTo, globalDir, root, frozen); err != nil {
 			fmt.Fprintf(output.ErrWriter, "Warning: install after add: %v\n", err)
 		}
 	}
@@ -292,7 +328,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 // chainInstallAfterAdd installs items that were successfully added to the
 // global library into the named target provider. Called when --install is set.
-func chainInstallAfterAdd(results []add.AddResult, toSlug, globalDir, projectRoot string) error {
+func chainInstallAfterAdd(results []add.AddResult, toSlug, globalDir, projectRoot string, frozen bool) error {
 	prov := findProviderBySlug(toSlug)
 	if prov == nil {
 		return output.NewStructuredError(output.ErrProviderNotFound, "unknown provider: "+toSlug, "Available: "+strings.Join(providerSlugs(), ", "))
@@ -325,6 +361,25 @@ func chainInstallAfterAdd(results []add.AddResult, toSlug, globalDir, projectRoo
 				fmt.Fprintf(output.ErrWriter, "Warning: install %s to %s: %v\n", item.Name, toSlug, err)
 			} else {
 				recordInstallBookkeeping(item, toSlug, placement)
+				if frozen {
+					if item.Meta != nil && item.Meta.SourceRegistry != "" {
+						coord := installstore.Coord{
+							Registry: item.Meta.SourceRegistry,
+							Type:     string(item.Type),
+							Name:     item.Name,
+						}
+						storePath, err := installstore.DefaultPath()
+						if err != nil {
+							warnInstallRecord(err)
+						} else {
+							if err := installstore.SetPinned(storePath, coord, true, time.Now()); err != nil {
+								warnInstallRecord(err)
+							}
+						}
+					} else {
+						fmt.Fprintf(output.ErrWriter, "warning: only registry items can be pinned\n")
+					}
+				}
 			}
 		}
 	}
@@ -1303,6 +1358,38 @@ func runAddFromRegistry(projectRoot string, args []string, fromSlug string, addA
 		if head, err := registry.Head(reg.Name); err == nil {
 			sourceSHA = head
 		}
+	}
+
+	// Check if any of the items requested to be added has an active install record that is Pinned: true
+	storePath, storeErr := installstore.DefaultPath()
+	if storeErr == nil {
+		if store, loadErr := installstore.Load(storePath); loadErr == nil {
+			var unpinnedItems []add.DiscoveryItem
+			for _, item := range items {
+				coord := installstore.Coord{Registry: reg.Name, Type: string(item.Type), Name: item.Name}
+				if rec := store.Find(coord); rec != nil && rec.Pinned {
+					if rec.SourceSHA != "" {
+						sha12 := rec.SourceSHA
+						if len(sha12) > 12 {
+							sha12 = sha12[:12]
+						}
+						fmt.Fprintf(output.ErrWriter, "  pinned %s/%s — holding at %s; unpin to update: syllago unpin %s\n", string(item.Type), item.Name, sha12, item.Name)
+					} else {
+						fmt.Fprintf(output.ErrWriter, "  pinned %s/%s; unpin to update: syllago unpin %s\n", string(item.Type), item.Name, item.Name)
+					}
+				} else {
+					unpinnedItems = append(unpinnedItems, item)
+				}
+			}
+			items = unpinnedItems
+		}
+	}
+	if len(items) == 0 {
+		return output.NewStructuredError(
+			output.ErrInstallConflict,
+			"all requested items are pinned",
+			"Run 'syllago unpin <name>' first to unpin the items you want to update",
+		)
 	}
 
 	results := add.AddItems(items, add.AddOptions{

--- a/cli/cmd/syllago/install_cmd.go
+++ b/cli/cmd/syllago/install_cmd.go
@@ -6,12 +6,14 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/OpenScribbler/syllago/cli/internal/audit"
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/config"
 	"github.com/OpenScribbler/syllago/cli/internal/converter"
 	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
 	"github.com/OpenScribbler/syllago/cli/internal/registry"
@@ -121,6 +123,7 @@ func init() {
 	installCmd.Flags().Bool("no-input", false, "Disable interactive prompts, use defaults")
 	installCmd.Flags().StringSlice("hook-scanner", nil, "Path to external hook scanner binary (repeatable)")
 	installCmd.Flags().Bool("force", false, "Proceed past high-severity scanner findings")
+	installCmd.Flags().Bool("frozen", false, "Pin the install record created by this command")
 	// D17 re-install decision flags for --method=append. Values validated in
 	// runInstall so bad inputs error before any disk work. See D17 flag table.
 	installCmd.Flags().String("on-clean", "", "Action when rule is already installed cleanly: replace|skip")
@@ -166,6 +169,8 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	installAll, _ := cmd.Flags().GetBool("all")
 	scannerPaths, _ := cmd.Flags().GetStringSlice("hook-scanner")
 	force, _ := cmd.Flags().GetBool("force")
+	frozen, _ := cmd.Flags().GetBool("frozen")
+	telemetry.Enrich("frozen", frozen)
 	installer.SetScannerChain(scannerPaths, force)
 	refreshInstallEntryPointsForInstall()
 
@@ -255,8 +260,12 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	// rationale and what this slice intentionally defers.
 	if len(args) == 1 {
 		if regName, itemName, ok := parseRegistryItemSyntax(args[0]); ok {
+			ctx := cmd.Context()
+			if frozen {
+				ctx = ContextWithFrozen(ctx, true)
+			}
 			return runInstallFromRegistry(
-				cmd.Context(),
+				ctx,
 				output.Writer,
 				output.ErrWriter,
 				mergedCfg,
@@ -316,7 +325,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(output.Writer, "Installing %d items to %s...\n", len(items), prov.Name)
 	}
 
-	result, _ := installToProvider(items, *prov, method, dryRun, resolver, toSlug, projectRoot)
+	result, _ := installToProvider(items, *prov, method, dryRun, resolver, toSlug, projectRoot, frozen)
 
 	if output.JSON {
 		output.Print(result)
@@ -348,6 +357,7 @@ func installToProvider(
 	resolver *config.PathResolver,
 	toSlug string,
 	projectRoot string,
+	frozen bool,
 ) (installResult, error) {
 	var result installResult
 
@@ -384,6 +394,25 @@ func installToProvider(
 			continue
 		}
 		recordInstallBookkeeping(item, toSlug, placement)
+		if frozen {
+			if item.Meta != nil && item.Meta.SourceRegistry != "" {
+				coord := installstore.Coord{
+					Registry: item.Meta.SourceRegistry,
+					Type:     string(item.Type),
+					Name:     item.Name,
+				}
+				storePath, err := installstore.DefaultPath()
+				if err != nil {
+					warnInstallRecord(err)
+				} else {
+					if err := installstore.SetPinned(storePath, coord, true, time.Now()); err != nil {
+						warnInstallRecord(err)
+					}
+				}
+			} else {
+				fmt.Fprintf(output.ErrWriter, "warning: only registry items can be pinned\n")
+			}
+		}
 		desc := placement.String()
 
 		// Check for portability warnings by running the converter.
@@ -458,7 +487,7 @@ type providerInstallResult struct {
 // It detects providers, installs to each, and prints a summary.
 // Returns a non-nil error if any provider had install failures.
 func runInstallToAll(
-	_ *cobra.Command,
+	cmd *cobra.Command,
 	args []string,
 	typeFilter string,
 	_ string,
@@ -468,6 +497,7 @@ func runInstallToAll(
 	installAll bool,
 	noInput bool,
 ) error {
+	frozen, _ := cmd.Flags().GetBool("frozen")
 	globalCfg, err := config.LoadGlobal()
 	if err != nil {
 		return output.NewStructuredErrorDetail(output.ErrConfigInvalid, "loading global config", "Check ~/.syllago/config.json syntax", err.Error())
@@ -571,7 +601,7 @@ func runInstallToAll(
 			fmt.Fprintf(output.Writer, "→ %s\n", prov.Name)
 		}
 
-		result, _ := installToProvider(items, prov, method, dryRun, resolver, prov.Slug, projectRoot)
+		result, _ := installToProvider(items, prov, method, dryRun, resolver, prov.Slug, projectRoot, frozen)
 
 		pr := providerInstallResult{
 			Provider: prov.Name,

--- a/cli/cmd/syllago/install_moat.go
+++ b/cli/cmd/syllago/install_moat.go
@@ -350,6 +350,20 @@ func runInstallFromRegistry(
 		)
 	}
 
+	// Check if the item is pinned before overwriting content
+	if storePath, storeErr := installstore.DefaultPath(); storeErr == nil {
+		if store, loadErr := installstore.Load(storePath); loadErr == nil {
+			coord := installstore.Coord{Registry: reg.Name, Type: string(ct), Name: entry.Name}
+			if rec := store.Find(coord); rec != nil && rec.Pinned {
+				return output.NewStructuredError(
+					output.ErrInstallConflict,
+					fmt.Sprintf("could not install %s/%s: item is pinned", reg.Name, entry.Name),
+					fmt.Sprintf("syllago unpin %s", entry.Name),
+				)
+			}
+		}
+	}
+
 	// Provider-side install: stage the verified source tree into the
 	// library first, then place it from the library with the regular
 	// installer so symlinks and install records share the normal path model.
@@ -381,6 +395,22 @@ func runInstallFromRegistry(
 		TrustTier:   entry.TrustTier().String(),
 		AttestedAt:  now,
 	})
+
+	if isFrozenFromContext(ctx) {
+		coord := installRecordCoord(item)
+		if coord.Registry != "" {
+			if storePath, err := installstore.DefaultPath(); err == nil {
+				if err := installstore.SetPinned(storePath, coord, true, now); err != nil {
+					warnInstallRecord(err)
+				}
+			} else {
+				warnInstallRecord(err)
+			}
+		} else {
+			fmt.Fprintf(output.ErrWriter, "warning: only registry items can be pinned\n")
+		}
+	}
+
 	fmt.Fprintf(out, "installed %s/%s (%s) to %s\n", reg.Name, entry.Name, entry.TrustTier().String(), placement.String())
 	return nil
 }
@@ -498,4 +528,17 @@ func shortHash(h string) string {
 		return h[:i+13] + "…"
 	}
 	return h
+}
+
+type frozenContextKeyType struct{}
+
+var frozenContextKey = frozenContextKeyType{}
+
+func ContextWithFrozen(ctx context.Context, frozen bool) context.Context {
+	return context.WithValue(ctx, frozenContextKey, frozen)
+}
+
+func isFrozenFromContext(ctx context.Context) bool {
+	val, _ := ctx.Value(frozenContextKey).(bool)
+	return val
 }

--- a/cli/cmd/syllago/install_trust_test.go
+++ b/cli/cmd/syllago/install_trust_test.go
@@ -54,7 +54,7 @@ func TestInstallTrustLine_DualAttested(t *testing.T) {
 
 	items := buildTrustItems(t, globalDir, catalog.TrustTierDualAttested, false, "")
 	result, err := installToProvider(items, *prov, installer.MethodSymlink,
-		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir())
+		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir(), false)
 	if err != nil {
 		t.Fatalf("installToProvider: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestInstallTrustLine_Signed(t *testing.T) {
 
 	items := buildTrustItems(t, globalDir, catalog.TrustTierSigned, false, "")
 	result, _ := installToProvider(items, *prov, installer.MethodSymlink,
-		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir())
+		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir(), false)
 
 	if !strings.Contains(stdout.String(), "Verified (registry-attested)") {
 		t.Errorf("expected signed-tier drill-down text, got: %s", stdout.String())
@@ -111,7 +111,7 @@ func TestInstallTrustLine_Revoked(t *testing.T) {
 	// DualAttested + Revoked must still render as Revoked, not Verified.
 	items := buildTrustItems(t, globalDir, catalog.TrustTierDualAttested, true, "publisher revoked 2026-04-18")
 	result, _ := installToProvider(items, *prov, installer.MethodSymlink,
-		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir())
+		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir(), false)
 
 	out := stdout.String()
 	if !strings.Contains(out, "Revoked \u2014 publisher revoked 2026-04-18") {
@@ -144,7 +144,7 @@ func TestInstallTrustLine_UnknownSuppressed(t *testing.T) {
 
 	items := buildTrustItems(t, globalDir, catalog.TrustTierUnknown, false, "")
 	result, _ := installToProvider(items, *prov, installer.MethodSymlink,
-		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir())
+		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir(), false)
 
 	out := stdout.String()
 	if strings.Contains(out, "Verified") || strings.Contains(out, "Revoked") ||
@@ -172,7 +172,7 @@ func TestInstallTrustLine_JSONModeSuppressesText(t *testing.T) {
 
 	items := buildTrustItems(t, globalDir, catalog.TrustTierSigned, false, "")
 	result, _ := installToProvider(items, *prov, installer.MethodSymlink,
-		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir())
+		false, config.NewResolver(nil, ""), prov.Slug, t.TempDir(), false)
 
 	// installToProvider does not print the result JSON itself — that's the
 	// caller's job. In JSON mode it must not print the human trust line.
@@ -193,7 +193,7 @@ func TestInstallTrustLine_JSONModeSuppressesText(t *testing.T) {
 	// And an Unknown-tier item must omit the trust key entirely (omitempty).
 	itemsUnknown := buildTrustItems(t, globalDir, catalog.TrustTierUnknown, false, "")
 	resultU, _ := installToProvider(itemsUnknown, *prov, installer.MethodSymlink,
-		true /* dryRun so we don't re-install to the same target */, config.NewResolver(nil, ""), prov.Slug, t.TempDir())
+		true /* dryRun so we don't re-install to the same target */, config.NewResolver(nil, ""), prov.Slug, t.TempDir(), false)
 	if len(resultU.Installed) > 0 {
 		t.Fatalf("dry-run should not produce Installed entries, got %d", len(resultU.Installed))
 	}

--- a/cli/cmd/syllago/pin_cmd.go
+++ b/cli/cmd/syllago/pin_cmd.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+type pinResult struct {
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Registry  string `json:"registry"`
+	Pinned    bool   `json:"pinned"`
+	SourceSHA string `json:"source_sha,omitempty"`
+}
+
+var pinCmd = &cobra.Command{
+	Use:   "pin <name>",
+	Short: "Pin an installed registry item to hold its current content",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runPin,
+}
+
+var unpinCmd = &cobra.Command{
+	Use:   "unpin <name>",
+	Short: "Unpin a pinned registry item to allow updates",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runUnpin,
+}
+
+func init() {
+	pinCmd.Flags().String("type", "", "Disambiguate when name exists in multiple types")
+	unpinCmd.Flags().String("type", "", "Disambiguate when name exists in multiple types")
+	rootCmd.AddCommand(pinCmd)
+	rootCmd.AddCommand(unpinCmd)
+}
+
+func runPin(cmd *cobra.Command, args []string) error {
+	return handlePinState(cmd, args[0], true)
+}
+
+func runUnpin(cmd *cobra.Command, args []string) error {
+	return handlePinState(cmd, args[0], false)
+}
+
+func handlePinState(cmd *cobra.Command, name string, pinned bool) error {
+	typeFilter, _ := cmd.Flags().GetString("type")
+
+	// Use an empty temp dir as contentRoot to avoid scan shadowing.
+	emptyRoot, err := os.MkdirTemp("", "syllago-pin-*")
+	if err != nil {
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, "creating temp dir failed", "Check filesystem permissions and disk space", err.Error())
+	}
+	defer func() { _ = os.RemoveAll(emptyRoot) }()
+
+	cat, err := catalog.ScanWithGlobalAndRegistries(emptyRoot, emptyRoot, nil)
+	if err != nil {
+		return output.NewStructuredErrorDetail(output.ErrCatalogScanFailed, "scanning library failed", "Check that ~/.syllago/content/ exists and is readable", err.Error())
+	}
+
+	item, err := findLibraryItem(cat, name, typeFilter)
+	if err != nil {
+		return err
+	}
+	telemetry.Enrich("content_type", string(item.Type))
+
+	if item.Meta == nil || item.Meta.SourceRegistry == "" {
+		return output.NewStructuredError(
+			output.ErrItemNotFound,
+			"only registry items can be pinned",
+			fmt.Sprintf("Run 'syllago info %s' to check its metadata", name),
+		)
+	}
+
+	coord := installstore.Coord{
+		Registry: item.Meta.SourceRegistry,
+		Type:     string(item.Type),
+		Name:     item.Name,
+	}
+
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, "could not determine install store path", "Check filesystem permissions", err.Error())
+	}
+
+	if err := installstore.SetPinned(storePath, coord, pinned, time.Now()); err != nil {
+		return output.NewStructuredErrorDetail(
+			output.ErrInstallNotInstalled,
+			"pinning needs an installed item",
+			fmt.Sprintf("Run 'syllago install %s --to <provider>' first", name),
+			err.Error(),
+		)
+	}
+
+	var sourceSHA string
+	store, err := installstore.Load(storePath)
+	if err == nil {
+		if rec := store.Find(coord); rec != nil {
+			sourceSHA = rec.SourceSHA
+		}
+	}
+
+	if output.JSON {
+		output.Print(pinResult{
+			Name:      item.Name,
+			Type:      string(item.Type),
+			Registry:  item.Meta.SourceRegistry,
+			Pinned:    pinned,
+			SourceSHA: sourceSHA,
+		})
+		return nil
+	}
+
+	if pinned {
+		if sourceSHA != "" {
+			sha12 := sourceSHA
+			if len(sha12) > 12 {
+				sha12 = sha12[:12]
+			}
+			fmt.Fprintf(output.Writer, "Pinned %s/%s — holding at %s\n", string(item.Type), item.Name, sha12)
+		} else {
+			fmt.Fprintf(output.Writer, "Pinned %s/%s\n", string(item.Type), item.Name)
+		}
+	} else {
+		fmt.Fprintf(output.Writer, "Unpinned %s/%s\n", string(item.Type), item.Name)
+	}
+
+	return nil
+}

--- a/cli/cmd/syllago/pin_cmd_test.go
+++ b/cli/cmd/syllago/pin_cmd_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
+)
+
+func TestPinCommand_NonRegistry(t *testing.T) {
+	// Set GlobalDirOverride to temp
+	tmpDir := t.TempDir()
+	prevGlobal := config.GlobalDirOverride
+	config.GlobalDirOverride = tmpDir
+	t.Cleanup(func() { config.GlobalDirOverride = prevGlobal })
+
+	// Setup global library and withGlobalLibrary
+	globalDir := filepath.Join(tmpDir, "content")
+	os.MkdirAll(filepath.Join(globalDir, "skills", "non-reg-skill"), 0755)
+	os.WriteFile(filepath.Join(globalDir, "skills", "non-reg-skill", "SKILL.md"), []byte("# SKILL\n"), 0644)
+	withGlobalLibrary(t, globalDir)
+
+	_, _ = output.SetForTest(t)
+
+	err := pinCmd.RunE(pinCmd, []string{"non-reg-skill"})
+	if err == nil {
+		t.Fatal("expected error when pinning a non-registry item, got nil")
+	}
+	if !strings.Contains(err.Error(), "only registry items can be pinned") {
+		t.Errorf("expected only registry items can be pinned error, got: %v", err)
+	}
+}
+
+func TestPinCommand_RegistryAndUnpin(t *testing.T) {
+	// Set GlobalDirOverride to temp
+	tmpDir := t.TempDir()
+	prevGlobal := config.GlobalDirOverride
+	config.GlobalDirOverride = tmpDir
+	t.Cleanup(func() { config.GlobalDirOverride = prevGlobal })
+
+	// Setup global library and withGlobalLibrary
+	globalDir := filepath.Join(tmpDir, "content")
+	os.MkdirAll(filepath.Join(globalDir, "skills", "my-reg-skill"), 0755)
+	os.WriteFile(filepath.Join(globalDir, "skills", "my-reg-skill", "SKILL.md"), []byte("# SKILL\n"), 0644)
+	os.WriteFile(filepath.Join(globalDir, "skills", "my-reg-skill", ".syllago.yaml"), []byte("source_type: registry\nsource_registry: my-reg\n"), 0644)
+	withGlobalLibrary(t, globalDir)
+
+	stdout, _ := output.SetForTest(t)
+
+	// Seeding the install record first
+	path, err := installstore.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	// Make sure the store dir exists
+	os.MkdirAll(filepath.Dir(path), 0755)
+	store, err := installstore.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	coord := installstore.Coord{Registry: "my-reg", Type: "skills", Name: "my-reg-skill"}
+	store.Records = append(store.Records, installstore.Record{
+		Coord:       coord,
+		ContentHash: "fakehash",
+		SourceSHA:   "abcdef1234567890",
+		InstalledAt: time.Now(),
+		UpdatedAt:   time.Now(),
+	})
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Run pinCmd
+	stdout.Reset()
+	if err := pinCmd.RunE(pinCmd, []string{"my-reg-skill"}); err != nil {
+		t.Fatalf("pinCmd failed: %v", err)
+	}
+
+	gotOut := stdout.String()
+	expectedPinOut := "Pinned skills/my-reg-skill — holding at abcdef123456\n"
+	if gotOut != expectedPinOut {
+		t.Errorf("stdout = %q; want %q", gotOut, expectedPinOut)
+	}
+
+	// Verify in store
+	store, _ = installstore.Load(path)
+	rec := store.Find(coord)
+	if rec == nil {
+		t.Fatal("expected record to be found in store")
+	}
+	if !rec.Pinned {
+		t.Error("expected rec.Pinned to be true")
+	}
+
+	// Run unpinCmd
+	stdout.Reset()
+	if err := unpinCmd.RunE(unpinCmd, []string{"my-reg-skill"}); err != nil {
+		t.Fatalf("unpinCmd failed: %v", err)
+	}
+
+	gotUnpinOut := stdout.String()
+	expectedUnpinOut := "Unpinned skills/my-reg-skill\n"
+	if gotUnpinOut != expectedUnpinOut {
+		t.Errorf("stdout = %q; want %q", gotUnpinOut, expectedUnpinOut)
+	}
+
+	// Verify in store
+	store, _ = installstore.Load(path)
+	rec = store.Find(coord)
+	if rec == nil {
+		t.Fatal("expected record to be found in store")
+	}
+	if rec.Pinned {
+		t.Error("expected rec.Pinned to be false")
+	}
+}
+
+func TestPreOverwritePinGuard_Add(t *testing.T) {
+	const regName = "test-org/test-registry"
+
+	cacheDir := t.TempDir()
+	origCache := registry.CacheDirOverride
+	registry.CacheDirOverride = cacheDir
+	t.Cleanup(func() { registry.CacheDirOverride = origCache })
+
+	setupRegistryClone(t, cacheDir, regName)
+
+	root := setupProjectWithRegistry(t, regName)
+	origRoot := findProjectRoot
+	findProjectRoot = func() (string, error) { return root, nil }
+	t.Cleanup(func() { findProjectRoot = origRoot })
+
+	globalDir := t.TempDir()
+	origGlobal := catalog.GlobalContentDirOverride
+	catalog.GlobalContentDirOverride = globalDir
+	t.Cleanup(func() { catalog.GlobalContentDirOverride = origGlobal })
+
+	// Seed the install store in the temp global dir (so DefaultPath points to it)
+	tmpDir := t.TempDir()
+	prevGlobalDir := config.GlobalDirOverride
+	config.GlobalDirOverride = tmpDir
+	t.Cleanup(func() { config.GlobalDirOverride = prevGlobalDir })
+
+	path, err := installstore.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	os.MkdirAll(filepath.Dir(path), 0755)
+	store, err := installstore.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	coord := installstore.Coord{Registry: regName, Type: "skills", Name: "canary-skill"}
+	store.Records = append(store.Records, installstore.Record{
+		Coord:       coord,
+		ContentHash: "fakehash",
+		SourceSHA:   "abcdef1234567890",
+		Pinned:      true,
+		PinnedAt:    time.Now(),
+	})
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	_, stderr := output.SetForTest(t)
+
+	addCmd.Flags().Set("from", regName)
+	addCmd.Flags().Set("force", "false")
+	addCmd.Flags().Set("dry-run", "false")
+	t.Cleanup(func() {
+		addCmd.Flags().Set("from", "")
+		addCmd.Flags().Set("force", "false")
+		addCmd.Flags().Set("dry-run", "false")
+	})
+
+	err = addCmd.RunE(addCmd, []string{"skills/canary-skill"})
+	if err == nil {
+		t.Fatal("expected ErrInstallConflict when adding a pinned item, got nil")
+	}
+
+	expectedWarning := "  pinned skills/canary-skill — holding at abcdef123456; unpin to update: syllago unpin canary-skill"
+	if !strings.Contains(stderr.String(), expectedWarning) {
+		t.Errorf("expected warning about skipping add in stderr, got:\n%s", stderr.String())
+	}
+}
+
+func TestAddFrozenFlagValidation(t *testing.T) {
+	root := t.TempDir()
+	origRoot := findProjectRoot
+	findProjectRoot = func() (string, error) { return root, nil }
+	t.Cleanup(func() { findProjectRoot = origRoot })
+
+	_, _ = output.SetForTest(t)
+
+	t.Cleanup(func() {
+		addCmd.Flags().Set("from", "")
+		addCmd.Flags().Set("frozen", "false")
+		addCmd.Flags().Set("install", "false")
+		addCmd.Flags().Set("to", "")
+	})
+
+	// --frozen without --install/--to must error, not silently drop the pin.
+	addCmd.Flags().Set("from", "claude-code")
+	addCmd.Flags().Set("frozen", "true")
+	err := addCmd.RunE(addCmd, []string{"skills/foo"})
+	if err == nil || !strings.Contains(err.Error(), "--frozen requires --install and --to") {
+		t.Errorf("expected frozen-requires-install error, got: %v", err)
+	}
+
+	// --frozen on a registry add must error: that branch never chains an install.
+	addCmd.Flags().Set("install", "true")
+	addCmd.Flags().Set("to", "claude-code")
+	addCmd.Flags().Set("from", "some-org/some-registry")
+	err = addCmd.RunE(addCmd, []string{"skills/foo"})
+	if err == nil || !strings.Contains(err.Error(), "not supported when adding from a registry") {
+		t.Errorf("expected registry frozen error, got: %v", err)
+	}
+}

--- a/cli/cmd/syllago/registry_diff.go
+++ b/cli/cmd/syllago/registry_diff.go
@@ -63,6 +63,22 @@ func printInstalledDrift(w io.Writer, drifts []registryops.InstalledDrift, hints
 
 	fmt.Fprintln(w, "Installed items drifted from upstream:")
 	for _, drift := range drifts {
+		if drift.Pinned {
+			provStr := ""
+			if len(drift.Providers) > 0 {
+				provStr = " (" + strings.Join(drift.Providers, ", ") + ")"
+			}
+			sha := drift.HeldAt
+			if len(sha) > 12 {
+				sha = sha[:12]
+			}
+			if sha != "" {
+				fmt.Fprintf(w, "  %s/%s%s is pinned — holding at %s\n", drift.Type, drift.Name, provStr, sha)
+			} else {
+				fmt.Fprintf(w, "  %s/%s%s is pinned\n", drift.Type, drift.Name, provStr)
+			}
+			continue
+		}
 		switch drift.Kind {
 		case registryops.DriftChanged:
 			switch hints {

--- a/cli/commands.json
+++ b/cli/commands.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generatedAt": "2026-08-24T18:46:23Z",
+  "generatedAt": "2026-08-24T19:18:09Z",
   "syllagoVersion": "0.14.0",
   "commands": [
     {
@@ -60,6 +60,14 @@
           "default": null,
           "required": true,
           "description": "Provider to add from, or path to a monolithic rule file (repeatable for files)"
+        },
+        {
+          "name": "--frozen",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Pin the install record created by this command"
         },
         {
           "name": "--install",
@@ -1581,6 +1589,14 @@
           "description": "Proceed past high-severity scanner findings"
         },
         {
+          "name": "--frozen",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Pin the install record created by this command"
+        },
+        {
           "name": "--hook-scanner",
           "shorthand": null,
           "type": "stringSlice",
@@ -2547,6 +2563,64 @@
       ],
       "examples": null,
       "source": "cli/cmd/syllago/trust_cmd.go"
+    },
+    {
+      "name": "pin",
+      "displayName": "Pin",
+      "slug": "pin",
+      "parent": null,
+      "synopsis": "syllago pin \u003cname\u003e [flags]",
+      "description": "Pin an installed registry item to hold its current content",
+      "longDescription": null,
+      "aliases": [],
+      "flags": [
+        {
+          "name": "--type",
+          "shorthand": null,
+          "type": "string",
+          "default": null,
+          "required": false,
+          "description": "Disambiguate when name exists in multiple types"
+        }
+      ],
+      "inheritedFlags": [
+        {
+          "name": "--json",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Output in JSON format"
+        },
+        {
+          "name": "--no-color",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Disable color output"
+        },
+        {
+          "name": "--quiet",
+          "shorthand": "-q",
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Suppress non-essential output"
+        },
+        {
+          "name": "--verbose",
+          "shorthand": "-v",
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Verbose output"
+        }
+      ],
+      "subcommands": [],
+      "seeAlso": [],
+      "examples": null,
+      "source": "cli/cmd/syllago/pin.go"
     },
     {
       "name": "providers",
@@ -4711,6 +4785,64 @@
       "seeAlso": [],
       "examples": "  # Uninstall from a specific provider\n  syllago uninstall my-skill --from claude-code\n\n  # Uninstall from all providers\n  syllago uninstall my-agent\n\n  # Skip confirmation prompt\n  syllago uninstall my-rule --from cursor --force\n\n  # Preview what would happen\n  syllago uninstall my-skill --dry-run",
       "source": "cli/cmd/syllago/uninstall.go"
+    },
+    {
+      "name": "unpin",
+      "displayName": "Unpin",
+      "slug": "unpin",
+      "parent": null,
+      "synopsis": "syllago unpin \u003cname\u003e [flags]",
+      "description": "Unpin a pinned registry item to allow updates",
+      "longDescription": null,
+      "aliases": [],
+      "flags": [
+        {
+          "name": "--type",
+          "shorthand": null,
+          "type": "string",
+          "default": null,
+          "required": false,
+          "description": "Disambiguate when name exists in multiple types"
+        }
+      ],
+      "inheritedFlags": [
+        {
+          "name": "--json",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Output in JSON format"
+        },
+        {
+          "name": "--no-color",
+          "shorthand": null,
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Disable color output"
+        },
+        {
+          "name": "--quiet",
+          "shorthand": "-q",
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Suppress non-essential output"
+        },
+        {
+          "name": "--verbose",
+          "shorthand": "-v",
+          "type": "bool",
+          "default": null,
+          "required": false,
+          "description": "Verbose output"
+        }
+      ],
+      "subcommands": [],
+      "seeAlso": [],
+      "examples": null,
+      "source": "cli/cmd/syllago/unpin.go"
     },
     {
       "name": "update",

--- a/cli/internal/registryops/drift.go
+++ b/cli/internal/registryops/drift.go
@@ -21,11 +21,13 @@ const (
 
 // InstalledDrift is one installed item's drift against its source registry.
 type InstalledDrift struct {
-	Registry  string
-	Type      string // content type slug, e.g. "skills"
-	Name      string
-	Kind      DriftKind
-	Providers []string // provider slugs with placements for this item, sorted, deduped
+	Registry  string    `json:"registry"`
+	Type      string    `json:"type"`
+	Name      string    `json:"name"`
+	Kind      DriftKind `json:"kind"`
+	Providers []string  `json:"providers"`
+	Pinned    bool      `json:"pinned"`
+	HeldAt    string    `json:"held_at"`
 }
 
 // InstalledGitDrift reports drift for every installed item that originated
@@ -73,6 +75,10 @@ func InstalledGitDrift(regName string) []InstalledDrift {
 	for _, rec := range records {
 		key := installedDriftKey{contentType: rec.Type, name: rec.Name}
 		status, ok := discovered[key]
+		heldAt := ""
+		if rec.Pinned {
+			heldAt = rec.SourceSHA
+		}
 		if !ok {
 			drifts = append(drifts, InstalledDrift{
 				Registry:  regName,
@@ -80,6 +86,8 @@ func InstalledGitDrift(regName string) []InstalledDrift {
 				Name:      rec.Name,
 				Kind:      DriftMissing,
 				Providers: installedDriftProviders(rec),
+				Pinned:    rec.Pinned,
+				HeldAt:    heldAt,
 			})
 			continue
 		}
@@ -90,6 +98,8 @@ func InstalledGitDrift(regName string) []InstalledDrift {
 				Name:      rec.Name,
 				Kind:      DriftChanged,
 				Providers: installedDriftProviders(rec),
+				Pinned:    rec.Pinned,
+				HeldAt:    heldAt,
 			})
 		}
 	}
@@ -136,6 +146,10 @@ func InstalledMOATDrift(regName string, diff *regdiff.Diff) []InstalledDrift {
 	drifts := make([]InstalledDrift, 0)
 	for _, rec := range records {
 		key := installedDriftKey{contentType: rec.Type, name: rec.Name}
+		heldAt := ""
+		if rec.Pinned {
+			heldAt = rec.SourceSHA
+		}
 		switch changes[key] {
 		case regdiff.KindModified:
 			drifts = append(drifts, InstalledDrift{
@@ -144,6 +158,8 @@ func InstalledMOATDrift(regName string, diff *regdiff.Diff) []InstalledDrift {
 				Name:      rec.Name,
 				Kind:      DriftChanged,
 				Providers: installedDriftProviders(rec),
+				Pinned:    rec.Pinned,
+				HeldAt:    heldAt,
 			})
 		case regdiff.KindRemoved:
 			drifts = append(drifts, InstalledDrift{
@@ -152,6 +168,8 @@ func InstalledMOATDrift(regName string, diff *regdiff.Diff) []InstalledDrift {
 				Name:      rec.Name,
 				Kind:      DriftMissing,
 				Providers: installedDriftProviders(rec),
+				Pinned:    rec.Pinned,
+				HeldAt:    heldAt,
 			})
 		}
 	}

--- a/cli/internal/telemetry/catalog.go
+++ b/cli/internal/telemetry/catalog.go
@@ -51,7 +51,14 @@ func EventCatalog() []EventDef {
 					Type:        "string",
 					Description: "Content type filter or specific type",
 					Example:     "rules",
-					Commands:    []string{"install", "add", "convert", "create", "uninstall", "remove", "list", "share", "rollback", "sync-and-export", "registry_items"},
+					Commands:    []string{"install", "add", "convert", "create", "uninstall", "remove", "list", "share", "rollback", "sync-and-export", "registry_items", "pin", "unpin"},
+				},
+				{
+					Name:        "frozen",
+					Type:        "bool",
+					Description: "Whether --frozen was used to pin the install record",
+					Example:     true,
+					Commands:    []string{"install", "add"},
 				},
 				{
 					Name:        "content_count",

--- a/cli/telemetry.json
+++ b/cli/telemetry.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generatedAt": "2026-08-24T18:46:24Z",
+  "generatedAt": "2026-08-24T19:18:10Z",
   "syllagoVersion": "0.14.0",
   "events": [
     {
@@ -46,7 +46,19 @@
             "share",
             "rollback",
             "sync-and-export",
-            "registry_items"
+            "registry_items",
+            "pin",
+            "unpin"
+          ]
+        },
+        {
+          "name": "frozen",
+          "type": "bool",
+          "description": "Whether --frozen was used to pin the install record",
+          "example": true,
+          "commands": [
+            "install",
+            "add"
           ]
         },
         {


### PR DESCRIPTION
## Summary

- Adds `syllago pin <name>` / `syllago unpin <name>` to hold a registry item at its current SourceSHA.
- Adds a `--frozen` flag on `install` and `add` (`--install --to`) that pins the created install record at creation time.
- Adds a pinned guard that blocks registry re-adds and MOAT installs of pinned items, so a pin cannot be silently overwritten.
- Renders pinned state in `registry diff` drift output.
- `--frozen` is rejected on add paths that never chain an install, instead of being silently dropped.

Part of #542 (item 7d).

## Testing

- Full local suite passed: `go build ./...` and `go test -count=1 ./...` green, gofmt clean.
- New tests: `TestPinCommand_NonRegistry`, `TestPinCommand_RegistryAndUnpin`, `TestPreOverwritePinGuard_Add`, `TestAddFrozenFlagValidation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
