### PR TITLE
refactor(cli): extract shared rollback package from rollback command (#542 item 7f-i)

### DIFF
--- a/cli/cmd/syllago/install_cmd_append.go
+++ b/cli/cmd/syllago/install_cmd_append.go
@@ -298,18 +298,5 @@ func runInstallAppend(cmd *cobra.Command, args []string, toSlug, typeFilter stri
 // wins when the same rule name exists under multiple source providers — D14
 // uniqueness is enforced per (LibraryID, TargetFile), not per name.
 func findLibraryRuleDir(rulesRoot, name string) (string, error) {
-	entries, err := os.ReadDir(rulesRoot)
-	if err != nil {
-		return "", err
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		candidate := filepath.Join(rulesRoot, e.Name(), name)
-		if info, serr := os.Stat(candidate); serr == nil && info.IsDir() {
-			return candidate, nil
-		}
-	}
-	return "", fs.ErrNotExist
+	return rulestore.FindRuleDir(rulesRoot, name)
 }

--- a/cli/cmd/syllago/rollback_cmd.go
+++ b/cli/cmd/syllago/rollback_cmd.go
@@ -1,22 +1,13 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"io"
-	"io/fs"
 	"os"
-	"path/filepath"
-	"time"
 
-	"github.com/OpenScribbler/syllago/cli/internal/add"
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
-	"github.com/OpenScribbler/syllago/cli/internal/installer"
 	"github.com/OpenScribbler/syllago/cli/internal/installstore"
 	"github.com/OpenScribbler/syllago/cli/internal/output"
-	"github.com/OpenScribbler/syllago/cli/internal/provider"
-	"github.com/OpenScribbler/syllago/cli/internal/registry"
-	"github.com/OpenScribbler/syllago/cli/internal/rulestore"
+	"github.com/OpenScribbler/syllago/cli/internal/rollback"
 	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
 	"github.com/spf13/cobra"
 )
@@ -67,32 +58,20 @@ func runRollback(cmd *cobra.Command, args []string) error {
 	telemetry.Enrich("content_type", string(item.Type))
 	telemetry.Enrich("dry_run", dryRun)
 
-	if item.Meta == nil || item.Meta.SourceRegistry == "" {
-		return output.NewStructuredError(
-			output.ErrInputInvalid,
-			fmt.Sprintf("%s/%s is not registry-sourced", item.Type, item.Name),
-			"Rollback needs an item installed from a registry update.",
-		)
-	}
-
-	storePath, rec, coord, err := loadRollbackRecord(*item)
+	plan, err := rollback.PlanFor(*item)
 	if err != nil {
 		return err
-	}
-	prev := rec.Previous
-	if prev == nil || prev.SourceSHA == "" && prev.CopyPath == "" {
-		return noRollbackDataError(coord)
 	}
 
 	result := rollbackResult{
 		Name:     item.Name,
 		Type:     string(item.Type),
-		Registry: coord.Registry,
+		Registry: plan.Coord.Registry,
 	}
-	if prev.CopyPath != "" {
+	if plan.FromCopy {
 		result.RestoredFromCopy = true
 	} else {
-		result.RestoredSourceSHA = prev.SourceSHA
+		result.RestoredSourceSHA = plan.Prev.SourceSHA
 	}
 
 	if dryRun {
@@ -100,29 +79,12 @@ func runRollback(cmd *cobra.Command, args []string) error {
 			output.Print(result)
 			return nil
 		}
-		printRollbackDryRunPlan(*item, prev)
+		printRollbackDryRunPlan(*item, &plan.Prev)
 		return nil
 	}
 
-	placements := append([]installstore.Placement(nil), rec.Placements...)
-
-	if prev.CopyPath != "" {
-		if err := restoreFromPreviousCopy(rec.LibraryPath, prev.CopyPath); err != nil {
-			return err
-		}
-	} else {
-		if err := restoreFromGitPrevious(*item, rec.LibraryPath, coord.Registry, prev.SourceSHA); err != nil {
-			return err
-		}
-	}
-
-	if err := installstore.RecordRollback(storePath, coord, rec.LibraryPath, time.Now()); err != nil {
-		return output.NewStructuredErrorDetail(
-			output.ErrSystemIO,
-			"content was restored but install record rollback failed",
-			"Inspect the library item and install record before running another update.",
-			err.Error(),
-		)
+	if err := rollback.Restore(plan, version); err != nil {
+		return err
 	}
 
 	var reappliedPlacements []installstore.Placement
@@ -130,7 +92,15 @@ func runRollback(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		fmt.Fprintf(output.ErrWriter, "warning: could not reload restored item for placement re-apply: %v\n", err)
 	} else {
-		reappliedPlacements = reapplyRollbackPlacements(*restoredItem, placements)
+		root, rootErr := findProjectRoot()
+		var warnings []string
+		reappliedPlacements, warnings = rollback.ReapplyPlacements(*restoredItem, plan.Placements, rollback.Options{
+			ProjectRoot:    root,
+			ProjectRootErr: rootErr,
+		})
+		for _, w := range warnings {
+			fmt.Fprintf(output.ErrWriter, "warning: %s\n", w)
+		}
 		result.PlacementsReapplied = len(reappliedPlacements)
 	}
 
@@ -144,7 +114,7 @@ func runRollback(cmd *cobra.Command, args []string) error {
 	if result.RestoredFromCopy {
 		fmt.Fprintf(output.Writer, "Rolled back %s/%s to previous version\n", item.Type, item.Name)
 	} else {
-		fmt.Fprintf(output.Writer, "Rolled back %s/%s to %s\n", item.Type, item.Name, shortSHA(prev.SourceSHA))
+		fmt.Fprintf(output.Writer, "Rolled back %s/%s to %s\n", item.Type, item.Name, rollback.ShortSHA(plan.Prev.SourceSHA))
 	}
 	for _, pl := range reappliedPlacements {
 		fmt.Fprintf(output.Writer, "Re-applied %s placement for %s\n", pl.Mechanism, pl.Provider)
@@ -166,49 +136,6 @@ func resolveRollbackLibraryItem(name, typeFilter string) (*catalog.ContentItem, 
 	return findLibraryItem(cat, name, typeFilter)
 }
 
-func loadRollbackRecord(item catalog.ContentItem) (string, *installstore.Record, installstore.Coord, error) {
-	coord := installstore.Coord{
-		Registry: item.Meta.SourceRegistry,
-		Type:     string(item.Type),
-		Name:     item.Name,
-	}
-	storePath, err := installstore.DefaultPath()
-	if err != nil {
-		return "", nil, coord, output.NewStructuredErrorDetail(output.ErrSystemHomedir, "install record path unavailable", "Set the HOME environment variable", err.Error())
-	}
-	if _, err := os.Stat(storePath); err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return "", nil, coord, noInstallRecordError(coord)
-		}
-		return "", nil, coord, output.NewStructuredErrorDetail(output.ErrSystemIO, "checking install record store failed", "Check ~/.syllago/installs.json permissions", err.Error())
-	}
-	store, err := installstore.Load(storePath)
-	if err != nil {
-		return "", nil, coord, output.NewStructuredErrorDetail(output.ErrSystemIO, "loading install record store failed", "Check ~/.syllago/installs.json syntax and permissions", err.Error())
-	}
-	rec := store.Find(coord)
-	if rec == nil {
-		return "", nil, coord, noInstallRecordError(coord)
-	}
-	return storePath, rec, coord, nil
-}
-
-func noInstallRecordError(c installstore.Coord) error {
-	return output.NewStructuredError(
-		output.ErrInstallNotInstalled,
-		fmt.Sprintf("no install record for %s/%s", c.Type, c.Name),
-		"Rollback needs an installed item with update history.",
-	)
-}
-
-func noRollbackDataError(c installstore.Coord) error {
-	return output.NewStructuredError(
-		output.ErrInstallConflict,
-		fmt.Sprintf("no rollback data for %s/%s", c.Type, c.Name),
-		"Rollback is one-step: it becomes available after an update replaces the item.",
-	)
-}
-
 func printRollbackDryRunPlan(item catalog.ContentItem, prev *installstore.PreviousVersion) {
 	if output.Quiet && !output.JSON {
 		return
@@ -221,245 +148,5 @@ func printRollbackDryRunPlan(item catalog.ContentItem, prev *installstore.Previo
 		fmt.Fprintf(output.Writer, "would roll back %s/%s to saved copy from %s\n", item.Type, item.Name, when)
 		return
 	}
-	fmt.Fprintf(output.Writer, "would roll back %s/%s to %s\n", item.Type, item.Name, shortSHA(prev.SourceSHA))
-}
-
-func restoreFromPreviousCopy(libraryPath, copyPath string) error {
-	info, err := os.Stat(copyPath)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return output.NewStructuredError(
-				output.ErrInstallConflict,
-				fmt.Sprintf("saved previous copy is gone: %s", copyPath),
-				"Rollback copy data is local and one-step; restore from backup or re-add the item from its registry.",
-			)
-		}
-		return output.NewStructuredErrorDetail(output.ErrSystemIO, "checking saved previous copy failed", "Check filesystem permissions", err.Error())
-	}
-	if !info.IsDir() {
-		return output.NewStructuredError(output.ErrInstallConflict, fmt.Sprintf("saved previous copy is not a directory: %s", copyPath), "Rollback copy data must be an intact directory tree.")
-	}
-	if err := os.RemoveAll(libraryPath); err != nil {
-		return output.NewStructuredErrorDetail(output.ErrSystemIO, "removing current library item failed", "Check permissions in ~/.syllago/content/", err.Error())
-	}
-	if err := copyTree(copyPath, libraryPath); err != nil {
-		return output.NewStructuredErrorDetail(output.ErrSystemIO, "restoring saved previous copy failed", "Check permissions in ~/.syllago/content/ and the saved rollback copy.", err.Error())
-	}
-	return nil
-}
-
-func restoreFromGitPrevious(item catalog.ContentItem, libraryPath, regName, sha string) error {
-	globalDir := catalog.GlobalContentDir()
-	if globalDir == "" {
-		return output.NewStructuredError(output.ErrSystemHomedir, "cannot determine home directory", "Set the HOME environment variable")
-	}
-	worktreeDir, cleanup, err := registry.WorktreeAt(regName, sha)
-	if err != nil {
-		return output.NewStructuredErrorDetail(
-			output.ErrRegistrySyncFailed,
-			fmt.Sprintf("could not materialize rollback source %s", shortSHA(sha)),
-			"Run 'syllago registry sync "+regName+"' or restore the registry clone with full history.",
-			err.Error(),
-		)
-	}
-	defer cleanup()
-
-	items, err := add.DiscoverFromRegistry(regName, worktreeDir, globalDir)
-	if err != nil {
-		return output.NewStructuredErrorDetail(output.ErrCatalogScanFailed, "scanning rollback registry checkout failed", "Check registry contents at the rollback commit.", err.Error())
-	}
-	var match *add.DiscoveryItem
-	for i := range items {
-		if items[i].Type == item.Type && items[i].Name == item.Name {
-			match = &items[i]
-			break
-		}
-	}
-	if match == nil {
-		return output.NewStructuredError(
-			output.ErrItemNotFound,
-			fmt.Sprintf("item did not exist at %s", shortSHA(sha)),
-			"Rollback can only restore items present at the recorded previous registry commit.",
-		)
-	}
-
-	sourceProvider := item.Provider
-	sourceVisibility := ""
-	if item.Meta != nil {
-		if sourceProvider == "" {
-			sourceProvider = item.Meta.SourceProvider
-		}
-		sourceVisibility = item.Meta.SourceVisibility
-	}
-	results := add.AddItems([]add.DiscoveryItem{*match}, add.AddOptions{
-		Force:            true,
-		Provider:         sourceProvider,
-		SourceRegistry:   regName,
-		SourceSHA:        sha,
-		SourceVisibility: sourceVisibility,
-	}, globalDir, nil, version)
-	if len(results) != 1 {
-		return output.NewStructuredError(output.ErrSystemIO, fmt.Sprintf("restoring %s/%s failed", item.Type, item.Name), "The rollback restore did not produce a result.")
-	}
-	if results[0].Status == add.AddStatusError {
-		return output.NewStructuredErrorDetail(output.ErrSystemIO, fmt.Sprintf("restoring %s/%s failed", item.Type, item.Name), "Check registry item contents and library permissions.", results[0].Error.Error())
-	}
-	if _, err := os.Stat(libraryPath); err != nil {
-		return output.NewStructuredErrorDetail(output.ErrSystemIO, "restored library item is missing", "The registry restore completed but the expected library path was not found.", err.Error())
-	}
-	return nil
-}
-
-func reapplyRollbackPlacements(item catalog.ContentItem, placements []installstore.Placement) []installstore.Placement {
-	projectRoot, projectErr := findProjectRoot()
-	var reapplied []installstore.Placement
-	for _, pl := range placements {
-		if !shouldReapplyPlacement(pl.Mechanism) {
-			continue
-		}
-		if projectErr != nil {
-			warnRollbackPlacement(pl, projectErr)
-			continue
-		}
-		prov := findProviderBySlug(pl.Provider)
-		if prov == nil {
-			warnRollbackPlacement(pl, fmt.Errorf("unknown provider"))
-			continue
-		}
-		var err error
-		switch pl.Mechanism {
-		case installstore.MechanismHookMerge, installstore.MechanismMCPMerge:
-			err = reapplyJSONMergePlacement(item, *prov, projectRoot)
-		case installstore.MechanismRuleAppend:
-			err = reapplyRuleAppendPlacement(item, pl, projectRoot)
-		}
-		if err != nil {
-			warnRollbackPlacement(pl, err)
-			continue
-		}
-		reapplied = append(reapplied, pl)
-	}
-	return reapplied
-}
-
-func shouldReapplyPlacement(m installstore.Mechanism) bool {
-	switch m {
-	case installstore.MechanismHookMerge, installstore.MechanismMCPMerge, installstore.MechanismRuleAppend:
-		return true
-	default:
-		return false
-	}
-}
-
-func reapplyJSONMergePlacement(item catalog.ContentItem, prov provider.Provider, projectRoot string) error {
-	if _, err := installer.Uninstall(item, prov, projectRoot); err != nil {
-		return fmt.Errorf("remove current merge before re-apply: %w", err)
-	}
-	if _, err := installer.Install(item, prov, projectRoot, installer.MethodSymlink, ""); err != nil {
-		return fmt.Errorf("install restored merge: %w", err)
-	}
-	return nil
-}
-
-func reapplyRuleAppendPlacement(item catalog.ContentItem, pl installstore.Placement, projectRoot string) error {
-	if item.Type != catalog.Rules {
-		return fmt.Errorf("rule_append placement recorded for %s item", item.Type)
-	}
-	globalDir := catalog.GlobalContentDir()
-	if globalDir == "" {
-		return fmt.Errorf("cannot determine home directory")
-	}
-	ruleDir, err := findLibraryRuleDir(filepath.Join(globalDir, string(catalog.Rules)), item.Name)
-	if err != nil {
-		return err
-	}
-	loaded, err := rulestore.LoadRule(ruleDir)
-	if err != nil {
-		return err
-	}
-	body := loaded.History[loaded.Meta.CurrentVersion]
-	if body == nil {
-		return fmt.Errorf("no history entry for current_version %s", loaded.Meta.CurrentVersion)
-	}
-	inst, err := installer.LoadInstalled(projectRoot)
-	if err != nil {
-		return err
-	}
-	libraryID := loaded.Meta.ID
-	for _, r := range inst.RuleAppends {
-		if r.Name == item.Name && r.Provider == pl.Provider && r.TargetFile == pl.Path {
-			libraryID = r.LibraryID
-			break
-		}
-	}
-	library := map[string]*rulestore.Loaded{
-		libraryID:      loaded,
-		loaded.Meta.ID: loaded,
-	}
-	return installer.ReplaceRuleAppend(projectRoot, libraryID, pl.Path, body, library)
-}
-
-func warnRollbackPlacement(pl installstore.Placement, err error) {
-	fmt.Fprintf(output.ErrWriter, "warning: could not re-apply %s placement for %s: %v\n", pl.Mechanism, pl.Provider, err)
-}
-
-func copyTree(src, dst string) error {
-	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.Type()&os.ModeSymlink != 0 {
-			return nil
-		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
-		if d.IsDir() {
-			return os.MkdirAll(target, 0755)
-		}
-		return copyTreeFile(path, target)
-	})
-}
-
-func copyTreeFile(src, dst string) (err error) {
-	if info, err := os.Lstat(dst); err == nil && info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("destination is a symlink: %s", dst)
-	}
-	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
-		return err
-	}
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = in.Close() }()
-
-	out, err := os.CreateTemp(filepath.Dir(dst), ".syllago-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := out.Name()
-	defer func() {
-		if err != nil {
-			_ = out.Close()
-			_ = os.Remove(tmpPath)
-		}
-	}()
-
-	if _, err = io.Copy(out, in); err != nil {
-		return err
-	}
-	if err = out.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tmpPath, dst)
-}
-
-func shortSHA(sha string) string {
-	if len(sha) <= 12 {
-		return sha
-	}
-	return sha[:12]
+	fmt.Fprintf(output.Writer, "would roll back %s/%s to %s\n", item.Type, item.Name, rollback.ShortSHA(prev.SourceSHA))
 }

--- a/cli/cmd/syllago/rollback_shortsha_test.go
+++ b/cli/cmd/syllago/rollback_shortsha_test.go
@@ -1,0 +1,7 @@
+package main
+
+import rollbackpkg "github.com/OpenScribbler/syllago/cli/internal/rollback"
+
+func shortSHA(sha string) string {
+	return rollbackpkg.ShortSHA(sha)
+}

--- a/cli/internal/rollback/rollback.go
+++ b/cli/internal/rollback/rollback.go
@@ -1,0 +1,382 @@
+package rollback
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/add"
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
+	"github.com/OpenScribbler/syllago/cli/internal/rulestore"
+)
+
+// Plan describes a resolved one-step rollback.
+type Plan struct {
+	Item        catalog.ContentItem
+	Coord       installstore.Coord
+	StorePath   string
+	LibraryPath string
+	Prev        installstore.PreviousVersion
+	Placements  []installstore.Placement
+	FromCopy    bool
+}
+
+// Options carries cmd-layer context into ReapplyPlacements.
+type Options struct {
+	ProjectRoot    string
+	ProjectRootErr error
+}
+
+// PlanFor resolves the install record and previous version data for item.
+func PlanFor(item catalog.ContentItem) (*Plan, error) {
+	if item.Meta == nil || item.Meta.SourceRegistry == "" {
+		return nil, output.NewStructuredError(
+			output.ErrInputInvalid,
+			fmt.Sprintf("%s/%s is not registry-sourced", item.Type, item.Name),
+			"Rollback needs an item installed from a registry update.",
+		)
+	}
+
+	storePath, rec, coord, err := loadRollbackRecord(item)
+	if err != nil {
+		return nil, err
+	}
+	if rec.Previous == nil || rec.Previous.SourceSHA == "" && rec.Previous.CopyPath == "" {
+		return nil, noRollbackDataError(coord)
+	}
+
+	prev := *rec.Previous
+	return &Plan{
+		Item:        item,
+		Coord:       coord,
+		StorePath:   storePath,
+		LibraryPath: rec.LibraryPath,
+		Prev:        prev,
+		Placements:  append([]installstore.Placement(nil), rec.Placements...),
+		FromCopy:    prev.CopyPath != "",
+	}, nil
+}
+
+func loadRollbackRecord(item catalog.ContentItem) (string, *installstore.Record, installstore.Coord, error) {
+	coord := installstore.Coord{
+		Registry: item.Meta.SourceRegistry,
+		Type:     string(item.Type),
+		Name:     item.Name,
+	}
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		return "", nil, coord, output.NewStructuredErrorDetail(output.ErrSystemHomedir, "install record path unavailable", "Set the HOME environment variable", err.Error())
+	}
+	if _, err := os.Stat(storePath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil, coord, noInstallRecordError(coord)
+		}
+		return "", nil, coord, output.NewStructuredErrorDetail(output.ErrSystemIO, "checking install record store failed", "Check ~/.syllago/installs.json permissions", err.Error())
+	}
+	store, err := installstore.Load(storePath)
+	if err != nil {
+		return "", nil, coord, output.NewStructuredErrorDetail(output.ErrSystemIO, "loading install record store failed", "Check ~/.syllago/installs.json syntax and permissions", err.Error())
+	}
+	rec := store.Find(coord)
+	if rec == nil {
+		return "", nil, coord, noInstallRecordError(coord)
+	}
+	return storePath, rec, coord, nil
+}
+
+func noInstallRecordError(c installstore.Coord) error {
+	return output.NewStructuredError(
+		output.ErrInstallNotInstalled,
+		fmt.Sprintf("no install record for %s/%s", c.Type, c.Name),
+		"Rollback needs an installed item with update history.",
+	)
+}
+
+func noRollbackDataError(c installstore.Coord) error {
+	return output.NewStructuredError(
+		output.ErrInstallConflict,
+		fmt.Sprintf("no rollback data for %s/%s", c.Type, c.Name),
+		"Rollback is one-step: it becomes available after an update replaces the item.",
+	)
+}
+
+// Restore restores plan's previous content and records the rollback.
+func Restore(plan *Plan, version string) error {
+	if plan.FromCopy {
+		if err := restoreFromPreviousCopy(plan.LibraryPath, plan.Prev.CopyPath); err != nil {
+			return err
+		}
+	} else {
+		if err := restoreFromGitPrevious(plan.Item, plan.LibraryPath, plan.Coord.Registry, plan.Prev.SourceSHA, version); err != nil {
+			return err
+		}
+	}
+
+	if err := installstore.RecordRollback(plan.StorePath, plan.Coord, plan.LibraryPath, time.Now()); err != nil {
+		return output.NewStructuredErrorDetail(
+			output.ErrSystemIO,
+			"content was restored but install record rollback failed",
+			"Inspect the library item and install record before running another update.",
+			err.Error(),
+		)
+	}
+	return nil
+}
+
+// ReapplyPlacements re-applies merge and append placements for a restored item.
+func ReapplyPlacements(item catalog.ContentItem, placements []installstore.Placement, opts Options) (reapplied []installstore.Placement, warnings []string) {
+	for _, pl := range placements {
+		if !shouldReapplyPlacement(pl.Mechanism) {
+			continue
+		}
+		if opts.ProjectRootErr != nil {
+			warnings = append(warnings, rollbackPlacementWarning(pl, opts.ProjectRootErr))
+			continue
+		}
+		prov := findProviderBySlug(pl.Provider)
+		if prov == nil {
+			warnings = append(warnings, rollbackPlacementWarning(pl, fmt.Errorf("unknown provider")))
+			continue
+		}
+		var err error
+		switch pl.Mechanism {
+		case installstore.MechanismHookMerge, installstore.MechanismMCPMerge:
+			err = reapplyJSONMergePlacement(item, *prov, opts.ProjectRoot)
+		case installstore.MechanismRuleAppend:
+			err = reapplyRuleAppendPlacement(item, pl, opts.ProjectRoot)
+		}
+		if err != nil {
+			warnings = append(warnings, rollbackPlacementWarning(pl, err))
+			continue
+		}
+		reapplied = append(reapplied, pl)
+	}
+	return reapplied, warnings
+}
+
+func shouldReapplyPlacement(m installstore.Mechanism) bool {
+	switch m {
+	case installstore.MechanismHookMerge, installstore.MechanismMCPMerge, installstore.MechanismRuleAppend:
+		return true
+	default:
+		return false
+	}
+}
+
+func reapplyJSONMergePlacement(item catalog.ContentItem, prov provider.Provider, projectRoot string) error {
+	if _, err := installer.Uninstall(item, prov, projectRoot); err != nil {
+		return fmt.Errorf("remove current merge before re-apply: %w", err)
+	}
+	if _, err := installer.Install(item, prov, projectRoot, installer.MethodSymlink, ""); err != nil {
+		return fmt.Errorf("install restored merge: %w", err)
+	}
+	return nil
+}
+
+func reapplyRuleAppendPlacement(item catalog.ContentItem, pl installstore.Placement, projectRoot string) error {
+	if item.Type != catalog.Rules {
+		return fmt.Errorf("rule_append placement recorded for %s item", item.Type)
+	}
+	globalDir := catalog.GlobalContentDir()
+	if globalDir == "" {
+		return fmt.Errorf("cannot determine home directory")
+	}
+	ruleDir, err := rulestore.FindRuleDir(filepath.Join(globalDir, string(catalog.Rules)), item.Name)
+	if err != nil {
+		return err
+	}
+	loaded, err := rulestore.LoadRule(ruleDir)
+	if err != nil {
+		return err
+	}
+	body := loaded.History[loaded.Meta.CurrentVersion]
+	if body == nil {
+		return fmt.Errorf("no history entry for current_version %s", loaded.Meta.CurrentVersion)
+	}
+	inst, err := installer.LoadInstalled(projectRoot)
+	if err != nil {
+		return err
+	}
+	libraryID := loaded.Meta.ID
+	for _, r := range inst.RuleAppends {
+		if r.Name == item.Name && r.Provider == pl.Provider && r.TargetFile == pl.Path {
+			libraryID = r.LibraryID
+			break
+		}
+	}
+	library := map[string]*rulestore.Loaded{
+		libraryID:      loaded,
+		loaded.Meta.ID: loaded,
+	}
+	return installer.ReplaceRuleAppend(projectRoot, libraryID, pl.Path, body, library)
+}
+
+func rollbackPlacementWarning(pl installstore.Placement, err error) string {
+	return fmt.Sprintf("could not re-apply %s placement for %s: %v", pl.Mechanism, pl.Provider, err)
+}
+
+func findProviderBySlug(slug string) *provider.Provider {
+	for i := range provider.AllProviders {
+		if provider.AllProviders[i].Slug == slug {
+			return &provider.AllProviders[i]
+		}
+	}
+	return nil
+}
+
+func restoreFromPreviousCopy(libraryPath, copyPath string) error {
+	info, err := os.Stat(copyPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return output.NewStructuredError(
+				output.ErrInstallConflict,
+				fmt.Sprintf("saved previous copy is gone: %s", copyPath),
+				"Rollback copy data is local and one-step; restore from backup or re-add the item from its registry.",
+			)
+		}
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, "checking saved previous copy failed", "Check filesystem permissions", err.Error())
+	}
+	if !info.IsDir() {
+		return output.NewStructuredError(output.ErrInstallConflict, fmt.Sprintf("saved previous copy is not a directory: %s", copyPath), "Rollback copy data must be an intact directory tree.")
+	}
+	if err := os.RemoveAll(libraryPath); err != nil {
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, "removing current library item failed", "Check permissions in ~/.syllago/content/", err.Error())
+	}
+	if err := copyTree(copyPath, libraryPath); err != nil {
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, "restoring saved previous copy failed", "Check permissions in ~/.syllago/content/ and the saved rollback copy.", err.Error())
+	}
+	return nil
+}
+
+func restoreFromGitPrevious(item catalog.ContentItem, libraryPath, regName, sha, version string) error {
+	globalDir := catalog.GlobalContentDir()
+	if globalDir == "" {
+		return output.NewStructuredError(output.ErrSystemHomedir, "cannot determine home directory", "Set the HOME environment variable")
+	}
+	worktreeDir, cleanup, err := registry.WorktreeAt(regName, sha)
+	if err != nil {
+		return output.NewStructuredErrorDetail(
+			output.ErrRegistrySyncFailed,
+			fmt.Sprintf("could not materialize rollback source %s", ShortSHA(sha)),
+			"Run 'syllago registry sync "+regName+"' or restore the registry clone with full history.",
+			err.Error(),
+		)
+	}
+	defer cleanup()
+
+	items, err := add.DiscoverFromRegistry(regName, worktreeDir, globalDir)
+	if err != nil {
+		return output.NewStructuredErrorDetail(output.ErrCatalogScanFailed, "scanning rollback registry checkout failed", "Check registry contents at the rollback commit.", err.Error())
+	}
+	var match *add.DiscoveryItem
+	for i := range items {
+		if items[i].Type == item.Type && items[i].Name == item.Name {
+			match = &items[i]
+			break
+		}
+	}
+	if match == nil {
+		return output.NewStructuredError(
+			output.ErrItemNotFound,
+			fmt.Sprintf("item did not exist at %s", ShortSHA(sha)),
+			"Rollback can only restore items present at the recorded previous registry commit.",
+		)
+	}
+
+	sourceProvider := item.Provider
+	sourceVisibility := ""
+	if item.Meta != nil {
+		if sourceProvider == "" {
+			sourceProvider = item.Meta.SourceProvider
+		}
+		sourceVisibility = item.Meta.SourceVisibility
+	}
+	results := add.AddItems([]add.DiscoveryItem{*match}, add.AddOptions{
+		Force:            true,
+		Provider:         sourceProvider,
+		SourceRegistry:   regName,
+		SourceSHA:        sha,
+		SourceVisibility: sourceVisibility,
+	}, globalDir, nil, version)
+	if len(results) != 1 {
+		return output.NewStructuredError(output.ErrSystemIO, fmt.Sprintf("restoring %s/%s failed", item.Type, item.Name), "The rollback restore did not produce a result.")
+	}
+	if results[0].Status == add.AddStatusError {
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, fmt.Sprintf("restoring %s/%s failed", item.Type, item.Name), "Check registry item contents and library permissions.", results[0].Error.Error())
+	}
+	if _, err := os.Stat(libraryPath); err != nil {
+		return output.NewStructuredErrorDetail(output.ErrSystemIO, "restored library item is missing", "The registry restore completed but the expected library path was not found.", err.Error())
+	}
+	return nil
+}
+
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		return copyTreeFile(path, target)
+	})
+}
+
+func copyTreeFile(src, dst string) (err error) {
+	if info, err := os.Lstat(dst); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("destination is a symlink: %s", dst)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.CreateTemp(filepath.Dir(dst), ".syllago-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := out.Name()
+	defer func() {
+		if err != nil {
+			_ = out.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+	if err = out.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, dst)
+}
+
+// ShortSHA returns sha shortened to the CLI display length.
+func ShortSHA(sha string) string {
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
+}

--- a/cli/internal/rollback/rollback_test.go
+++ b/cli/internal/rollback/rollback_test.go
@@ -1,0 +1,177 @@
+package rollback
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/metadata"
+)
+
+func TestPlanForErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		item      func(t *testing.T) catalog.ContentItem
+		wantError string
+	}{
+		{
+			name: "not registry sourced",
+			item: func(t *testing.T) catalog.ContentItem {
+				return catalog.ContentItem{
+					Name: "local-skill",
+					Type: catalog.Skills,
+					Meta: &metadata.Meta{},
+				}
+			},
+			wantError: "is not registry-sourced",
+		},
+		{
+			name: "no install record store",
+			item: func(t *testing.T) catalog.ContentItem {
+				withConfigDir(t, t.TempDir())
+				return catalog.ContentItem{
+					Name: "canary-skill",
+					Type: catalog.Skills,
+					Meta: &metadata.Meta{SourceRegistry: "test-reg"},
+				}
+			},
+			wantError: "no install record",
+		},
+		{
+			name: "previous nil",
+			item: func(t *testing.T) catalog.ContentItem {
+				configDir := t.TempDir()
+				withConfigDir(t, configDir)
+				libraryPath := filepath.Join(t.TempDir(), "canary-skill")
+				if err := os.MkdirAll(libraryPath, 0755); err != nil {
+					t.Fatalf("MkdirAll libraryPath: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(libraryPath, "SKILL.md"), []byte("# Canary\n"), 0644); err != nil {
+					t.Fatalf("WriteFile library item: %v", err)
+				}
+				coord := installstore.Coord{
+					Registry: "test-reg",
+					Type:     string(catalog.Skills),
+					Name:     "canary-skill",
+				}
+				if err := installstore.RecordInstallMeta(filepath.Join(configDir, "installs.json"), coord, libraryPath, installstore.PlacementInput{
+					Provider:  "claude-code",
+					Mechanism: installstore.MechanismSymlink,
+					Path:      filepath.Join(t.TempDir(), "canary-skill"),
+				}, installstore.InstallMeta{}, time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)); err != nil {
+					t.Fatalf("RecordInstallMeta: %v", err)
+				}
+				return catalog.ContentItem{
+					Name: "canary-skill",
+					Type: catalog.Skills,
+					Meta: &metadata.Meta{SourceRegistry: "test-reg"},
+				}
+			},
+			wantError: "no rollback data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := PlanFor(tt.item(t))
+			if err == nil {
+				t.Fatal("PlanFor returned nil error")
+			}
+			if !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("PlanFor error = %v, want substring %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestCopyTreeCopiesNestedFilesSkipsSymlinksAndRefusesDestinationSymlink(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	dst := filepath.Join(root, "dst")
+	nested := filepath.Join(src, "nested")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatalf("MkdirAll nested: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "file.txt"), []byte("contents\n"), 0644); err != nil {
+		t.Fatalf("WriteFile source: %v", err)
+	}
+	if err := os.Symlink(filepath.Join("nested", "file.txt"), filepath.Join(src, "link.txt")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	if err := copyTree(src, dst); err != nil {
+		t.Fatalf("copyTree: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dst, "nested", "file.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile copied file: %v", err)
+	}
+	if string(data) != "contents\n" {
+		t.Fatalf("copied file = %q, want contents", data)
+	}
+	if _, err := os.Lstat(filepath.Join(dst, "link.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("destination symlink copy err = %v, want not exist", err)
+	}
+
+	dstWithSymlink := filepath.Join(root, "dst-with-symlink")
+	if err := os.MkdirAll(filepath.Join(dstWithSymlink, "nested"), 0755); err != nil {
+		t.Fatalf("MkdirAll dst nested: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(root, "outside"), filepath.Join(dstWithSymlink, "nested", "file.txt")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	err = copyTree(src, dstWithSymlink)
+	if err == nil {
+		t.Fatal("copyTree overwrote destination symlink")
+	}
+	if !strings.Contains(err.Error(), "destination is a symlink") {
+		t.Fatalf("copyTree error = %v, want destination symlink error", err)
+	}
+}
+
+func TestShortSHA(t *testing.T) {
+	tests := []struct {
+		name string
+		sha  string
+		want string
+	}{
+		{
+			name: "long",
+			sha:  "1234567890abcdef",
+			want: "1234567890ab",
+		},
+		{
+			name: "short",
+			sha:  "1234567",
+			want: "1234567",
+		},
+		{
+			name: "exact",
+			sha:  "1234567890ab",
+			want: "1234567890ab",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShortSHA(tt.sha); got != tt.want {
+				t.Fatalf("ShortSHA(%q) = %q, want %q", tt.sha, got, tt.want)
+			}
+		})
+	}
+}
+
+func withConfigDir(t *testing.T, dir string) {
+	t.Helper()
+	prev := config.GlobalDirOverride
+	config.GlobalDirOverride = dir
+	t.Cleanup(func() {
+		config.GlobalDirOverride = prev
+	})
+}

--- a/cli/internal/rulestore/finddir.go
+++ b/cli/internal/rulestore/finddir.go
@@ -1,0 +1,27 @@
+package rulestore
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// FindRuleDir locates <rulesRoot>/*/<name>/ by iterating source-provider
+// subdirectories. Returns fs.ErrNotExist if no match is found. First-match
+// wins when the same rule name exists under multiple source providers.
+func FindRuleDir(rulesRoot, name string) (string, error) {
+	entries, err := os.ReadDir(rulesRoot)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(rulesRoot, e.Name(), name)
+		if info, serr := os.Stat(candidate); serr == nil && info.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fs.ErrNotExist
+}

--- a/cli/internal/rulestore/finddir_test.go
+++ b/cli/internal/rulestore/finddir_test.go
@@ -1,0 +1,33 @@
+package rulestore
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindRuleDir(t *testing.T) {
+	root := t.TempDir()
+	ruleDir := filepath.Join(root, "claude-code", "concise-comments")
+	if err := os.MkdirAll(ruleDir, 0755); err != nil {
+		t.Fatalf("MkdirAll ruleDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "not-a-provider"), []byte("skip\n"), 0644); err != nil {
+		t.Fatalf("WriteFile non-dir: %v", err)
+	}
+
+	got, err := FindRuleDir(root, "concise-comments")
+	if err != nil {
+		t.Fatalf("FindRuleDir: %v", err)
+	}
+	if got != ruleDir {
+		t.Fatalf("FindRuleDir = %s, want %s", got, ruleDir)
+	}
+
+	_, err = FindRuleDir(root, "missing")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("FindRuleDir missing err = %v, want fs.ErrNotExist", err)
+	}
+}


### PR DESCRIPTION
## Summary

Extracts the rollback restore core out of `package main` into a new importable `cli/internal/rollback` package so the TUI can call it directly:

- **`internal/rollback`** — new package exposing `PlanFor` (resolves how an installed item can be restored: previous-copy or git-worktree), `Restore` (executes the restore, including install-record rollback and `copyTree`), `ReapplyPlacements`, and `ShortSHA`.
- **`rulestore.FindRuleDir`** — `findLibraryRuleDir`'s implementation moves into `cli/internal/rulestore/finddir.go` as a reusable helper.
- **Thin command wrapper** — `cli/cmd/syllago/rollback_cmd.go` now delegates to the package; all structured error messages and CLI output are byte-identical. No behavior change.

## Testing

- Full local suite passed: `go build ./...` and `go test -count=1 ./...` green, gofmt clean.
- Existing `rollback_cmd_test.go` passes unchanged — confirms CLI behavior is identical.
- New unit tests: `TestPlanForErrors`, `TestCopyTreeCopiesNestedFilesSkipsSymlinksAndRefusesDestinationSymlink`, `TestShortSHA`, `TestFindRuleDir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)