### PR TITLE
feat(tui): pin/unpin and rollback actions with mouse parity (#542 item 7f-ii)

### DIFF
--- a/cli/internal/tui/actions.go
+++ b/cli/internal/tui/actions.go
@@ -247,6 +247,15 @@ func (a App) handleConfirmResult(msg confirmResultMsg) (tea.Model, tea.Cmd) {
 		return a, a.doInstallAllCmd(*pendingAll)
 	}
 
+	if msg.purpose == confirmPurposeRollback {
+		plan := a.pendingRollback
+		a.pendingRollback = nil
+		if !msg.confirmed {
+			return a, nil
+		}
+		return a, a.doRollbackCmd(plan)
+	}
+
 	if !msg.confirmed {
 		return a, nil
 	}

--- a/cli/internal/tui/app.go
+++ b/cli/internal/tui/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/metadata"
 	"github.com/OpenScribbler/syllago/cli/internal/moat"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
+	"github.com/OpenScribbler/syllago/cli/internal/rollback"
 	"github.com/OpenScribbler/syllago/cli/internal/rulestore"
 	"github.com/OpenScribbler/syllago/cli/internal/telemetry"
 )
@@ -108,6 +109,7 @@ type App struct {
 	// / pendingInstallAll is non-nil at a time.
 	pendingInstall    *installResultMsg
 	pendingInstallAll *installAllResultMsg
+	pendingRollback   *rollback.Plan
 
 	// MOAT install-gate state. moatSession persists for the TUI run so a
 	// publisher-warn acknowledgement survives rescans (ADR 0007 G-8 warn-
@@ -462,7 +464,7 @@ func (a App) currentHints() []string {
 		if a.library.mode == libraryDetail {
 			return append(base, "↑/↓ navigate", "←/→ switch pane", "esc close", "t trust", "R refresh", "? help", "q back")
 		}
-		return append(base, "↑/↓ navigate", "enter preview", "/ search", "s sort", "e edit", "d remove", "x uninstall", "t trust", "R refresh", "? help", "q back")
+		return append(base, "↑/↓ navigate", "enter preview", "/ search", "s sort", "e edit", "d remove", "x uninstall", "p pin/unpin", "z rollback", "t trust", "R refresh", "? help", "q back")
 	}
 	if a.isRegistriesTab() && !a.galleryDrillIn {
 		return append(base, "arrows grid", "enter select", "tab grid/contents", "/ search", "a add", "S sync", "d remove", "e edit", "t trust", "R refresh", "? help", "q back")
@@ -477,7 +479,7 @@ func (a App) currentHints() []string {
 	}
 
 	if a.isLibraryTab() {
-		return append(base, "↑/↓ navigate", "enter preview", "/ search", "s sort", "i install", "e edit", "d remove", "x uninstall", "t trust", "R refresh", "a add", "? help", "q quit")
+		return append(base, "↑/↓ navigate", "enter preview", "/ search", "s sort", "i install", "e edit", "d remove", "x uninstall", "p pin/unpin", "z rollback", "t trust", "R refresh", "a add", "? help", "q quit")
 	}
 
 	// Explorer in detail mode
@@ -487,7 +489,7 @@ func (a App) currentHints() []string {
 
 	hints := append(base, "↑/↓ navigate", "←/→ switch pane", "enter detail", "/ search")
 	if group != "Config" {
-		hints = append(hints, "i install", "e edit", "d remove", "x uninstall", "t trust", "R refresh", "a add")
+		hints = append(hints, "i install", "e edit", "d remove", "x uninstall", "p pin/unpin", "z rollback", "t trust", "R refresh", "a add")
 	}
 	return append(hints, "? help", "q quit")
 }

--- a/cli/internal/tui/app_update.go
+++ b/cli/internal/tui/app_update.go
@@ -281,6 +281,14 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case msg.String() == keyUninstall:
 			return a.handleUninstall()
 
+		// Pin/unpin registry item
+		case msg.String() == keyPin:
+			return a.handlePin()
+
+		// Rollback last update
+		case msg.String() == keyRollback:
+			return a.handleRollback()
+
 		// Install item to a provider
 		case msg.String() == keyInstall:
 			return a.handleInstall()
@@ -510,6 +518,67 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case libraryUninstallMsg:
 		return a.handleUninstall()
+
+	case libraryPinMsg:
+		return a.handlePin()
+
+	case libraryRollbackMsg:
+		return a.handleRollback()
+
+	case pinToggleMsg:
+		if msg.err != nil {
+			return a, a.toast.Push(msg.err.Error(), toastWarning)
+		}
+		var toastCmd tea.Cmd
+		if msg.pinned {
+			if msg.sourceSHA != "" {
+				toastCmd = a.toast.Push(fmt.Sprintf("Pinned %s/%s — holding at %s", msg.typ, msg.name, shortSHA(msg.sourceSHA)), toastSuccess)
+			} else {
+				toastCmd = a.toast.Push(fmt.Sprintf("Pinned %s/%s", msg.typ, msg.name), toastSuccess)
+			}
+		} else {
+			toastCmd = a.toast.Push(fmt.Sprintf("Unpinned %s/%s", msg.typ, msg.name), toastSuccess)
+		}
+		return a, tea.Batch(toastCmd, a.rescanCatalog())
+
+	case rollbackPlanMsg:
+		if msg.err != nil {
+			return a, a.toast.Push(msg.err.Error(), toastWarning)
+		}
+		plan := msg.plan
+		a.pendingRollback = plan
+
+		var body string
+		if plan.FromCopy {
+			when := "unknown date"
+			if !plan.Prev.ReplacedAt.IsZero() {
+				when = plan.Prev.ReplacedAt.Format("2006-01-02")
+			}
+			body = fmt.Sprintf("Restores %s/%s to the saved copy from %s.\nOne-step: the current version becomes the new rollback point.", plan.Item.Type, plan.Item.Name, when)
+		} else {
+			body = fmt.Sprintf("Restores %s/%s to %s.\nOne-step: the current version becomes the new rollback point.", plan.Item.Type, plan.Item.Name, shortSHA(plan.Prev.SourceSHA))
+		}
+
+		title := fmt.Sprintf("Roll back %q?", plan.Item.Name)
+		a.confirm.OpenForItem(title, body, "Roll back", true, nil, plan.Item)
+		a.confirm.purpose = confirmPurposeRollback
+		return a, nil
+
+	case rollbackDoneMsg:
+		if msg.err != nil {
+			return a, a.toast.Push(msg.err.Error(), toastWarning)
+		}
+		var toastCmds []tea.Cmd
+		if msg.fromCopy {
+			toastCmds = append(toastCmds, a.toast.Push(fmt.Sprintf("Rolled back %s/%s to previous version", msg.typ, msg.name), toastSuccess))
+		} else {
+			toastCmds = append(toastCmds, a.toast.Push(fmt.Sprintf("Rolled back %s/%s to %s", msg.typ, msg.name, shortSHA(msg.sha)), toastSuccess))
+		}
+		for _, w := range msg.warnings {
+			toastCmds = append(toastCmds, a.toast.Push("warning: "+w, toastWarning))
+		}
+		toastCmds = append(toastCmds, a.rescanCatalog())
+		return a, tea.Batch(toastCmds...)
 
 	case libraryDrillMsg:
 		a.updateNavState()

--- a/cli/internal/tui/confirm.go
+++ b/cli/internal/tui/confirm.go
@@ -19,6 +19,7 @@ type confirmResultMsg struct {
 	item               catalog.ContentItem
 	itemName           string
 	uninstallProviders []provider.Provider
+	purpose            string
 }
 
 // confirmCheckbox represents a toggleable checkbox in the confirm modal.
@@ -40,6 +41,7 @@ type confirmModal struct {
 	focusIdx     int
 	width        int
 	height       int
+	purpose      string
 
 	// Caller context — passed through to result messages untouched.
 	item               catalog.ContentItem
@@ -75,6 +77,7 @@ func (m *confirmModal) Open(title, body, confirmLabel string, danger bool, check
 	m.item = catalog.ContentItem{}
 	m.itemName = ""
 	m.uninstallProviders = nil
+	m.purpose = ""
 }
 
 // OpenForItem is a convenience that also stores item context for the result message.
@@ -96,6 +99,7 @@ func (m *confirmModal) Close() {
 	m.item = catalog.ContentItem{}
 	m.itemName = ""
 	m.uninstallProviders = nil
+	m.purpose = ""
 }
 
 func (m confirmModal) result(confirmed bool) (confirmModal, tea.Cmd) {
@@ -105,6 +109,7 @@ func (m confirmModal) result(confirmed bool) (confirmModal, tea.Cmd) {
 		item:               m.item,
 		itemName:           m.itemName,
 		uninstallProviders: m.uninstallProviders,
+		purpose:            m.purpose,
 	}
 	m.Close()
 	return m, func() tea.Msg { return res }

--- a/cli/internal/tui/explorer.go
+++ b/cli/internal/tui/explorer.go
@@ -387,6 +387,12 @@ func (e explorerModel) updateBrowseMouse(msg tea.MouseMsg) (explorerModel, tea.C
 		if zone.Get("meta-uninstall").InBounds(msg) {
 			return e, func() tea.Msg { return libraryUninstallMsg{} }
 		}
+		if zone.Get("meta-pin").InBounds(msg) {
+			return e, func() tea.Msg { return libraryPinMsg{} }
+		}
+		if zone.Get("meta-rollback").InBounds(msg) {
+			return e, func() tea.Msg { return libraryRollbackMsg{} }
+		}
 		if zone.Get("meta-trust").InBounds(msg) {
 			if item := e.items.Selected(); item != nil {
 				return e, func() tea.Msg { return explorerTrustInspectMsg{item: item} }
@@ -470,6 +476,12 @@ func (e explorerModel) updateDetailMouse(msg tea.MouseMsg) (explorerModel, tea.C
 		}
 		if zone.Get("meta-uninstall").InBounds(msg) {
 			return e, func() tea.Msg { return libraryUninstallMsg{} }
+		}
+		if zone.Get("meta-pin").InBounds(msg) {
+			return e, func() tea.Msg { return libraryPinMsg{} }
+		}
+		if zone.Get("meta-rollback").InBounds(msg) {
+			return e, func() tea.Msg { return libraryRollbackMsg{} }
 		}
 		if zone.Get("meta-trust").InBounds(msg) {
 			if e.detailItem != nil {

--- a/cli/internal/tui/help.go
+++ b/cli/internal/tui/help.go
@@ -112,6 +112,8 @@ func (h helpOverlay) View() string {
 			{"e", "Edit name/description"},
 			{"d", "Remove from library"},
 			{"x", "Uninstall from provider"},
+			{"p", "Pin/unpin"},
+			{"z", "Rollback"},
 			{"t", "Inspect trust details"},
 			{"/", "Search"},
 			{"s / S", "Sort / reverse sort"},

--- a/cli/internal/tui/keys.go
+++ b/cli/internal/tui/keys.go
@@ -26,4 +26,6 @@ const (
 	keyHelp      = "?"
 	keyTrust     = "t"
 	keyFilter    = "f"
+	keyPin       = "p"
+	keyRollback  = "z"
 )

--- a/cli/internal/tui/library.go
+++ b/cli/internal/tui/library.go
@@ -64,6 +64,12 @@ type libraryRemoveMsg struct{}
 // libraryUninstallMsg is sent when the uninstall button is clicked in the metadata bar.
 type libraryUninstallMsg struct{}
 
+// libraryPinMsg is sent when the pin button is clicked in the metadata bar.
+type libraryPinMsg struct{}
+
+// libraryRollbackMsg is sent when the rollback button is clicked in the metadata bar.
+type libraryRollbackMsg struct{}
+
 // libraryCloseMsg is sent when the user closes the detail view.
 type libraryCloseMsg struct{}
 
@@ -491,6 +497,12 @@ func (l libraryModel) updateMouse(msg tea.MouseMsg) (libraryModel, tea.Cmd) {
 			if zone.Get("meta-uninstall").InBounds(msg) {
 				return l, func() tea.Msg { return libraryUninstallMsg{} }
 			}
+			if zone.Get("meta-pin").InBounds(msg) {
+				return l, func() tea.Msg { return libraryPinMsg{} }
+			}
+			if zone.Get("meta-rollback").InBounds(msg) {
+				return l, func() tea.Msg { return libraryRollbackMsg{} }
+			}
 			if zone.Get("meta-trust").InBounds(msg) {
 				if item := l.table.Selected(); item != nil {
 					return l, func() tea.Msg { return libraryTrustInspectMsg{item: item} }
@@ -543,6 +555,12 @@ func (l libraryModel) updateMouse(msg tea.MouseMsg) (libraryModel, tea.Cmd) {
 			}
 			if zone.Get("meta-uninstall").InBounds(msg) {
 				return l, func() tea.Msg { return libraryUninstallMsg{} }
+			}
+			if zone.Get("meta-pin").InBounds(msg) {
+				return l, func() tea.Msg { return libraryPinMsg{} }
+			}
+			if zone.Get("meta-rollback").InBounds(msg) {
+				return l, func() tea.Msg { return libraryRollbackMsg{} }
 			}
 			if zone.Get("meta-trust").InBounds(msg) {
 				if l.detailItem != nil {

--- a/cli/internal/tui/metapanel.go
+++ b/cli/internal/tui/metapanel.go
@@ -10,8 +10,16 @@ import (
 	"github.com/OpenScribbler/syllago/cli/internal/catalog"
 	"github.com/OpenScribbler/syllago/cli/internal/installcheck"
 	"github.com/OpenScribbler/syllago/cli/internal/installer"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
 	"github.com/OpenScribbler/syllago/cli/internal/provider"
 )
+
+func shortSHA(sha string) string {
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
+}
 
 // ruleTargetStatus is a single row for the D16 per-target breakdown in the
 // rule metapanel: which target file an InstalledRuleAppend record points at
@@ -28,6 +36,10 @@ type metaPanelData struct {
 	typeDetail  string // type-specific detail (hooks/MCP/loadouts) or ""
 	canInstall  bool   // true when item is in library and has at least one uninstalled provider
 	ruleRecords []ruleTargetStatus
+	pinned      bool
+	heldAt      string
+	canRollback bool
+	hasRecord   bool
 }
 
 // computeMetaPanelData computes installed status and type-specific detail for an item.
@@ -62,10 +74,39 @@ func computeMetaPanelData(item catalog.ContentItem, providers []provider.Provide
 		}
 	}
 
+	var pinned bool
+	var heldAt string
+	var canRollback bool
+	var hasRecord bool
+
+	if item.Meta != nil && item.Meta.SourceRegistry != "" {
+		if storePath, err := installstore.DefaultPath(); err == nil {
+			if store, err := installstore.Load(storePath); err == nil {
+				coord := installstore.Coord{
+					Registry: item.Meta.SourceRegistry,
+					Type:     string(item.Type),
+					Name:     item.Name,
+				}
+				if rec := store.Find(coord); rec != nil {
+					hasRecord = true
+					pinned = rec.Pinned
+					if pinned {
+						heldAt = shortSHA(rec.SourceSHA)
+					}
+					canRollback = rec.Previous != nil && (rec.Previous.SourceSHA != "" || rec.Previous.CopyPath != "")
+				}
+			}
+		}
+	}
+
 	return metaPanelData{
-		installed:  installed,
-		typeDetail: computeTypeDetail(item),
-		canInstall: canInstall,
+		installed:   installed,
+		typeDetail:  computeTypeDetail(item),
+		canInstall:  canInstall,
+		pinned:      pinned,
+		heldAt:      heldAt,
+		canRollback: canRollback,
+		hasRecord:   hasRecord,
 	}
 }
 
@@ -242,6 +283,16 @@ func renderMetaPanel(item *catalog.ContentItem, data metaPanelData, width int) s
 			btns = append(btns, zone.Mark("meta-remove", activeButtonStyle.Render("[d] Remove")))
 		}
 		btns = append(btns, zone.Mark("meta-edit", activeButtonStyle.Render("[e] Edit")))
+		if item.Meta != nil && item.Meta.SourceRegistry != "" && data.hasRecord {
+			if data.pinned {
+				btns = append(btns, zone.Mark("meta-pin", activeButtonStyle.Render("[p] Unpin")))
+			} else {
+				btns = append(btns, zone.Mark("meta-pin", activeButtonStyle.Render("[p] Pin")))
+			}
+		}
+		if data.canRollback {
+			btns = append(btns, zone.Mark("meta-rollback", activeButtonStyle.Render("[z] Rollback")))
+		}
 	}
 	btnRow := strings.Join(btns, " ")
 	btnRowW := lipgloss.Width(btnRow)
@@ -282,6 +333,15 @@ func renderMetaPanel(item *catalog.ContentItem, data metaPanelData, width int) s
 		visibilityStyle = privateIndicatorStyle
 	}
 	leftPortion += gap + boldStyle.Render("Visibility: ") + visibilityStyle.Render(visibility)
+
+	if data.pinned {
+		pinnedVal := "Pinned"
+		if data.heldAt != "" {
+			pinnedVal = "Pinned @" + data.heldAt
+		}
+		pinnedVal = truncate(pinnedVal, 20)
+		leftPortion += gap + lipgloss.NewStyle().Foreground(warningColor).Bold(true).Render(pinnedVal)
+	}
 
 	// Gap between left portion and buttons; always at least one space.
 	leftW := lipgloss.Width(leftPortion)

--- a/cli/internal/tui/pin_actions.go
+++ b/cli/internal/tui/pin_actions.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"fmt"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/rollback"
+)
+
+const confirmPurposeRollback = "rollback"
+
+// Message types
+type pinToggleMsg struct {
+	name      string
+	typ       string
+	pinned    bool
+	sourceSHA string
+	err       error
+}
+
+type rollbackPlanMsg struct {
+	plan *rollback.Plan
+	err  error
+}
+
+type rollbackDoneMsg struct {
+	name      string
+	typ       string
+	fromCopy  bool
+	sha       string
+	reapplied int
+	warnings  []string
+	err       error
+}
+
+// handlePin toggle action
+func (a App) handlePin() (tea.Model, tea.Cmd) {
+	item := a.selectedItem()
+	if item == nil {
+		return a, nil
+	}
+	if item.Meta == nil || item.Meta.SourceRegistry == "" || !item.Library {
+		cmd := a.toast.Push("Only installed registry items can be pinned", toastWarning)
+		return a, cmd
+	}
+
+	coord := installstore.Coord{
+		Registry: item.Meta.SourceRegistry,
+		Type:     string(item.Type),
+		Name:     item.Name,
+	}
+
+	cmd := func() tea.Msg {
+		storePath, err := installstore.DefaultPath()
+		if err != nil {
+			return pinToggleMsg{err: fmt.Errorf("pin needs an installed item — install it first")}
+		}
+		store, err := installstore.Load(storePath)
+		if err != nil {
+			return pinToggleMsg{err: fmt.Errorf("pin needs an installed item — install it first")}
+		}
+		rec := store.Find(coord)
+		if rec == nil {
+			return pinToggleMsg{err: fmt.Errorf("pin needs an installed item — install it first")}
+		}
+
+		nextPinned := !rec.Pinned
+		err = installstore.SetPinned(storePath, coord, nextPinned, time.Now())
+		if err != nil {
+			return pinToggleMsg{err: err}
+		}
+
+		return pinToggleMsg{
+			name:      coord.Name,
+			typ:       coord.Type,
+			pinned:    nextPinned,
+			sourceSHA: rec.SourceSHA,
+		}
+	}
+
+	return a, cmd
+}
+
+// handleRollback action
+func (a App) handleRollback() (tea.Model, tea.Cmd) {
+	item := a.selectedItem()
+	if item == nil {
+		return a, nil
+	}
+	cmd := func() tea.Msg {
+		plan, err := rollback.PlanFor(*item)
+		return rollbackPlanMsg{plan: plan, err: err}
+	}
+	return a, cmd
+}
+
+// doRollbackCmd
+func (a App) doRollbackCmd(plan *rollback.Plan) tea.Cmd {
+	return func() tea.Msg {
+		err := rollback.Restore(plan, a.version)
+		if err != nil {
+			return rollbackDoneMsg{err: err}
+		}
+
+		// Re-apply placements
+		opts := rollback.Options{ProjectRoot: a.projectRoot}
+		reapplied, warnings := rollback.ReapplyPlacements(plan.Item, plan.Placements, opts)
+
+		return rollbackDoneMsg{
+			name:      plan.Item.Name,
+			typ:       string(plan.Item.Type),
+			fromCopy:  plan.FromCopy,
+			sha:       plan.Prev.SourceSHA,
+			reapplied: len(reapplied),
+			warnings:  warnings,
+		}
+	}
+}

--- a/cli/internal/tui/pin_actions_test.go
+++ b/cli/internal/tui/pin_actions_test.go
@@ -1,0 +1,328 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	zone "github.com/lrstanley/bubblezone"
+
+	"github.com/OpenScribbler/syllago/cli/internal/catalog"
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/installstore"
+	"github.com/OpenScribbler/syllago/cli/internal/metadata"
+	"github.com/OpenScribbler/syllago/cli/internal/rollback"
+)
+
+func TestPinToggle_RoundTrip(t *testing.T) {
+	// Seed global dir override
+	tmpDir := t.TempDir()
+	origGlobal := config.GlobalDirOverride
+	config.GlobalDirOverride = tmpDir
+	t.Cleanup(func() { config.GlobalDirOverride = origGlobal })
+
+	// Seed install store record
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(storePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := installstore.Load(storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coord := installstore.Coord{
+		Registry: "https://my-registry.com",
+		Type:     "rules",
+		Name:     "my-rule",
+	}
+	rec := installstore.Record{
+		Coord:       coord,
+		SourceSHA:   "1234567890abcdef1234567890abcdef",
+		InstalledAt: time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	store.Records = append(store.Records, rec)
+	err = store.Save()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build App
+	item := catalog.ContentItem{
+		Name:    "my-rule",
+		Type:    catalog.Rules,
+		Library: true,
+		Meta:    &metadata.Meta{SourceRegistry: "https://my-registry.com"},
+	}
+	cat := &catalog.Catalog{Items: []catalog.ContentItem{item}}
+	app := NewApp(cat, testProviders(), "0.0.0-test", false, nil, testConfig(), false, "", t.TempDir())
+	m, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = m.(App)
+
+	// Press "p"
+	m, cmd := app.Update(keyRune('p'))
+	app = m.(App)
+	if cmd == nil {
+		t.Fatal("expected command from handlePin")
+	}
+
+	// Execute command
+	msg := cmd()
+	pinMsg, ok := msg.(pinToggleMsg)
+	if !ok {
+		t.Fatalf("expected pinToggleMsg, got %T", msg)
+	}
+	if pinMsg.err != nil {
+		t.Fatalf("unexpected pinToggleMsg error: %v", pinMsg.err)
+	}
+	if !pinMsg.pinned {
+		t.Fatal("expected pinToggleMsg to have pinned=true")
+	}
+
+	// Send pinToggleMsg back to Update
+	m, rescmd := app.Update(pinMsg)
+	app = m.(App)
+	if rescmd == nil {
+		t.Fatal("expected rescan cmd")
+	}
+
+	// Check if store flipped to pinned
+	store, _ = installstore.Load(storePath)
+	recOut := store.Find(coord)
+	if recOut == nil || !recOut.Pinned {
+		t.Fatal("expected record to be pinned in store")
+	}
+
+	// Check toast is success toast
+	assertCurrentToastMessage(t, app, "Pinned rules/my-rule — holding at 1234567890ab")
+}
+
+func TestRollback_NoData(t *testing.T) {
+	// Seed global dir override so PlanFor reads an empty store, not ~/.syllago
+	tmpDir := t.TempDir()
+	origGlobal := config.GlobalDirOverride
+	config.GlobalDirOverride = tmpDir
+	t.Cleanup(func() { config.GlobalDirOverride = origGlobal })
+
+	item := catalog.ContentItem{
+		Name:    "my-rule",
+		Type:    catalog.Rules,
+		Library: true,
+		Meta:    &metadata.Meta{SourceRegistry: "https://my-registry.com"},
+	}
+	cat := &catalog.Catalog{Items: []catalog.ContentItem{item}}
+	app := NewApp(cat, testProviders(), "0.0.0-test", false, nil, testConfig(), false, "", t.TempDir())
+	m, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = m.(App)
+
+	// Press "z"
+	m, cmd := app.Update(keyRune('z'))
+	app = m.(App)
+	if cmd == nil {
+		t.Fatal("expected command from handleRollback")
+	}
+
+	// Execute command
+	msg := cmd()
+	planMsg, ok := msg.(rollbackPlanMsg)
+	if !ok {
+		t.Fatalf("expected rollbackPlanMsg, got %T", msg)
+	}
+	if planMsg.err == nil {
+		t.Fatal("expected rollbackPlanMsg to have error")
+	}
+
+	// Feed rollbackPlanMsg back to Update
+	m, _ = app.Update(planMsg)
+	app = m.(App)
+
+	// Toast should show the error message
+	cur := app.toast.Current()
+	if cur == nil {
+		t.Fatal("expected toast message")
+	}
+	if !strings.Contains(cur.message, "no install record") {
+		t.Errorf("toast message = %q, want substring %q", cur.message, "no install record")
+	}
+}
+
+func TestConfirmPurposeRouting(t *testing.T) {
+	plan := &rollback.Plan{
+		Item: catalog.ContentItem{Name: "my-rule", Type: catalog.Rules},
+	}
+	app := NewApp(&catalog.Catalog{}, testProviders(), "0.0.0-test", false, nil, testConfig(), false, "", t.TempDir())
+	app.pendingRollback = plan
+
+	// confirmed: false should clear pendingRollback and do nothing
+	m, cmd := app.handleConfirmResult(confirmResultMsg{
+		purpose:   confirmPurposeRollback,
+		confirmed: false,
+	})
+	app = m.(App)
+	if app.pendingRollback != nil {
+		t.Error("expected pendingRollback to be cleared on cancel")
+	}
+	if cmd != nil {
+		t.Error("expected no command on cancel")
+	}
+
+	// confirmed: true should clear pendingRollback and return doRollbackCmd
+	app.pendingRollback = plan
+	m, cmd = app.handleConfirmResult(confirmResultMsg{
+		purpose:   confirmPurposeRollback,
+		confirmed: true,
+	})
+	app = m.(App)
+	if app.pendingRollback != nil {
+		t.Error("expected pendingRollback to be cleared on confirm")
+	}
+	if cmd == nil {
+		t.Error("expected doRollbackCmd to be returned on confirm")
+	}
+}
+
+func TestLibrary_UpdateMouse_MetaPinAndRollback(t *testing.T) {
+	// Seed global dir override
+	tmpDir := t.TempDir()
+	origGlobal := config.GlobalDirOverride
+	config.GlobalDirOverride = tmpDir
+	t.Cleanup(func() { config.GlobalDirOverride = origGlobal })
+
+	// Seed install store record so buttons render
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(storePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := installstore.Load(storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coord := installstore.Coord{Registry: "https://my-registry.com", Type: "rules", Name: "my-rule"}
+	rec := installstore.Record{
+		Coord:       coord,
+		SourceSHA:   "123",
+		InstalledAt: time.Now(),
+		UpdatedAt:   time.Now(),
+		Previous:    &installstore.PreviousVersion{SourceSHA: "123"},
+	}
+	store.Records = append(store.Records, rec)
+	if err := store.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	item := catalog.ContentItem{
+		Name:    "my-rule",
+		Type:    catalog.Rules,
+		Library: true,
+		Meta:    &metadata.Meta{SourceRegistry: "https://my-registry.com"},
+	}
+	l := newLibraryModel([]catalog.ContentItem{item}, testProviders(), t.TempDir())
+	l.SetSize(120, 30)
+
+	// Render to register zones
+	scanZones(l.View())
+
+	// Test Pin
+	zPin := zone.Get("meta-pin")
+	if zPin.IsZero() {
+		t.Skip("zone meta-pin not registered")
+	}
+	_, cmdPin := l.updateMouse(mouseClick(zPin.StartX, zPin.StartY))
+	if cmdPin == nil {
+		t.Fatal("click on meta-pin should emit cmd")
+	}
+	if _, ok := cmdPin().(libraryPinMsg); !ok {
+		t.Errorf("expected libraryPinMsg, got %T", cmdPin())
+	}
+
+	// Test Rollback
+	zRollback := zone.Get("meta-rollback")
+	if zRollback.IsZero() {
+		t.Skip("zone meta-rollback not registered")
+	}
+	_, cmdRollback := l.updateMouse(mouseClick(zRollback.StartX, zRollback.StartY))
+	if cmdRollback == nil {
+		t.Fatal("click on meta-rollback should emit cmd")
+	}
+	if _, ok := cmdRollback().(libraryRollbackMsg); !ok {
+		t.Errorf("expected libraryRollbackMsg, got %T", cmdRollback())
+	}
+}
+
+func TestExplorer_UpdateMouse_MetaPinAndRollback(t *testing.T) {
+	// Seed global dir override
+	tmpDir := t.TempDir()
+	origGlobal := config.GlobalDirOverride
+	config.GlobalDirOverride = tmpDir
+	t.Cleanup(func() { config.GlobalDirOverride = origGlobal })
+
+	// Seed install store record so buttons render
+	storePath, err := installstore.DefaultPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(storePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := installstore.Load(storePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coord := installstore.Coord{Registry: "https://my-registry.com", Type: "skills", Name: "alpha-skill"}
+	rec := installstore.Record{
+		Coord:       coord,
+		SourceSHA:   "123",
+		InstalledAt: time.Now(),
+		UpdatedAt:   time.Now(),
+		Previous:    &installstore.PreviousVersion{SourceSHA: "123"},
+	}
+	store.Records = append(store.Records, rec)
+	if err := store.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	e, _ := newExplorerWithDiskItems(t, 120, 30)
+	// Make sure the item has Meta registry
+	if len(e.items.items) > 0 {
+		e.items.items[0].Meta = &metadata.Meta{SourceRegistry: "https://my-registry.com"}
+		e.items.items[0].Library = true
+	}
+
+	// Render to register zones
+	scanZones(e.View())
+
+	// Test Pin
+	zPin := zone.Get("meta-pin")
+	if zPin.IsZero() {
+		t.Skip("zone meta-pin not registered")
+	}
+	_, cmdPin := e.Update(mouseClick(zPin.StartX, zPin.StartY))
+	if cmdPin == nil {
+		t.Fatal("click on meta-pin should emit cmd")
+	}
+	if _, ok := cmdPin().(libraryPinMsg); !ok {
+		t.Errorf("expected libraryPinMsg, got %T", cmdPin())
+	}
+
+	// Test Rollback
+	zRollback := zone.Get("meta-rollback")
+	if zRollback.IsZero() {
+		t.Skip("zone meta-rollback not registered")
+	}
+	_, cmdRollback := e.Update(mouseClick(zRollback.StartX, zRollback.StartY))
+	if cmdRollback == nil {
+		t.Fatal("click on meta-rollback should emit cmd")
+	}
+	if _, ok := cmdRollback().(libraryRollbackMsg); !ok {
+		t.Errorf("expected libraryRollbackMsg, got %T", cmdRollback())
+	}
+}

--- a/cli/internal/tui/testdata/content-80x30.golden
+++ b/cli/internal/tui/testdata/content-80x30.golden
@@ -27,4 +27,4 @@
 │                           │                                                  │
 ╰───────────────────────────┴──────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · ←/→ switch pane   syllago v0.0.0-test
-enter detail · / search · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+enter detail · / search · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/explorer-skills-80x30.golden
+++ b/cli/internal/tui/testdata/explorer-skills-80x30.golden
@@ -27,4 +27,4 @@
 │                           │                                                  │
 ╰───────────────────────────┴──────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · ←/→ switch pane   syllago v0.0.0-test
-enter detail · / search · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+enter detail · / search · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/hint-modal-80x30.golden
+++ b/cli/internal/tui/testdata/hint-modal-80x30.golden
@@ -27,4 +27,4 @@
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview     syllago v0.0.0-test
-/ search · s sort · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+/ search · s sort · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/library-filter-chips-80x30.golden
+++ b/cli/internal/tui/testdata/library-filter-chips-80x30.golden
@@ -27,4 +27,4 @@
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview     syllago v0.0.0-test
-/ search · s sort · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+/ search · s sort · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/library-installed-rules-120x40.golden
+++ b/cli/internal/tui/testdata/library-installed-rules-120x40.golden
@@ -37,4 +37,4 @@
 │                                                                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview · / search · s sort · i install · e edit    syllago v0.0.0-test
-d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/library-installed-rules-80x30.golden
+++ b/cli/internal/tui/testdata/library-installed-rules-80x30.golden
@@ -27,4 +27,4 @@
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview     syllago v0.0.0-test
-/ search · s sort · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+/ search · s sort · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/library-table-120x40.golden
+++ b/cli/internal/tui/testdata/library-table-120x40.golden
@@ -37,4 +37,4 @@
 │                                                                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview · / search · s sort · i install · e edit    syllago v0.0.0-test
-d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/library-table-80x30.golden
+++ b/cli/internal/tui/testdata/library-table-80x30.golden
@@ -27,4 +27,4 @@
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview     syllago v0.0.0-test
-/ search · s sort · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+/ search · s sort · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/library-unified-list-80x30.golden
+++ b/cli/internal/tui/testdata/library-unified-list-80x30.golden
@@ -27,4 +27,4 @@
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview     syllago v0.0.0-test
-/ search · s sort · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+/ search · s sort · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/metapanel-rule-installed-120x40.golden
+++ b/cli/internal/tui/testdata/metapanel-rule-installed-120x40.golden
@@ -37,4 +37,4 @@
 │                                                                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview · / search · s sort · i install · e edit    syllago v0.0.0-test
-d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/metapanel-rule-installed-80x30.golden
+++ b/cli/internal/tui/testdata/metapanel-rule-installed-80x30.golden
@@ -27,4 +27,4 @@
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview     syllago v0.0.0-test
-/ search · s sort · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+/ search · s sort · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/moat-library-120x40.golden
+++ b/cli/internal/tui/testdata/moat-library-120x40.golden
@@ -37,4 +37,4 @@
 │                                                                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview · / search · s sort · i install · e edit    syllago v0.0.0-test
-d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/moat-library-80x30.golden
+++ b/cli/internal/tui/testdata/moat-library-80x30.golden
@@ -27,4 +27,4 @@
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview     syllago v0.0.0-test
-/ search · s sort · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+/ search · s sort · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/moat-library-private-selected-80x30.golden
+++ b/cli/internal/tui/testdata/moat-library-private-selected-80x30.golden
@@ -27,4 +27,4 @@
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview     syllago v0.0.0-test
-/ search · s sort · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+/ search · s sort · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/moat-library-revoked-selected-120x40.golden
+++ b/cli/internal/tui/testdata/moat-library-revoked-selected-120x40.golden
@@ -37,4 +37,4 @@
 │                                                                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview · / search · s sort · i install · e edit    syllago v0.0.0-test
-d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/moat-library-revoked-selected-80x30.golden
+++ b/cli/internal/tui/testdata/moat-library-revoked-selected-80x30.golden
@@ -27,4 +27,4 @@
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview     syllago v0.0.0-test
-/ search · s sort · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+/ search · s sort · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/moat-publisher-warn-120x40.golden
+++ b/cli/internal/tui/testdata/moat-publisher-warn-120x40.golden
@@ -37,4 +37,4 @@
 │                                                                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview · / search · s sort · i install · e edit    syllago v0.0.0-test
-d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/moat-publisher-warn-80x30.golden
+++ b/cli/internal/tui/testdata/moat-publisher-warn-80x30.golden
@@ -27,4 +27,4 @@
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview     syllago v0.0.0-test
-/ search · s sort · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+/ search · s sort · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/shell-empty-120x40.golden
+++ b/cli/internal/tui/testdata/shell-empty-120x40.golden
@@ -37,4 +37,4 @@
 │                                                                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview · / search · s sort · i install · e edit    syllago v0.0.0-test
-d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit

--- a/cli/internal/tui/testdata/shell-empty-80x30.golden
+++ b/cli/internal/tui/testdata/shell-empty-80x30.golden
@@ -27,4 +27,4 @@
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 1/2/3 groups · tab items · ↑/↓ navigate · enter preview     syllago v0.0.0-test
-/ search · s sort · i install · e edit · d remove · x uninstall · t trust · R refresh · a add · ? help · q quit
+/ search · s sort · i install · e edit · d remove · x uninstall · p pin/unpin · z rollback · t trust · R refresh · a add · ? help · q quit


### PR DESCRIPTION
## Summary

- Adds `p` (pin/unpin) and `z` (rollback) keybinds to both the library and explorer views.
- Metapanel gains Pin/Unpin and Rollback buttons, gated on install-record state, plus a `Pinned @<sha>` chip on pinned items.
- Rollback routes through the confirm modal via a new explicit purpose discriminator on `confirmResultMsg`; on confirm, `doRollbackCmd` calls the shared `internal/rollback` package (`PlanFor`/`Restore`/`ReapplyPlacements`) and then rescans the catalog.
- Toast wording mirrors the CLI pin/rollback output.
- Full mouse parity in all four dispatch spots (library/explorer browse and detail modes) per the repo's `zone.Mark`/`InBounds` rule.

## Testing

- Full local suite green: `go build ./... && go test -count=1 ./...` — only the two expected no-test-file packages.
- gofmt clean.
- Golden baselines regenerated at all sizes.
- New tests: `TestPinToggle_RoundTrip`, `TestRollback_NoData`, `TestConfirmPurposeRouting`, `TestLibrary_UpdateMouse_MetaPinAndRollback`, `TestExplorer_UpdateMouse_MetaPinAndRollback`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
