### PR TITLE
feat(cli): show registry ref and pinned state in registry list

### DIFF
--- a/cli/cmd/syllago/registry_cmd.go
+++ b/cli/cmd/syllago/registry_cmd.go
@@ -349,6 +349,7 @@ type registryListItem struct {
 	Status    string             `json:"status"`
 	URL       string             `json:"url"`
 	Ref       string             `json:"ref"`
+	Pinned    bool               `json:"pinned"` // True if the clone sits on a detached HEAD, so sync fetches without moving it
 	Manifest  *registry.Manifest `json:"manifest,omitempty"`
 	IsMOAT    bool               `json:"is_moat"`
 	TrustTier string             `json:"trust_tier,omitempty"` // "moat", "pending", or "" for git registries
@@ -376,8 +377,14 @@ var registryListCmd = &cobra.Command{
 		var items []registryListItem
 		for _, r := range cfg.Registries {
 			status := "missing"
+			pinned := false
 			if registry.IsCloned(r.Name) {
 				status = "cloned"
+				// The checkout is the truth about pinning: a tag or commit ref
+				// leaves a detached HEAD, a branch ref does not.
+				if p, errPinned := registry.IsPinned(r.Name); errPinned == nil {
+					pinned = p
+				}
 			}
 			ref := r.Ref
 			if ref == "" {
@@ -397,6 +404,7 @@ var registryListCmd = &cobra.Command{
 				Status:    status,
 				URL:       r.URL,
 				Ref:       ref,
+				Pinned:    pinned,
 				Manifest:  manifest,
 				IsMOAT:    r.IsMOAT(),
 				TrustTier: tier,
@@ -408,10 +416,11 @@ var registryListCmd = &cobra.Command{
 			return nil
 		}
 
-		fmt.Fprintf(output.Writer, "%-20s  %-8s  %-8s  %-9s  %s\n", "NAME", "STATUS", "VERSION", "TRUST", "URL / DESCRIPTION")
-		fmt.Fprintf(output.Writer, "%-20s  %-8s  %-8s  %-9s  %s\n",
+		fmt.Fprintf(output.Writer, "%-20s  %-8s  %-8s  %-18s  %-9s  %s\n", "NAME", "STATUS", "VERSION", "REF", "TRUST", "URL / DESCRIPTION")
+		fmt.Fprintf(output.Writer, "%-20s  %-8s  %-8s  %-18s  %-9s  %s\n",
 			strings.Repeat("─", 20), strings.Repeat("─", 8),
-			strings.Repeat("─", 8), strings.Repeat("─", 9), strings.Repeat("─", 40))
+			strings.Repeat("─", 8), strings.Repeat("─", 18),
+			strings.Repeat("─", 9), strings.Repeat("─", 40))
 		for _, item := range items {
 			version := "─"
 			if item.Manifest != nil && item.Manifest.Version != "" {
@@ -421,8 +430,9 @@ var registryListCmd = &cobra.Command{
 			if item.TrustTier != "" {
 				trust = item.TrustTier
 			}
-			fmt.Fprintf(output.Writer, "%-20s  %-8s  %-8s  %-9s  %s\n",
-				truncateStr(item.Name, 20), item.Status, version, trust, item.URL)
+			fmt.Fprintf(output.Writer, "%-20s  %-8s  %-8s  %-18s  %-9s  %s\n",
+				truncateStr(item.Name, 20), item.Status, version,
+				registryRefCell(item.Ref, item.Pinned), trust, item.URL)
 			if item.Manifest != nil && item.Manifest.Description != "" {
 				fmt.Fprintf(output.Writer, "  %s\n", item.Manifest.Description)
 			}
@@ -873,6 +883,23 @@ func runRegistryCreateNew(cmd *cobra.Command, name string) error {
 func runRegistryCreateFromNative(cmd *cobra.Command) error {
 	desc, _ := cmd.Flags().GetString("description")
 	return registryCreateFromNative(desc)
+}
+
+// registryRefCell renders the REF column for one registry. An unconfigured ref
+// shows as a dash rather than the internal "default" sentinel, and a clone
+// sitting on a detached HEAD carries a "(pinned)" marker so a held checkout is
+// visible without reading `registry list --json`.
+func registryRefCell(ref string, pinned bool) string {
+	if ref == "" || ref == "default" {
+		if pinned {
+			return "─ (pinned)"
+		}
+		return "─"
+	}
+	if pinned {
+		return truncateStr(ref, 9) + " (pinned)"
+	}
+	return truncateStr(ref, 18)
 }
 
 // truncateStr cuts a string to max length with "..." suffix.

--- a/cli/cmd/syllago/registry_list_ref_test.go
+++ b/cli/cmd/syllago/registry_list_ref_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/OpenScribbler/syllago/cli/internal/config"
+	"github.com/OpenScribbler/syllago/cli/internal/output"
+	"github.com/OpenScribbler/syllago/cli/internal/registry"
+)
+
+// makeCloneAtRef creates a git repo at the registry clone path for name.
+// When detach is true the checkout is left on a detached HEAD, which is what
+// registry.IsPinned reports as pinned.
+func makeCloneAtRef(t *testing.T, name string, detach bool) {
+	t.Helper()
+	dir, err := registry.CloneDir(name)
+	if err != nil {
+		t.Fatalf("registry.CloneDir(%q): %v", name, err)
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	gitRun := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	gitRun("init", "-b", "main")
+	gitRun("config", "user.email", "test@example.com")
+	gitRun("config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(dir, "registry.yaml"), []byte("name: test-reg\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	gitRun("add", "registry.yaml")
+	gitRun("commit", "-m", "initial commit")
+	if detach {
+		gitRun("checkout", "--detach", gitRun("rev-parse", "HEAD"))
+	}
+}
+
+func TestRegistryList_RefColumn(t *testing.T) {
+	cfg := &config.Config{
+		Registries: []config.Registry{
+			{Name: "example/tagged", URL: "https://github.com/example/tagged", Ref: "v1.2.0"},
+			{Name: "example/plain", URL: "https://github.com/example/plain"},
+		},
+	}
+	withRegistryProjectAndCache(t, nil, cfg)
+	stdout, _ := output.SetForTest(t)
+
+	registryListCmd.SilenceUsage = true
+	registryListCmd.SilenceErrors = true
+	if err := registryListCmd.RunE(registryListCmd, nil); err != nil {
+		t.Fatalf("registryListCmd.RunE: %v", err)
+	}
+
+	got := stdout.String()
+	if !strings.Contains(got, "REF") {
+		t.Errorf("expected REF column header in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "v1.2.0") {
+		t.Errorf("expected configured ref v1.2.0 in REF column, got:\n%s", got)
+	}
+	// An unset ref must not render the internal "default" sentinel.
+	if strings.Contains(got, "default") {
+		t.Errorf("expected unset ref to render as a dash, not %q, got:\n%s", "default", got)
+	}
+}
+
+func TestRegistryList_PinnedMarker(t *testing.T) {
+	cfg := &config.Config{
+		Registries: []config.Registry{
+			{Name: "example/pinned", URL: "https://github.com/example/pinned", Ref: "v1.0.0"},
+			{Name: "example/tracking", URL: "https://github.com/example/tracking", Ref: "main"},
+		},
+	}
+	withRegistryProjectAndCache(t, nil, cfg)
+	makeCloneAtRef(t, "example/pinned", true)
+	makeCloneAtRef(t, "example/tracking", false)
+	stdout, _ := output.SetForTest(t)
+
+	registryListCmd.SilenceUsage = true
+	registryListCmd.SilenceErrors = true
+	if err := registryListCmd.RunE(registryListCmd, nil); err != nil {
+		t.Fatalf("registryListCmd.RunE: %v", err)
+	}
+
+	got := stdout.String()
+	lines := strings.Split(got, "\n")
+	var pinnedLine, trackingLine string
+	for _, l := range lines {
+		if strings.Contains(l, "example/pinned") {
+			pinnedLine = l
+		}
+		if strings.Contains(l, "example/tracking") {
+			trackingLine = l
+		}
+	}
+	if pinnedLine == "" || trackingLine == "" {
+		t.Fatalf("expected both registries listed, got:\n%s", got)
+	}
+	if !strings.Contains(pinnedLine, "(pinned)") {
+		t.Errorf("expected detached-HEAD clone marked (pinned), got line:\n%s", pinnedLine)
+	}
+	if strings.Contains(trackingLine, "(pinned)") {
+		t.Errorf("expected branch-tracking clone not marked pinned, got line:\n%s", trackingLine)
+	}
+}
+
+func TestRegistryList_JSONIncludesPinned(t *testing.T) {
+	cfg := &config.Config{
+		Registries: []config.Registry{
+			{Name: "example/pinned", URL: "https://github.com/example/pinned", Ref: "v1.0.0"},
+		},
+	}
+	withRegistryProjectAndCache(t, nil, cfg)
+	makeCloneAtRef(t, "example/pinned", true)
+	stdout, _ := output.SetForTest(t)
+
+	origJSON := output.JSON
+	output.JSON = true
+	t.Cleanup(func() { output.JSON = origJSON })
+
+	registryListCmd.SilenceUsage = true
+	registryListCmd.SilenceErrors = true
+	if err := registryListCmd.RunE(registryListCmd, nil); err != nil {
+		t.Fatalf("registryListCmd.RunE: %v", err)
+	}
+
+	var items []struct {
+		Name   string `json:"name"`
+		Ref    string `json:"ref"`
+		Pinned bool   `json:"pinned"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &items); err != nil {
+		t.Fatalf("unmarshal registry list JSON: %v\n%s", err, stdout.String())
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].Ref != "v1.0.0" {
+		t.Errorf("expected ref v1.0.0 in JSON, got %q", items[0].Ref)
+	}
+	if !items[0].Pinned {
+		t.Errorf("expected pinned=true in JSON for detached-HEAD clone")
+	}
+}


### PR DESCRIPTION
A registry pinned to a tag or commit rendered identically to one tracking a branch. `registryListItem.Ref` reached `--json`, but the table printf emitted NAME/STATUS/VERSION/TRUST/URL only, so the only way to tell a held checkout from a moving one was reading JSON.

`registry list` now has a REF column:

```
NAME                  STATUS    VERSION   REF                 TRUST      URL / DESCRIPTION
────────────────────  ────────  ────────  ──────────────────  ─────────  ───────────────────
smoke/pinned          cloned    0.1.0     v1.0.0 (pinned)     ─          /tmp/.../upstream
smoke/tracking        cloned    0.1.0     main                ─          /tmp/.../upstream
smoke/plain           cloned    0.1.0     ─                   ─          /tmp/.../upstream
```

The `(pinned)` marker comes from `registry.IsPinned`, which reads the clone's detached-HEAD state, so it reflects the actual checkout rather than the config value — a registry configured with `--ref v1.0.0` but never cloned shows the ref without the marker. An unset ref renders as a dash instead of the internal `default` sentinel. `--json` gains a `pinned` field alongside the existing `ref`.

This closes the last of the three design questions on bead `syllago-vxb7` (pin syntax, per-registry vs global, how to surface a pin). `registry sync` already printed `Synced (pinned): <name> — checkout held at <sha>` and an upstream-moved line; `registry list` was the remaining blind spot.

## Testing

`cli/cmd/syllago/registry_list_ref_test.go` — three tests written before the change and confirmed failing against the old output:

- `TestRegistryList_RefColumn` — REF header present, configured ref shown, no `default` sentinel leak
- `TestRegistryList_PinnedMarker` — detached-HEAD clone marked, branch-tracking clone not marked
- `TestRegistryList_JSONIncludesPinned` — `ref` and `pinned` both in JSON

Full suite passes (`go test -count=1 ./...`, only the two expected no-test-file lines). Verified end to end through the installed binary against a real local registry pinned with `registry add --ref v1.0.0 --sync`, output shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)